### PR TITLE
Feat/config inheritance

### DIFF
--- a/polytope_server/common/collection.py
+++ b/polytope_server/common/collection.py
@@ -23,8 +23,7 @@ from typing import Dict
 import yaml
 
 from . import coercion
-from . import config as polytope_config
-from .datasource import DataSource, create_datasource
+from .datasource import create_datasource, DataSource, get_datasource_config
 from .exceptions import InvalidConfig
 from .request import Request
 
@@ -42,19 +41,7 @@ class Collection:
             raise InvalidConfig("No datasources configured for collection {}".format(self.name))
 
         for ds_config in self.config.get("datasources"):
-            # Allows passing in just the name as config
-            if isinstance(ds_config, str):
-                ds_config = {"name": ds_config}
-
-            # 'name' means we are linking to a datasource defined in global_config.datasources
-            if "name" in ds_config:
-                name = ds_config["name"]
-                datasource_configs = polytope_config.global_config.get("datasources")
-                if name not in datasource_configs:
-                    raise KeyError("Could not find config for datasource {}".format(name))
-                # Merge with supplied config
-                ds_config = polytope_config.merge(datasource_configs.get(name, None), ds_config)
-            self.ds_configs.append(ds_config)
+            self.ds_configs.append(get_datasource_config(ds_config))
 
     def dispatch(self, request: Request, input_data: bytes | None) -> DataSource:
         """

--- a/polytope_server/common/collection.py
+++ b/polytope_server/common/collection.py
@@ -23,7 +23,7 @@ from typing import Dict
 import yaml
 
 from . import coercion
-from .datasource import create_datasource, DataSource, get_datasource_config
+from .datasource import DataSource, create_datasource, get_datasource_config
 from .exceptions import InvalidConfig
 from .request import Request
 

--- a/polytope_server/common/datasource/datasource.py
+++ b/polytope_server/common/datasource/datasource.py
@@ -223,7 +223,7 @@ def get_datasource_config(config: str | dict) -> dict:
     config = polytope_config.merge(datasource_configs.get(name, None), config)
 
     config = _load_ds_parents_recursively(name, config, datasource_configs)
-    logging.info("Loaded datasource config: {}".format(config))
+    logging.debug("Loaded datasource config: {}".format(config))
     return config
 
 

--- a/polytope_server/common/datasource/datasource.py
+++ b/polytope_server/common/datasource/datasource.py
@@ -231,7 +231,6 @@ def _load_ds_parents_recursively(name: str, ds_config: dict, global_ds_configs: 
     config = {}
     if parents := ds_config.get("parents", []):
         for p in parents:
-            logging.debug("Attempting to merge {} into {}".format(p, name))
             if p in children:
                 raise KeyError(f"Datasource {ds_config['name']} has circular parent reference to {p}")
             parent_config = global_ds_configs.get(p, {})
@@ -240,6 +239,7 @@ def _load_ds_parents_recursively(name: str, ds_config: dict, global_ds_configs: 
             config = polytope_config.merge(
                 config, _load_ds_parents_recursively(p, parent_config, global_ds_configs, children + [p])
             )
+            logging.debug("Merged {} into {}".format(p, name))
 
     return polytope_config.merge(config, ds_config)
 

--- a/polytope_server/common/datasource/datasource.py
+++ b/polytope_server/common/datasource/datasource.py
@@ -24,6 +24,7 @@ from importlib import import_module
 from typing import Any, Dict, Iterator
 
 from ..coercion import coerce_value
+from ..config import polytope_config
 from ..exceptions import ForbiddenRequest
 from ..request import Request, Verb
 from ..user import User
@@ -204,8 +205,46 @@ type_to_class_map = {
 }
 
 
-def create_datasource(config) -> DataSource:
+def get_datasource_config(config: str | dict) -> dict:
 
+    # Allows passing in just the name as config
+    if isinstance(config, str):
+        config = {"name": config}
+
+    datasource_configs = polytope_config.global_config.get("datasources", {})
+
+    # 'name' means we are linking to a datasource defined in global_config.datasources
+    name = config.get("name", None)
+    if not name:
+        raise KeyError("Datasource config must contain a 'name' key")
+    if name not in datasource_configs:
+        raise KeyError("Could not find config for datasource {}".format(name))
+    # Merge with supplied config
+    config = polytope_config.merge(datasource_configs.get(name, None), config)
+
+    config = _load_ds_parents_recursively(name, config, datasource_configs)
+    logging.info("Loaded datasource config: {}".format(config))
+    return config
+
+
+def _load_ds_parents_recursively(name: str, ds_config: dict, global_ds_configs: dict, children: list = []) -> dict:
+    config = {}
+    if parents := ds_config.get("parents", []):
+        for p in parents:
+            logging.debug("Attempting to merge {} into {}".format(p, name))
+            if p in children:
+                raise KeyError(f"Datasource {ds_config['name']} has circular parent reference to {p}")
+            parent_config = global_ds_configs.get(p, {})
+            if not parent_config:
+                raise KeyError(f"Parent datasource '{p}' not found in global config.")
+            config = polytope_config.merge(
+                config, _load_ds_parents_recursively(p, parent_config, global_ds_configs, children + [p])
+            )
+
+    return polytope_config.merge(config, ds_config)
+
+
+def create_datasource(config: dict) -> DataSource:
     # Find the class matching config.type
     type = config.get("type")
     module = import_module("polytope_server.common.datasource." + type)

--- a/polytope_server/common/datasource/fdb.py
+++ b/polytope_server/common/datasource/fdb.py
@@ -35,7 +35,7 @@ from . import datasource
 class FDBDataSource(datasource.DataSource):
     def __init__(self, config):
         self.config = config
-        self.fdb_config = self.config["config"]
+        self.fdb_config = self.config["fdb_config"]
         self.type = config["type"]
         assert self.type == "fdb"
         self.output = None

--- a/polytope_server/common/datasource/mars.py
+++ b/polytope_server/common/datasource/mars.py
@@ -182,7 +182,7 @@ class MARSDataSource(datasource.DataSource):
                 "MARS_USER_EMAIL": mars_user,
                 "MARS_USER_TOKEN": mars_token,
                 "ECMWF_MARS_COMMAND": self.mars_binary,
-                "FDB5_CONFIG": yaml.dump(self.fdb_config[0]),
+                "FDB5_CONFIG": yaml.dump(self.fdb_config),
             }
 
             if self.mars_config is not None:

--- a/polytope_server/common/datasource/mars.py
+++ b/polytope_server/common/datasource/mars.py
@@ -53,7 +53,7 @@ class MARSDataSource(datasource.DataSource):
         self.mars_error_filter = config.get("mars_error_filter", "mars - EROR")
 
         # self.fdb_config = None
-        self.fdb_config = config.get("fdb_config", [{}])
+        self.fdb_config = config.get("fdb_config", {})
         if self.protocol == "remote":
             # need to set FDB5 config in a <path>/etc/fdb/config.yaml
             self.fdb_home = self.tmp_dir + "/fdb-home"

--- a/tests/unit/test_datasource_configs.py
+++ b/tests/unit/test_datasource_configs.py
@@ -1,0 +1,74 @@
+import pytest
+from polytope_server.common.datasource.datasource import get_datasource_config
+from polytope_server.common.config import polytope_config
+
+
+def test_merge_parents(monkeypatch):
+    global_config = {
+        "datasources": {
+            "base": {"type": "dummy", "defaults": {"a": 1}},
+            "child": {"type": "dummy", "parents": ["base"], "defaults": {"b": 2}},
+            "grandchild": {"type": "dummy", "parents": ["child"], "defaults": {"c": 3}},
+        }
+    }
+
+    monkeypatch.setattr(polytope_config, "global_config", global_config)
+    config = get_datasource_config("child")
+    # Should merge defaults from base and child
+    assert config["defaults"]["a"] == 1
+    assert config["defaults"]["b"] == 2
+
+    config2 = get_datasource_config("grandchild")
+    # Should merge all three levels
+    assert config2["defaults"]["a"] == 1
+    assert config2["defaults"]["b"] == 2
+    assert config2["defaults"]["c"] == 3
+
+
+def test_chain_order(monkeypatch):
+    global_config = {
+        "datasources": {
+            "valid_chain_1": {"type": "dummy", "defaults": {"d": 4, "overwrite": 0}, "other": [1]},
+            "valid_chain_2": {"type": "dummy", "defaults": {"e": 5, "overwrite": 1}, "other": [2]},
+            "valid_chain_3": {
+                "type": "dummy",
+                "parents": ["valid_chain_1", "valid_chain_2"],
+                "defaults": {"f": 6},
+                "other": [3],
+            },
+        }
+    }
+
+    monkeypatch.setattr(polytope_config, "global_config", global_config)
+    config = get_datasource_config("valid_chain_3")
+    assert config["defaults"] == {"d": 4, "e": 5, "f": 6, "overwrite": 1}
+    assert config["other"] == [1, 2, 3]
+
+    # test that latest config overwrites
+    config = get_datasource_config("valid_chain_3")
+    config["defaults"]["overwrite"] = 2
+    config = get_datasource_config(config)
+    assert config["defaults"]["overwrite"] == 2
+
+
+def test_recursive_parent_detection(monkeypatch):
+    global_config = {
+        "datasources": {
+            "cycle": {"type": "dummy", "parents": ["cycle"]},
+            "cycle1": {"type": "dummy", "parents": ["cycle3"]},
+            "cycle2": {"type": "dummy", "parents": ["cycle1"]},
+            "cycle3": {"type": "dummy", "parents": ["cycle2"]},
+        }
+    }
+
+    monkeypatch.setattr(polytope_config, "global_config", global_config)
+    # Direct cycle
+    with pytest.raises(KeyError):
+        get_datasource_config("cycle")
+    # Indirect cycle
+    with pytest.raises(KeyError):
+        get_datasource_config("cycle2")
+    with pytest.raises(KeyError):
+        get_datasource_config("cycle1")
+    with pytest.raises(KeyError):
+        get_datasource_config("cycle3")

--- a/tests/unit/test_datasource_configs.py
+++ b/tests/unit/test_datasource_configs.py
@@ -1,6 +1,7 @@
 import pytest
-from polytope_server.common.datasource.datasource import get_datasource_config
+
 from polytope_server.common.config import polytope_config
+from polytope_server.common.datasource.datasource import get_datasource_config
 
 
 def test_merge_parents(monkeypatch):


### PR DESCRIPTION
### Description
Introduce datasource configuration inheritance to the lumi configuration. 

This means that e.g. fdb config can now be defined in a single location as a "datasource" that is not initiated due ot not being included directly in any collections. Other datasources (fdb, polytope, mars) can inherit this datasource config and not have to define their own.

Further such deduplications can be made on an ad-hoc basis

BREAKING CHANGES:
FDB configs are now listed under the same field (fdb_config) for all datasources to allow different datasource types to inherit the same fdb config

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 