### PR TITLE
Feat/gribjump server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,7 @@ RUN set -eux \
 
 FROM python:3.11-bookworm AS gribjump-base
 ARG rpm_repo
-ARG gribjump_version=0.5.4
+ARG gribjump_version=0.9.2
 
 RUN response=$(curl -s -w "%{http_code}" ${rpm_repo}) \
     && if [ "$response" = "403" ]; then echo "Unauthorized access to ${rpm_repo} "; fi
@@ -188,7 +188,7 @@ RUN set -eux \
 
 RUN set -eux \
     && apt-get update \
-    && apt install -y gribjump-client=${gribjump_version}-gribjump
+    && apt install -y gribjump-server=${gribjump_version}-gribjumpserver
 
 RUN set -eux \
     ls -R /opt
@@ -328,12 +328,12 @@ ENV PATH="/polytope/bin/:/opt/ecmwf/mars-client/bin:/opt/ecmwf/mars-client-cloud
 COPY --chown=polytope --from=fdb-base-final /opt/fdb/ /opt/fdb/
 COPY --chown=polytope ./aux/default_fdb_schema /polytope/config/fdb/default
 RUN mkdir -p /polytope/fdb/ && sudo chmod -R o+rw /polytope/fdb
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/fdb/lib:/opt/ecmwf/gribjump-client/lib
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/fdb/lib:/opt/ecmwf/gribjump-server/lib
 COPY --chown=polytope --from=fdb-base-final /root/.local /home/polytope/.local
 
 # Copy gribjump-related artifacts, including python libraries
 # COPY --chown=polytope --from=gribjump-base-final /opt/fdb/ /opt/fdb/
-COPY --chown=polytope --from=gribjump-base-final /opt/ecmwf/gribjump-client/ /opt/ecmwf/gribjump-client/
+COPY --chown=polytope --from=gribjump-base-final /opt/ecmwf/gribjump-server/ /opt/ecmwf/gribjump-server/
 COPY --chown=polytope --from=gribjump-base-final /root/.local /home/polytope/.local
 # RUN sudo apt install -y libopenjp2-7
 # COPY polytope-deployment/common/default_fdb_schema /polytope/config/fdb/default

--- a/polytope_server/common/datasource/polytope.py
+++ b/polytope_server/common/datasource/polytope.py
@@ -62,6 +62,13 @@ class PolytopeDataSource(datasource.DataSource):
         self.config["datacube"]["config"] = self.config_file
         os.environ["GRIBJUMP_CONFIG_FILE"] = self.config_file
 
+        # Create a temp file to store FDB config
+        self.fdb_config_file = "/tmp/fdb.yaml"
+        if "fdb_config" in config:
+            with open(self.fdb_config_file, "w") as f:
+                f.write(yaml.dump(self.config.pop("fdb_config")))
+            os.environ["FDB5_CONFIG_FILE"] = self.fdb_config_file
+
         logging.info("Set up gribjump")
 
     def get_type(self):
@@ -188,6 +195,11 @@ class PolytopeDataSource(datasource.DataSource):
                     raise Exception("got {}: {}, not one of {}".format(k, req_value, v))
 
     def destroy(self, request) -> None:
+        # delete temp files
+        if os.path.exists(self.config_file):
+            os.remove(self.config_file)
+        if os.path.exists(self.fdb_config_file):
+            os.remove(self.fdb_config_file)
         pass
 
     def repr(self):

--- a/polytope_server/worker/worker.py
+++ b/polytope_server/worker/worker.py
@@ -196,6 +196,7 @@ class Worker:
 
                     self.update_status("idle")
                     self.request_store.update_request(self.request)
+                    sys.exit(0)
 
                     self.future = None
                     self.queue_msg = None

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -46,7 +46,7 @@ build:
         mars_config_branch: '{{ .mars_config_branch }}'
         developer_mode: '{{ default "false" .developer_mode }}'
         # mars_client_c_version: 6.33.20.2
-        gribjump_version: '{{ default "0.8.0" .gribjump_version }}'
+        gribjump_version: '{{ default "0.9.2" .gribjump_version }}'
         mars_client_cpp_version: 7.0.0.7
         # ecbuild_version: 3.8.2
         # eccodes_version: 2.33.1


### PR DESCRIPTION
- use gribjump server instead of gribjump client in build
- sys.exit at the end of a successful request to avoid apparent fdb memory leaks