### PR TITLE
Auth offline token

### DIFF
--- a/polytope_server/common/authentication/openid_offline_access_authentication.py
+++ b/polytope_server/common/authentication/openid_offline_access_authentication.py
@@ -103,6 +103,9 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
                 raise ForbiddenRequest("Not a valid offline_access token")
 
             token = self.get_token(credentials)
+            if token is None:
+                raise ForbiddenRequest("Not a valid offline_access token")
+
             certs = self.get_certs()
             decoded_token = jwt.decode(token=token, algorithms=jwt.get_unverified_header(token).get("alg"), key=certs)
 

--- a/polytope_server/common/authentication/openid_offline_access_authentication.py
+++ b/polytope_server/common/authentication/openid_offline_access_authentication.py
@@ -41,6 +41,7 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
         self.iam_url = config["iam_url"]
         self.iam_realm = config["iam_realm"]
         self.jwt_aud = config.get("jwt_aud", None)
+        self.jwt_iss = config.get("jwt_iss", None)
         self.disable_check = config.get("disable_check", False)
 
         super().__init__(name, realm, config)
@@ -103,6 +104,7 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
             algorithms=jwt.get_unverified_header(token).get("alg"),
             key=certs,
             audience=self.jwt_aud,
+            issuer=self.jwt_iss,
         )
 
         logging.info("Decoded JWT: {}".format(decoded_token))

--- a/polytope_server/common/authentication/openid_offline_access_authentication.py
+++ b/polytope_server/common/authentication/openid_offline_access_authentication.py
@@ -40,6 +40,7 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
         self.private_client_secret = config["private_client_secret"]
         self.iam_url = config["iam_url"]
         self.iam_realm = config["iam_realm"]
+        self.jwt_aud = config.get("jwt_aud", None)
         self.disable_check = config.get("disable_check", False)
 
         super().__init__(name, realm, config)
@@ -97,7 +98,12 @@ class OpenIDOfflineAuthentication(authentication.Authentication):
             resp.raise_for_status()
 
         certs = self.get_certs()
-        decoded_token = jwt.decode(token=token, algorithms=jwt.get_unverified_header(token).get("alg"), key=certs)
+        decoded_token = jwt.decode(
+            token=token,
+            algorithms=jwt.get_unverified_header(token).get("alg"),
+            key=certs,
+            audience=self.jwt_aud,
+        )
 
         logging.info("Decoded JWT: {}".format(decoded_token))
 


### PR DESCRIPTION
- add option to disable check through the introspection API
- refactor to allow cache to persist unsuccessful authentication attempts
- add config entries for the JWT issuer and audience claim checks