### PR TITLE
Update version of covjsonkit with levelist fix for path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrdict==2.0.1
 boto3==1.35.19
-covjsonkit==0.2.1
+covjsonkit==0.2.3
 deepmerge==2.0
 docker==7.1.0
 ecmwf-api-client==1.6.3


### PR DESCRIPTION
### Description

There was a bug in the trajectory feature where if the user had levelist in the main body the covjson generated was incorrect, this has been fixed in covjsonkit `0.2.3`

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 