### PR TITLE
feat/coercion

### DIFF
--- a/polytope_server/common/datasource/coercion.py
+++ b/polytope_server/common/datasource/coercion.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 from datetime import datetime, timedelta
 import copy
 
+
 class CoercionError(Exception):
     pass
 
@@ -13,14 +14,7 @@ class Coercion:
         "step",
         "date",
     ]
-    allow_lists = [
-        "class",
-        "stream",
-        "type",
-        "expver",
-        "param"
-    ]
-        
+    allow_lists = ["class", "stream", "type", "expver", "param"]
 
     @staticmethod
     def coerce(request: Dict[str, Any]) -> Dict[str, Any]:
@@ -37,20 +31,20 @@ class Coercion:
             if isinstance(value, list):
                 # Coerce each item in the list
                 coerced_values = [Coercion.coerce_value(key, v) for v in value]
-                return '/'.join(coerced_values)
+                return "/".join(coerced_values)
             elif isinstance(value, str):
-                if '/to/' in value and key in Coercion.allow_ranges:
+                if "/to/" in value and key in Coercion.allow_ranges:
                     # Handle ranges with possible "/by/" suffix
-                    start_value, rest = value.split('/to/', 1)
+                    start_value, rest = value.split("/to/", 1)
                     if not rest:
                         raise CoercionError(f"Invalid range format for key {key}.")
 
-                    if '/by/' in rest:
-                        end_value, suffix = rest.split('/by/', 1)
-                        suffix = '/by/' + suffix  # Add back the '/by/'
+                    if "/by/" in rest:
+                        end_value, suffix = rest.split("/by/", 1)
+                        suffix = "/by/" + suffix  # Add back the '/by/'
                     else:
                         end_value = rest
-                        suffix = ''
+                        suffix = ""
 
                     # Coerce start_value and end_value
                     start_coerced = coercer_func(start_value)
@@ -60,13 +54,13 @@ class Coercion:
                 else:
                     # Single value
                     return coercer_func(value)
-            else: # not list or string
+            else:  # not list or string
                 return coercer_func(value)
         else:
             if isinstance(value, list):
                 # Join list into '/' separated string
                 coerced_values = [str(v) for v in value]
-                return '/'.join(coerced_values)
+                return "/".join(coerced_values)
             else:
                 return value
 
@@ -196,7 +190,6 @@ class Coercion:
         time_str = f"{hour:02d}{minute:02d}"
         return time_str
 
-
         # Validate hour and minute
         if not (0 <= hour <= 23):
             raise CoercionError("Hour must be between 0 and 23.")
@@ -212,18 +205,18 @@ class Coercion:
 
     @staticmethod
     def coerce_expver(value: Any) -> str:
-        
+
         # Integers accepted, converted to 4-length strings
         if isinstance(value, int):
             if 0 <= value <= 9999:
                 return f"{value:0>4d}"
             else:
                 raise CoercionError("expver integer must be between 0 and 9999 inclusive.")
-        
+
         # Strings accepted if they are convertible to integer or exactly 4 characters long
         elif isinstance(value, str):
             if value.isdigit():
-                int_value = int(value.lstrip('0') or '0')
+                int_value = int(value.lstrip("0") or "0")
                 if 0 <= int_value <= 9999:
                     return f"{int_value:0>4d}"
                 else:
@@ -232,10 +225,9 @@ class Coercion:
                 return value
             else:
                 raise CoercionError("expver string length must be 4 characters exactly.")
-        
+
         else:
             raise CoercionError("expver must be an integer or a string.")
-
 
     coercer = {
         "date": coerce_date,
@@ -243,5 +235,5 @@ class Coercion:
         "number": coerce_number,
         "param": coerce_param,
         "time": coerce_time,
-        "expver": coerce_expver
+        "expver": coerce_expver,
     }

--- a/polytope_server/common/datasource/coercion.py
+++ b/polytope_server/common/datasource/coercion.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
-from datetime import datetime, timedelta
 import copy
+from datetime import datetime, timedelta
+from typing import Any, Dict
 
 
 class CoercionError(Exception):

--- a/polytope_server/common/datasource/coercion.py
+++ b/polytope_server/common/datasource/coercion.py
@@ -1,0 +1,247 @@
+from typing import Any, Dict
+from datetime import datetime, timedelta
+import copy
+
+class CoercionError(Exception):
+    pass
+
+
+class Coercion:
+
+    allow_ranges = [
+        "number",
+        "step",
+        "date",
+    ]
+    allow_lists = [
+        "class",
+        "stream",
+        "type",
+        "expver",
+        "param"
+    ]
+        
+
+    @staticmethod
+    def coerce(request: Dict[str, Any]) -> Dict[str, Any]:
+        request = copy.deepcopy(request)
+        for key, value in request.items():
+            request[key] = Coercion.coerce_value(key, value)
+        return request
+
+    @staticmethod
+    def coerce_value(key: str, value: Any):
+        if key in Coercion.coercer:
+            coercer_func = Coercion.coercer[key]
+
+            if isinstance(value, list):
+                # Coerce each item in the list
+                coerced_values = [Coercion.coerce_value(key, v) for v in value]
+                return '/'.join(coerced_values)
+            elif isinstance(value, str):
+                if '/to/' in value and key in Coercion.allow_ranges:
+                    # Handle ranges with possible "/by/" suffix
+                    start_value, rest = value.split('/to/', 1)
+                    if not rest:
+                        raise CoercionError(f"Invalid range format for key {key}.")
+
+                    if '/by/' in rest:
+                        end_value, suffix = rest.split('/by/', 1)
+                        suffix = '/by/' + suffix  # Add back the '/by/'
+                    else:
+                        end_value = rest
+                        suffix = ''
+
+                    # Coerce start_value and end_value
+                    start_coerced = coercer_func(start_value)
+                    end_coerced = coercer_func(end_value)
+
+                    return f"{start_coerced}/to/{end_coerced}{suffix}"
+                else:
+                    # Single value
+                    return coercer_func(value)
+            else: # not list or string
+                return coercer_func(value)
+        else:
+            if isinstance(value, list):
+                # Join list into '/' separated string
+                coerced_values = [str(v) for v in value]
+                return '/'.join(coerced_values)
+            else:
+                return value
+
+    @staticmethod
+    def coerce_date(value: Any) -> str:
+        if isinstance(value, int):
+            if value > 0:
+                # Assume it's a date in YYYYMMDD format
+                date_str = str(value)
+                try:
+                    datetime.strptime(date_str, "%Y%m%d")
+                    return date_str
+                except ValueError:
+                    raise CoercionError("Invalid date format, expected YYYYMMDD or YYYY-MM-DD.")
+            else:
+                # Negative or zero values: relative days from today
+                target_date = datetime.today() + timedelta(days=value)
+                return target_date.strftime("%Y%m%d")
+        elif isinstance(value, str):
+            # Try parsing as YYYYMMDD
+            try:
+                datetime.strptime(value, "%Y%m%d")
+                return value
+            except ValueError:
+                # Try parsing as YYYY-MM-DD
+                try:
+                    date_obj = datetime.strptime(value, "%Y-%m-%d")
+                    return date_obj.strftime("%Y%m%d")
+                except ValueError:
+                    raise CoercionError("Invalid date format, expected YYYYMMDD or YYYY-MM-DD.")
+        else:
+            raise CoercionError("Invalid date format, expected YYYYMMDD or YYYY-MM-DD.")
+
+    @staticmethod
+    def coerce_step(value: Any) -> str:
+
+        if isinstance(value, int):
+            if value < 0:
+                raise CoercionError("Step must be greater than or equal to 0.")
+            else:
+                return str(value)
+        elif isinstance(value, str):
+            if not value.isdigit() or int(value) < 0:
+                raise CoercionError("Step must be greater than or equal to 0.")
+            return value
+        else:
+            raise CoercionError("Invalid type, expected integer or string.")
+
+    @staticmethod
+    def coerce_number(value: Any) -> str:
+
+        if isinstance(value, int):
+            if value <= 0:
+                raise CoercionError("Number must be a positive value.")
+            else:
+                return str(value)
+        elif isinstance(value, str):
+            if not value.isdigit() or int(value) <= 0:
+                raise CoercionError("Number must be a positive integer.")
+            return value
+        else:
+            raise CoercionError("Invalid type, expected integer or string.")
+
+    @staticmethod
+    def coerce_param(value: Any) -> str:
+        if isinstance(value, int):
+            return str(value)
+        elif isinstance(value, str):
+            return value
+        else:
+            raise CoercionError("Invalid param type, expected integer or string.")
+
+    @staticmethod
+    def coerce_time(value: Any) -> str:
+        if isinstance(value, int):
+            if value < 0:
+                raise CoercionError("Invalid time format, expected HHMM or HH greater than zero.")
+            elif value < 24:
+                # Treat as hour with minute=0
+                hour = value
+                minute = 0
+            elif 100 <= value <= 2359:
+                # Possible HHMM format
+                hour = value // 100
+                minute = value % 100
+            else:
+                raise CoercionError("Invalid time format, expected HHMM or HH.")
+        elif isinstance(value, str):
+            value_stripped = value.strip()
+            # Check for colon-separated time (e.g., "12:00")
+            if ":" in value_stripped:
+                parts = value_stripped.split(":")
+                if len(parts) != 2:
+                    raise CoercionError("Invalid time format, expected HHMM or HH.")
+                hour_str, minute_str = parts
+                if not (hour_str.isdigit() and minute_str.isdigit()):
+                    raise CoercionError("Invalid time format, expected HHMM or HH.")
+                hour = int(hour_str)
+                minute = int(minute_str)
+            else:
+                if value_stripped.isdigit():
+                    num_digits = len(value_stripped)
+                    if num_digits == 4:
+                        # Format is "HHMM"
+                        hour = int(value_stripped[:2])
+                        minute = int(value_stripped[2:])
+                    elif num_digits <= 2:
+                        # Format is "H" or "HH"
+                        hour = int(value_stripped)
+                        minute = 0
+                    else:
+                        raise CoercionError("Invalid time format, expected HHMM or HH.")
+                else:
+                    raise CoercionError("Invalid time format, expected HHMM or HH.")
+        else:
+            raise CoercionError("Invalid type for time, expected string or integer.")
+
+        # Validate hour and minute
+        if not (0 <= hour <= 23):
+            raise CoercionError("Invalid time format, expected HHMM or HH.")
+        if not (0 <= minute <= 59):
+            raise CoercionError("Invalid time format, expected HHMM or HH.")
+        if minute != 0:
+            raise CoercionError("Invalid time format, expected HHMM or HH.")
+
+        # Format time as HHMM
+        time_str = f"{hour:02d}{minute:02d}"
+        return time_str
+
+
+        # Validate hour and minute
+        if not (0 <= hour <= 23):
+            raise CoercionError("Hour must be between 0 and 23.")
+        if not (0 <= minute <= 59):
+            raise CoercionError("Minute must be between 0 and 59.")
+        if minute != 0:
+            # In your test cases, minute must be zero
+            raise CoercionError("Minute must be zero.")
+
+        # Format time as HHMM
+        time_str = f"{hour:02d}{minute:02d}"
+        return time_str
+
+    @staticmethod
+    def coerce_expver(value: Any) -> str:
+        
+        # Integers accepted, converted to 4-length strings
+        if isinstance(value, int):
+            if 0 <= value <= 9999:
+                return f"{value:0>4d}"
+            else:
+                raise CoercionError("expver integer must be between 0 and 9999 inclusive.")
+        
+        # Strings accepted if they are convertible to integer or exactly 4 characters long
+        elif isinstance(value, str):
+            if value.isdigit():
+                int_value = int(value.lstrip('0') or '0')
+                if 0 <= int_value <= 9999:
+                    return f"{int_value:0>4d}"
+                else:
+                    raise CoercionError("expver integer string must represent a number between 0 and 9999 inclusive.")
+            elif len(value) == 4:
+                return value
+            else:
+                raise CoercionError("expver string length must be 4 characters exactly.")
+        
+        else:
+            raise CoercionError("expver must be an integer or a string.")
+
+
+    coercer = {
+        "date": coerce_date,
+        "step": coerce_step,
+        "number": coerce_number,
+        "param": coerce_param,
+        "time": coerce_time,
+        "expver": coerce_expver
+    }

--- a/polytope_server/common/datasource/polytope.py
+++ b/polytope_server/common/datasource/polytope.py
@@ -58,10 +58,9 @@ class PolytopeDataSource(datasource.DataSource):
 
     def retrieve(self, request):
         r = yaml.safe_load(request.user_request)
-        
+
         r = coercion.Coercion.coerce(r)
 
-        
         logging.info(r)
 
         # Set the "pre-path" for this request

--- a/polytope_server/common/datasource/polytope.py
+++ b/polytope_server/common/datasource/polytope.py
@@ -27,8 +27,7 @@ import yaml
 from polytope_feature.utility.exceptions import PolytopeError
 from polytope_mars.api import PolytopeMars
 
-from . import datasource
-from . import coercion
+from . import coercion, datasource
 
 
 class PolytopeDataSource(datasource.DataSource):

--- a/polytope_server/common/datasource/polytope.py
+++ b/polytope_server/common/datasource/polytope.py
@@ -28,6 +28,7 @@ from polytope_feature.utility.exceptions import PolytopeError
 from polytope_mars.api import PolytopeMars
 
 from . import datasource
+from . import coercion
 
 
 class PolytopeDataSource(datasource.DataSource):
@@ -57,6 +58,10 @@ class PolytopeDataSource(datasource.DataSource):
 
     def retrieve(self, request):
         r = yaml.safe_load(request.user_request)
+        
+        r = coercion.Coercion.coerce(r)
+
+        
         logging.info(r)
 
         # Set the "pre-path" for this request
@@ -95,6 +100,8 @@ class PolytopeDataSource(datasource.DataSource):
     def match(self, request):
 
         r = yaml.safe_load(request.user_request) or {}
+
+        r = coercion.Coercion.coerce(r)
 
         # Check that there is a feature specified in the request
         if "feature" not in r:

--- a/tests/unit/test_polytope_datasource_coercion.py
+++ b/tests/unit/test_polytope_datasource_coercion.py
@@ -1,4 +1,5 @@
 import pytest
+
 from polytope_server.common.datasource.coercion import Coercion, CoercionError
 
 

--- a/tests/unit/test_polytope_datasource_coercion.py
+++ b/tests/unit/test_polytope_datasource_coercion.py
@@ -1,64 +1,65 @@
 import pytest
-from  polytope_server.common.datasource.coercion import Coercion, CoercionError
+from polytope_server.common.datasource.coercion import Coercion, CoercionError
+
 
 def test_coerce():
 
     # mars-like
     request_mars = {
         "class": "od",
-        "stream" : "enfo",
-        "type" : "pf",
-        "date" : "2024-11-14",
-        "time" : 12,
-        "levtype" : "sfc",
-        "expver" : 1, 
-        "domain" : "g",
-        "param" : "164/166/167/169",
-        "number" : "1/to/33",
+        "stream": "enfo",
+        "type": "pf",
+        "date": "2024-11-14",
+        "time": 12,
+        "levtype": "sfc",
+        "expver": 1,
+        "domain": "g",
+        "param": "164/166/167/169",
+        "number": "1/to/33",
         "step": "0/to/360/by/6",
-        "feature" : { # dict ignored
-            "foo" : "bar",
+        "feature": {  # dict ignored
+            "foo": "bar",
         },
     }
 
     # json-like
     request_json = {
         "class": "od",
-        "stream" : ["enfo"],
-        "type" : "pf",
-        "date" : "2024-11-14",
-        "time" : 12,
-        "levtype" : "sfc",
-        "expver" : [1], 
-        "domain" : "g",
-        "param" : [ 164, 166, 167, "169" ],
-        "number" : "1/to/33",
+        "stream": ["enfo"],
+        "type": "pf",
+        "date": "2024-11-14",
+        "time": 12,
+        "levtype": "sfc",
+        "expver": [1],
+        "domain": "g",
+        "param": [164, 166, 167, "169"],
+        "number": "1/to/33",
         "step": "0/to/360/by/6",
-        "feature" : { # dict ignored
-            "foo" : "bar",
+        "feature": {  # dict ignored
+            "foo": "bar",
         },
     }
 
     request_out = {
         "class": "od",
-        "stream" : "enfo",
-        "type" : "pf",
-        "date" : "20241114",
-        "time" : "1200",
-        "levtype" : "sfc",
-        "expver" : "0001", 
-        "domain" : "g",
-        "param" : "164/166/167/169",
-        "number" : "1/to/33",
+        "stream": "enfo",
+        "type": "pf",
+        "date": "20241114",
+        "time": "1200",
+        "levtype": "sfc",
+        "expver": "0001",
+        "domain": "g",
+        "param": "164/166/167/169",
+        "number": "1/to/33",
         "step": "0/to/360/by/6",
-        "feature" : { # dict ignored
-            "foo" : "bar",
+        "feature": {  # dict ignored
+            "foo": "bar",
         },
     }
 
     assert Coercion.coerce(request_mars) == request_out
     assert Coercion.coerce(request_json) == request_out
-    
+
 
 def test_date_coercion():
 
@@ -110,12 +111,7 @@ def test_step_coercion():
         ("0", "0"),
     ]
 
-    fail = [
-        -1,
-        1.0,
-        [],
-        {}
-    ]
+    fail = [-1, 1.0, [], {}]
 
     for value, expected in ok:
         result = Coercion.coerce_step(value)
@@ -126,23 +122,12 @@ def test_step_coercion():
             Coercion.coerce_step(value)
 
 
-
 def test_number_coercion():
 
     # Should accept integer or string, converted to string
-    ok = [
-        (2, "2"),
-        ("1", "1"),
-        (10, "10")
-    ]
+    ok = [(2, "2"), ("1", "1"), (10, "10")]
 
-    fail = [
-        -1,
-        0,
-        1.0,
-        [],
-        {}
-    ]
+    fail = [-1, 0, 1.0, [], {}]
 
     for value, expected in ok:
         result = Coercion.coerce_number(value)
@@ -153,10 +138,8 @@ def test_number_coercion():
             Coercion.coerce_number(value)
 
 
-
-
 def test_param_coercion():
-    
+
     # OK, but should be converted
     ok = [
         (100, "100"),
@@ -164,23 +147,19 @@ def test_param_coercion():
         ("100.200", "100.200"),
         ("2t", "2t"),
     ]
-    fail = [
-        [],
-        {},
-        1.0
-    ]
+    fail = [[], {}, 1.0]
 
     for value, expected in ok:
         result = Coercion.coerce_param(value)
         assert result == expected
-    
+
     for value in fail:
         with pytest.raises(CoercionError):
             Coercion.coerce_param(value)
 
 
 def test_time_coercion():
-    
+
     # OK, but should be converted
     ok = [
         ("1200", "1200"),
@@ -206,12 +185,10 @@ def test_time_coercion():
     for value, expected in ok:
         result = Coercion.coerce_time(value)
         assert result == expected
-    
+
     for value in fail:
         with pytest.raises(CoercionError):
             Coercion.coerce_time(value)
-
-    
 
 
 def test_expver_coercion():
@@ -230,15 +207,15 @@ def test_expver_coercion():
     assert Coercion.coerce_expver("abcd") == "abcd"
     assert Coercion.coerce_expver(10) == "0010"
     assert Coercion.coerce_expver("1abc") == "1abc"
-    
-    with pytest.raises(CoercionError):
-        Coercion.coerce_expver("abcde") # too long
-    
-    with pytest.raises(CoercionError):
-        Coercion.coerce_expver("abc") # too short
 
     with pytest.raises(CoercionError):
-        Coercion.coerce_expver(1.0) # float
+        Coercion.coerce_expver("abcde")  # too long
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver("abc")  # too short
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver(1.0)  # float
 
     with pytest.raises(CoercionError):
         Coercion.coerce_expver([])
@@ -247,5 +224,4 @@ def test_expver_coercion():
         Coercion.coerce_expver({})
 
     with pytest.raises(CoercionError):
-        Coercion.coerce_expver(['a', 'b', 'c', 'd'])
-
+        Coercion.coerce_expver(["a", "b", "c", "d"])

--- a/tests/unit/test_polytope_datasource_coercion.py
+++ b/tests/unit/test_polytope_datasource_coercion.py
@@ -1,0 +1,251 @@
+import pytest
+from  polytope_server.common.datasource.coercion import Coercion, CoercionError
+
+def test_coerce():
+
+    # mars-like
+    request_mars = {
+        "class": "od",
+        "stream" : "enfo",
+        "type" : "pf",
+        "date" : "2024-11-14",
+        "time" : 12,
+        "levtype" : "sfc",
+        "expver" : 1, 
+        "domain" : "g",
+        "param" : "164/166/167/169",
+        "number" : "1/to/33",
+        "step": "0/to/360/by/6",
+        "feature" : { # dict ignored
+            "foo" : "bar",
+        },
+    }
+
+    # json-like
+    request_json = {
+        "class": "od",
+        "stream" : ["enfo"],
+        "type" : "pf",
+        "date" : "2024-11-14",
+        "time" : 12,
+        "levtype" : "sfc",
+        "expver" : [1], 
+        "domain" : "g",
+        "param" : [ 164, 166, 167, "169" ],
+        "number" : "1/to/33",
+        "step": "0/to/360/by/6",
+        "feature" : { # dict ignored
+            "foo" : "bar",
+        },
+    }
+
+    request_out = {
+        "class": "od",
+        "stream" : "enfo",
+        "type" : "pf",
+        "date" : "20241114",
+        "time" : "1200",
+        "levtype" : "sfc",
+        "expver" : "0001", 
+        "domain" : "g",
+        "param" : "164/166/167/169",
+        "number" : "1/to/33",
+        "step": "0/to/360/by/6",
+        "feature" : { # dict ignored
+            "foo" : "bar",
+        },
+    }
+
+    assert Coercion.coerce(request_mars) == request_out
+    assert Coercion.coerce(request_json) == request_out
+    
+
+def test_date_coercion():
+
+    from datetime import datetime, timedelta
+
+    today = datetime.today()
+    yyyymmdd = today.strftime("%Y%m%d")
+    yyyy_mm_dd = today.strftime("%Y-%m-%d")
+    yesterday = (today + timedelta(days=-1)).strftime("%Y%m%d")
+    today = today.strftime("%Y%m%d")
+
+    ok = [
+        (20241114, "20241114"),
+        ("20241114", "20241114"),
+        ("2024-11-14", "20241114"),
+        (int(yyyymmdd), yyyymmdd),
+        (yyyymmdd, yyyymmdd),
+        (yyyy_mm_dd, yyyymmdd),
+        (-1, yesterday),
+        (0, today),
+    ]
+
+    fail = [
+        "2024-11-14T00:00:00",
+        202401,
+        2024010,
+        1.0,
+        [],
+        {},
+    ]
+
+    for value, expected in ok:
+        result = Coercion.coerce_date(value)
+        assert result == expected
+
+    for value in fail:
+        with pytest.raises(CoercionError):
+            Coercion.coerce_date(value)
+
+
+def test_step_coercion():
+
+    # Should accept integer or string, converted to string
+    ok = [
+        (2, "2"),
+        ("1", "1"),
+        (10, "10"),
+        (0, "0"),
+        ("0", "0"),
+    ]
+
+    fail = [
+        -1,
+        1.0,
+        [],
+        {}
+    ]
+
+    for value, expected in ok:
+        result = Coercion.coerce_step(value)
+        assert result == expected
+
+    for value in fail:
+        with pytest.raises(CoercionError):
+            Coercion.coerce_step(value)
+
+
+
+def test_number_coercion():
+
+    # Should accept integer or string, converted to string
+    ok = [
+        (2, "2"),
+        ("1", "1"),
+        (10, "10")
+    ]
+
+    fail = [
+        -1,
+        0,
+        1.0,
+        [],
+        {}
+    ]
+
+    for value, expected in ok:
+        result = Coercion.coerce_number(value)
+        assert result == expected
+
+    for value in fail:
+        with pytest.raises(CoercionError):
+            Coercion.coerce_number(value)
+
+
+
+
+def test_param_coercion():
+    
+    # OK, but should be converted
+    ok = [
+        (100, "100"),
+        ("100", "100"),
+        ("100.200", "100.200"),
+        ("2t", "2t"),
+    ]
+    fail = [
+        [],
+        {},
+        1.0
+    ]
+
+    for value, expected in ok:
+        result = Coercion.coerce_param(value)
+        assert result == expected
+    
+    for value in fail:
+        with pytest.raises(CoercionError):
+            Coercion.coerce_param(value)
+
+
+def test_time_coercion():
+    
+    # OK, but should be converted
+    ok = [
+        ("1200", "1200"),
+        ("12", "1200"),
+        ("1", "0100"),
+        ("6", "0600"),
+        ("12:00", "1200"),
+        (0, "0000"),
+        (12, "1200"),
+        (1200, "1200"),
+    ]
+    fail = [
+        "abc",
+        25,
+        2400,
+        2401,
+        -1,
+        -10,
+        [],
+        {},
+    ]
+
+    for value, expected in ok:
+        result = Coercion.coerce_time(value)
+        assert result == expected
+    
+    for value in fail:
+        with pytest.raises(CoercionError):
+            Coercion.coerce_time(value)
+
+    
+
+
+def test_expver_coercion():
+    expvers = [
+        "0001",
+        "001",
+        "01",
+        "1",
+        1,
+    ]
+
+    for expver in expvers:
+        result = Coercion.coerce_expver(expver)
+        assert result == "0001"
+
+    assert Coercion.coerce_expver("abcd") == "abcd"
+    assert Coercion.coerce_expver(10) == "0010"
+    assert Coercion.coerce_expver("1abc") == "1abc"
+    
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver("abcde") # too long
+    
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver("abc") # too short
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver(1.0) # float
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver([])
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver({})
+
+    with pytest.raises(CoercionError):
+        Coercion.coerce_expver(['a', 'b', 'c', 'd'])
+


### PR DESCRIPTION
Allows polytope to accept non-strings in the request and coerce them to the correct format. Includes formatting of JSON-lists into "/"-separated lists.