### PR TITLE
Fix/mars subprocess

### DIFF
--- a/polytope_server/common/datasource/mars.py
+++ b/polytope_server/common/datasource/mars.py
@@ -155,6 +155,7 @@ class MARSDataSource(datasource.DataSource):
             else:
                 logging.debug("Detected MARS process has exited before opening FIFO.")
                 self.destroy(request)
+                raise Exception("MARS process exited before opening FIFO.")
         except Exception as e:
             logging.error(f"Error while waiting for MARS process to open FIFO: {e}.")
             self.destroy(request)
@@ -170,13 +171,15 @@ class MARSDataSource(datasource.DataSource):
 
         logging.info("FIFO reached EOF.")
 
+        self.subprocess.finalize(request)
+
         return
 
     def destroy(self, request):
         try:
             self.subprocess.finalize(request)  # Will raise if non-zero return
         except Exception as e:
-            logging.debug("MARS subprocess failed: {}".format(e))
+            logging.info("MARS subprocess failed: {}".format(e))
             pass
         try:
             os.unlink(self.request_file)

--- a/polytope_server/common/datasource/mars.py
+++ b/polytope_server/common/datasource/mars.py
@@ -23,6 +23,7 @@ import os
 import re
 import tempfile
 from datetime import datetime, timedelta
+from subprocess import CalledProcessError
 
 import yaml
 from dateutil.relativedelta import relativedelta
@@ -171,7 +172,11 @@ class MARSDataSource(datasource.DataSource):
 
         logging.info("FIFO reached EOF.")
 
-        self.subprocess.finalize(request)
+        try:
+            self.subprocess.finalize(request)
+        except CalledProcessError as e:
+            logging.error("MARS subprocess failed: {}".format(e))
+            raise Exception("MARS retrieval failed unexpectedly with error code {}".format(e.returncode))
 
         return
 

--- a/polytope_server/common/subprocess.py
+++ b/polytope_server/common/subprocess.py
@@ -21,6 +21,7 @@
 import logging
 import os
 import subprocess
+from subprocess import CalledProcessError
 
 
 class Subprocess:
@@ -49,13 +50,13 @@ class Subprocess:
     def finalize(self, request, filter=None):
         """Close subprocess and decode output"""
 
-        out, _ = self.subprocess.communicate()
+        out, err = self.subprocess.communicate()
         logging.info(out.decode())
         self.output = out.decode().splitlines()
 
         for line in self.output:
             if filter and filter in line:
                 request.user_message += line + "\n"
-
+        self.subprocess.args
         if self.returncode() != 0:
-            raise Exception("Subprocess exited with code {}.".format(self.returncode()))
+            raise CalledProcessError(self.returncode(), self.subprocess.args, out, err)

--- a/polytope_server/common/subprocess.py
+++ b/polytope_server/common/subprocess.py
@@ -57,6 +57,6 @@ class Subprocess:
         for line in self.output:
             if filter and filter in line:
                 request.user_message += line + "\n"
-        self.subprocess.args
+
         if self.returncode() != 0:
             raise CalledProcessError(self.returncode(), self.subprocess.args, out, err)

--- a/polytope_server/worker/worker.py
+++ b/polytope_server/worker/worker.py
@@ -234,6 +234,7 @@ class Worker:
             )
             if ds.dispatch(request, input_data):
                 datasource = ds
+                request.user_message += "Datasource {} accepted request.\n".format(ds.repr())
                 break
 
         # Clean up
@@ -248,8 +249,6 @@ class Worker:
                 request.url = self.staging.create(id, datasource.result(request), datasource.mime_type())
 
         except Exception as e:
-            request.user_message += f"Failed to finalize request: [{str(type(e))}] {str(e)}"
-            logging.info(request.user_message, extra={"request_id": id})
             logging.exception("Failed to finalize request", extra={"request_id": id, "exception": str(e)})
             raise
 


### PR DESCRIPTION
Fixes to worker.py, datasource.py and mars.py
- log to user when datasource is accepted
- check subprocess exitcode at the end of result call (so after all data available was read)
- remove redundant error log and report