### PR TITLE
Fix/revoke

### DIFF
--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -184,7 +184,6 @@ class DynamoDBRequestStore(request_store.RequestStore):
             items = self.metric_store.get_metrics(request_id=id)
             for item in items:
                 self.metric_store.remove_metric(item.uuid)
-        logger.info("Metrics for request ID %s removed.", id)
 
         logger.info("Request ID %s removed.", id)
 

--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -205,13 +205,7 @@ class DynamoDBRequestStore(request_store.RequestStore):
                 for req_id in items_to_delete:
                     try:
                         # Try to delete using the same logic as _revoke_single_request
-                        batch.delete_item(
-                            Key={"id": req_id},
-                            ConditionExpression=Attr("id").exists()
-                            & Attr("status").is_in(
-                                [Status.WAITING.value, Status.QUEUED.value]
-                            ),  # in case the status changes between query and delete
-                        )
+                        batch.delete_item(Key={"id": req_id})
                         deleted += 1
                     except Exception as e:
                         logger.error("Failed to revoke request %s: %s", req_id, e)

--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -170,11 +170,7 @@ class DynamoDBRequestStore(request_store.RequestStore):
 
     def remove_request(self, id):
         try:
-            self.table.delete_item(
-                Key={"id": id},
-                ConditionExpression=Attr("id").exists()
-                & Attr("status").is_in([Status.WAITING.value, Status.QUEUED.value]),
-            )
+            self.table.delete_item(Key={"id": id}, ConditionExpression=Attr("id").exists())
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
                 raise KeyError("Request does not exist in request store") from e

--- a/polytope_server/common/request_store/mongodb_request_store.py
+++ b/polytope_server/common/request_store/mongodb_request_store.py
@@ -169,6 +169,9 @@ class MongoRequestStore(request_store.RequestStore):
             return_document=pymongo.ReturnDocument.AFTER,
         )
 
+        if res is None:
+            raise NotFound("Request {} not found in request store".format(request.id))
+
         if self.metric_store:
             self.metric_store.add_metric(
                 RequestStatusChange(request_id=request.id, status=request.status, user_id=request.user.id)

--- a/polytope_server/common/request_store/request_store.py
+++ b/polytope_server/common/request_store/request_store.py
@@ -24,6 +24,7 @@ from typing import Dict, List, Union
 
 from ..metric import MetricType
 from ..request import Request, Status
+from ..user import User
 
 
 class RequestStore(ABC):
@@ -47,7 +48,30 @@ class RequestStore(ABC):
 
     @abstractmethod
     def remove_request(self, id: str) -> None:
-        """Remove a request from the request store"""
+        """Remove a request from the request store."""
+
+    @abstractmethod
+    def revoke_request(self, user: User, id: str) -> None:
+        """
+        Revoke a queued but unstarted request (and related metrics) from the request store.
+
+        Only the user who created the request can revoke it.
+
+        Only requests with status 'waiting' or 'queued' can be removed.
+
+        Args:
+            user: User who is revoking the request
+            id: ID of the request to be revoked
+
+        Raises:
+            NotFound: if the request is not in the request store
+            UnauthorizedRequest: if the request belongs to a different user
+            ForbiddenRequest: if the request has started processing.
+        """
+
+    @abstractmethod
+    def remove_request_metrics(self, id: str) -> None:
+        """Remove all metrics related to a request from the metric store"""
 
     @abstractmethod
     def update_request(self, request: Request) -> None:

--- a/polytope_server/common/request_store/request_store.py
+++ b/polytope_server/common/request_store/request_store.py
@@ -51,9 +51,9 @@ class RequestStore(ABC):
         """Remove a request from the request store."""
 
     @abstractmethod
-    def revoke_request(self, user: User, id: str) -> None:
+    def revoke_request(self, user: User, id: str) -> int:
         """
-        Revoke a queued but unstarted request (and related metrics) from the request store.
+        Revoke a queued but unstarted request from the request store.
 
         Only the user who created the request can revoke it.
 
@@ -61,17 +61,17 @@ class RequestStore(ABC):
 
         Args:
             user: User who is revoking the request
-            id: ID of the request to be revoked
+            id: ID of the request to be revoked. Alternatively "all" can be used to
+                revoke all revokeable requests of the user.
+
+        Returns:
+            int: Number of requests revoked.
 
         Raises:
             NotFound: if the request is not in the request store
             UnauthorizedRequest: if the request belongs to a different user
             ForbiddenRequest: if the request has started processing.
         """
-
-    @abstractmethod
-    def remove_request_metrics(self, id: str) -> None:
-        """Remove all metrics related to a request from the metric store"""
 
     @abstractmethod
     def update_request(self, request: Request) -> None:

--- a/polytope_server/frontend/common/data_transfer.py
+++ b/polytope_server/frontend/common/data_transfer.py
@@ -199,9 +199,9 @@ class DataTransfer:
         return response
 
     def revoke_request(self, user: User, id: str):
-        self.request_store.revoke_request(user, id)
+        n = self.request_store.revoke_request(user, id)
 
-        return RequestSucceeded("Successfully deleted request")
+        return RequestSucceeded(f"Successfully revoked {n} requests")
 
     def get_request(self, id):
         try:

--- a/polytope_server/frontend/common/data_transfer.py
+++ b/polytope_server/frontend/common/data_transfer.py
@@ -28,6 +28,7 @@ from flask import Response
 
 from ...common.exceptions import BadRequest, NotFound, ServerError
 from ...common.request import Request, Status, Verb
+from ...common.user import User
 from .flask_decorators import RequestAccepted, RequestRedirected, RequestSucceeded
 
 
@@ -197,27 +198,8 @@ class DataTransfer:
             response["status"] = "queued"
         return response
 
-    def delete_request(self, user, id):
-        request = self.get_request(id)
-
-        if not request:
-            raise NotFound("Request {} not found".format(id))
-
-        if request.user != user:
-            raise NotFound("Request {} not found".format(id))
-
-        if request.verb != Verb.ARCHIVE:
-            try:
-                self.staging.delete(id)
-            except KeyError:
-                pass
-            except Exception:
-                raise ServerError("Error accessing data staging for deletion")
-
-        try:
-            self.request_store.remove_request(id)
-        except Exception:
-            raise ServerError("Error removing request {} from the request store".format(id))
+    def revoke_request(self, user: User, id: str):
+        self.request_store.revoke_request(user, id)
 
         return RequestSucceeded("Successfully deleted request")
 

--- a/polytope_server/frontend/flask_handler.py
+++ b/polytope_server/frontend/flask_handler.py
@@ -187,7 +187,7 @@ class FlaskHandler(frontend.FrontendHandler):
             elif request.method == "POST":
                 raise NotFound("Unsupported collection type: %s" % request_id)
             elif request.method == "DELETE":
-                return data_transfer.delete_request(user, request_id)
+                return data_transfer.revoke_request(user, request_id)
 
         @handler.route(
             "/api/v1/requests/<collection_or_request_id>",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ jsonschema==4.23.0
 ldap3==2.9.1
 Markdown==3.7
 minio==7.2.8
+mongomock==4.3.0
 moto[dynamodb,s3]==5.0.16
 pika==1.3.2
 polytope-mars==0.2.9

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -7,7 +7,7 @@ from moto import mock_aws
 from polytope_server.common import request, user
 from polytope_server.common.request_store import dynamodb_request_store
 
-from .test_request_store import _test_revoke_request
+from .test_request_store import _test_revoke_request, _test_update_request
 
 
 @pytest.fixture(scope="function")
@@ -119,6 +119,8 @@ def test_update(mocked_aws):
     r3 = store.get_request(r1.id)
     assert r3.id == r1.id
     assert r3.user.attributes["test"] == "updated"
+
+    _test_update_request(store)
 
 
 def test_metric_store(mocked_aws):

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -7,6 +7,8 @@ from moto import mock_aws
 from polytope_server.common import request, user
 from polytope_server.common.request_store import dynamodb_request_store
 
+from .test_request_store import _test_revoke_request
+
 
 @pytest.fixture(scope="function")
 def aws_credentials():
@@ -63,6 +65,11 @@ def test_remove_request(mocked_aws):
     assert store.get_request(req.id) is not None
     store.remove_request(req.id)
     assert store.get_request(req.id) is None
+
+
+def test_revoke_request(mocked_aws):
+    store = dynamodb_request_store.DynamoDBRequestStore()
+    _test_revoke_request(store)
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_mongodb_request_store.py
+++ b/tests/unit/test_mongodb_request_store.py
@@ -2,7 +2,7 @@ import mongomock
 
 from polytope_server.common.request_store.mongodb_request_store import MongoRequestStore
 
-from .test_request_store import _test_revoke_request
+from .test_request_store import _test_revoke_request, _test_update_request
 
 
 def test_revoke_request():
@@ -11,3 +11,11 @@ def test_revoke_request():
     store.store = mongomock.MongoClient().db.requests
 
     _test_revoke_request(store)
+
+
+def test_update_request():
+    # Create a mocked MongoRequestStore
+    store = MongoRequestStore({})
+    store.store = mongomock.MongoClient().db.requests
+
+    _test_update_request(store)

--- a/tests/unit/test_mongodb_request_store.py
+++ b/tests/unit/test_mongodb_request_store.py
@@ -1,0 +1,13 @@
+import mongomock
+
+from polytope_server.common.request_store.mongodb_request_store import MongoRequestStore
+
+from .test_request_store import _test_revoke_request
+
+
+def test_revoke_request():
+    # Create a mocked MongoRequestStore
+    store = MongoRequestStore({})
+    store.store = mongomock.MongoClient().db.requests
+
+    _test_revoke_request(store)

--- a/tests/unit/test_request_store.py
+++ b/tests/unit/test_request_store.py
@@ -1,0 +1,33 @@
+import pytest
+
+from polytope_server.common import exceptions, request, user
+
+
+def _test_revoke_request(store):
+    # Create a test user
+    test_user = user.User("test-user", "test-realm")
+    # test queued request gets removed
+    req_queued = request.Request(status=request.Status.QUEUED, user=test_user)
+    store.add_request(req_queued)
+    assert store.get_request(req_queued.id) is not None
+    store.revoke_request(test_user, req_queued.id)
+    assert store.get_request(req_queued.id) is None
+
+    # test processed request does not get removed and raises KeyError about status
+    req_processed = request.Request(status=request.Status.PROCESSED, user=test_user)
+    store.add_request(req_processed)
+    assert store.get_request(req_processed.id) is not None
+    with pytest.raises(exceptions.ForbiddenRequest):
+        store.revoke_request(test_user, req_processed.id)
+    assert store.get_request(req_processed.id) is not None
+
+    # test request from a different user raises UnauthorizedRequest
+    other_user = user.User("other-user", "other-realm")
+    req_other = request.Request(status=request.Status.QUEUED, user=other_user)
+    store.add_request(req_other)
+    assert store.get_request(req_other.id) is not None
+    with pytest.raises(exceptions.UnauthorizedRequest):
+        store.revoke_request(test_user, req_other.id)
+    # test non-existing request raises KeyError
+    with pytest.raises(exceptions.NotFound):
+        store.revoke_request(test_user, "non-existing-id")

--- a/tests/unit/test_request_store.py
+++ b/tests/unit/test_request_store.py
@@ -16,6 +16,7 @@ def _test_revoke_request(store):
     # test processed request does not get removed and raises KeyError about status
     req_processed = request.Request(status=request.Status.PROCESSED, user=test_user)
     store.add_request(req_processed)
+
     assert store.get_request(req_processed.id) is not None
     with pytest.raises(exceptions.ForbiddenRequest):
         store.revoke_request(test_user, req_processed.id)
@@ -43,3 +44,24 @@ def _test_revoke_request(store):
     deleted_count = store.revoke_request(test_user, "all")
     assert deleted_count == 2
     assert store.get_request(req_processed.id) is not None
+
+
+def _test_update_request(store):
+    # Create a test user
+    test_user = user.User("test-user", "test-realm")
+    # Create a request
+    req = request.Request(user=test_user, collection="test-collection", status=request.Status.WAITING)
+    store.add_request(req)
+
+    # Update the request
+    req.status = request.Status.PROCESSED
+    store.update_request(req)
+
+    # Retrieve the updated request and check its status
+    updated_req = store.get_request(req.id)
+    assert updated_req.status == request.Status.PROCESSED
+
+    # Test updating a non-existing request raises NotFound
+    non_existing_req = request.Request(id="non-existing-id", user=test_user)
+    with pytest.raises(exceptions.NotFound):
+        store.update_request(non_existing_req)

--- a/tests/unit/test_request_store.py
+++ b/tests/unit/test_request_store.py
@@ -28,6 +28,18 @@ def _test_revoke_request(store):
     assert store.get_request(req_other.id) is not None
     with pytest.raises(exceptions.UnauthorizedRequest):
         store.revoke_request(test_user, req_other.id)
+
     # test non-existing request raises KeyError
     with pytest.raises(exceptions.NotFound):
         store.revoke_request(test_user, "non-existing-id")
+
+    # test revoking all requests of the user
+    req1 = request.Request(status=request.Status.WAITING, user=test_user)
+    req2 = request.Request(status=request.Status.QUEUED, user=test_user)
+    store.add_request(req1)
+    store.add_request(req2)
+    assert store.get_request(req1.id) is not None
+    assert store.get_request(req2.id) is not None
+    deleted_count = store.revoke_request(test_user, "all")
+    assert deleted_count == 2
+    assert store.get_request(req_processed.id) is not None


### PR DESCRIPTION
### Description
- Split request revoking into a separate function. 
- Only revoke (delete) requests that are in queued or waiting status. 
- Successfully revoking request stops it from executing
- Allow deleting "all" such requests on the server side.

+Fix: dynamodb request store now fails to update request if it does not exist (previously created request again)
+Fix: mongodb request store now fails to update request if it does not exist (previously just did nothing)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 