### PR TITLE
Update requirements with new polytope-mars release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ Markdown==3.7
 minio==7.2.8
 moto[dynamodb]==5.0.16
 pika==1.3.2
-polytope-mars==0.2.2
+polytope-mars==0.2.3
 polytope-python==1.0.35
 py-bcrypt==0.4
 pykwalify==1.8.0


### PR DESCRIPTION
Fix error of no __init__ file in polytope-mars utils dir that broke deployment.