### PR TITLE
Chore/logging fixes

### DIFF
--- a/polytope_server/broker/broker.py
+++ b/polytope_server/broker/broker.py
@@ -120,7 +120,7 @@ class Broker:
                     f"User {request.user} has {user_active_requests} of {limit} "
                     f"active requests in collection {request.collection}"
                 )
-                logging.info(user_limit_message)
+                logging.debug(user_limit_message)
                 if user_active_requests >= limit:
                     return False
                 else:

--- a/polytope_server/broker/broker.py
+++ b/polytope_server/broker/broker.py
@@ -56,7 +56,7 @@ class Broker:
 
         # Don't queue if full. We don't need to query request_store.
         if self.queue.count() >= self.max_queue_size:
-            logging.info("Queue is full")
+            logging.debug("Queue is full")
             return
 
         # Find all requests that are waiting to be queued (oldest first)

--- a/polytope_server/broker/broker.py
+++ b/polytope_server/broker/broker.py
@@ -132,7 +132,7 @@ class Broker:
 
     def enqueue(self, request: PolytopeRequest):
         with with_baggage_items({"request_id": request.id}):
-            logging.info("Queuing request")
+            logging.debug("Queuing request")
 
             try:
                 # Must update request_store before queue, worker checks request status immediately
@@ -143,6 +143,5 @@ class Broker:
             except Exception as e:
                 # If we fail to call this, the request will be stuck (POLY-21)
                 logging.exception("Failed to queue, error: {}".format(repr(e)))
+                request.user_message = "Failed to queue request due to an internal error. Please try again later."
                 self.request_store.set_request_status(request, Status.FAILED)
-            else:
-                logging.info("Queued request")

--- a/polytope_server/common/authotron.py
+++ b/polytope_server/common/authotron.py
@@ -53,7 +53,13 @@ class Authotron:
 
         response = requests.get(f"{self.url}/authenticate", headers={"Authorization": auth_header})
         if response.status_code != 200:
-            logging.error("Authentication failed with response: {}".format(response))
+            logging.error(
+                "Authentication failed",
+                extra={
+                    "auth.response_status": response.status_code,
+                    "auth.www_authenticate": response.headers.get("WWW-Authenticate", ""),
+                },
+            )
             raise UnauthorizedRequest(
                 "Authentication failed", www_authenticate=response.headers.get("WWW-Authenticate", "")
             )

--- a/polytope_server/common/collection.py
+++ b/polytope_server/common/collection.py
@@ -57,7 +57,9 @@ class Collection:
         Raises a BadRequest exception if no datasource matches.
         """
         coerced_ur = coercion.coerce(yaml.safe_load(request.user_request))
-        logging.info("Coerced user request", extra={"coerced_request": coerced_ur})
+        logging.info(
+            "Coerced user request", extra={"coerced_request": coerced_ur, "user_request": request.user_request}
+        )
         match_errors = []
         for ds_config in self.ds_configs:
             match_result = DataSource.match(ds_config, coerced_ur, request.user)

--- a/polytope_server/common/request.py
+++ b/polytope_server/common/request.py
@@ -25,6 +25,10 @@ import uuid
 
 from .user import User
 
+DEFAULT_LOG_MAX_STRING_LENGTH = 1000
+DEFAULT_LOG_MAX_LIST_LENGTH = 100
+DEFAULT_LOG_LIST_PREVIEW_LENGTH = 10
+
 
 class Status(enum.Enum):
     WAITING = "waiting"
@@ -133,13 +137,75 @@ class PolytopeRequest:
             result[k] = self.serialize_slot(k, v)
         return result
 
-    def serialize_logging(self):
+    @classmethod
+    def _bound_logging_value(
+        cls,
+        value,
+        *,
+        max_string_length: int,
+        max_list_length: int,
+        list_preview_length: int,
+    ):
+        if isinstance(value, dict):
+            return {
+                key: cls._bound_logging_value(
+                    sub_value,
+                    max_string_length=max_string_length,
+                    max_list_length=max_list_length,
+                    list_preview_length=list_preview_length,
+                )
+                for key, sub_value in value.items()
+            }
+
+        if isinstance(value, list):
+            if len(value) > max_list_length:
+                preview = [
+                    cls._bound_logging_value(
+                        item,
+                        max_string_length=max_string_length,
+                        max_list_length=max_list_length,
+                        list_preview_length=list_preview_length,
+                    )
+                    for item in value[: min(list_preview_length, max_list_length)]
+                ]
+                return {
+                    "_summary": "list",
+                    "count": len(value),
+                    "preview": preview,
+                }
+            return [
+                cls._bound_logging_value(
+                    item,
+                    max_string_length=max_string_length,
+                    max_list_length=max_list_length,
+                    list_preview_length=list_preview_length,
+                )
+                for item in value
+            ]
+
+        if isinstance(value, str) and len(value) > max_string_length:
+            return value[:max_string_length] + "...<truncated>"
+
+        return value
+
+    def serialize_logging(
+        self,
+        *,
+        max_string_length: int = DEFAULT_LOG_MAX_STRING_LENGTH,
+        max_list_length: int = DEFAULT_LOG_MAX_LIST_LENGTH,
+        list_preview_length: int = DEFAULT_LOG_LIST_PREVIEW_LENGTH,
+    ):
         """Serialize the request object to a reduced dictionary for logging purposes"""
         result = self.serialize()
         # unnecessary for request logging
         result.pop("user", None)
         result.pop("user_request", None)
-        return result
+        return self._bound_logging_value(
+            result,
+            max_string_length=max_string_length,
+            max_list_length=max_list_length,
+            list_preview_length=list_preview_length,
+        )
 
     def deserialize(self, dict):
         """Modify the request by deserializing a dictionary into it"""

--- a/polytope_server/common/request.py
+++ b/polytope_server/common/request.py
@@ -138,9 +138,7 @@ class PolytopeRequest:
         result = self.serialize()
         # unnecessary for request logging
         result.pop("user", None)
-        # omit user_request if request has been coerced
-        if self.coerced_request:
-            result.pop("user_request", None)
+        result.pop("user_request", None)
         return result
 
     def deserialize(self, dict):

--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -169,7 +169,7 @@ class DynamoDBRequestStore(request_store.RequestStore):
         logger.info(
             "Request ID %s added to request store.",
             request.id,
-            extra={"request": request.serialize_logging()},
+            extra={"request_id": request.id, "request": request.serialize_logging()},
         )
 
     def remove_request(self, id):

--- a/polytope_server/common/request_store/dynamodb_request_store.py
+++ b/polytope_server/common/request_store/dynamodb_request_store.py
@@ -166,7 +166,11 @@ class DynamoDBRequestStore(request_store.RequestStore):
         if self.metric_store:
             self.metric_store.add_metric(RequestStatusChange(request_id=request.id, status=request.status))
 
-        logger.info("Request ID %s status set to %s.", request.id, request.status)
+        logger.info(
+            "Request ID %s added to request store.",
+            request.id,
+            extra={"request": request.serialize_logging()},
+        )
 
     def remove_request(self, id):
         try:
@@ -320,7 +324,12 @@ class DynamoDBRequestStore(request_store.RequestStore):
                 raise NotFound("Request {} not found in request store".format(request.id)) from e
             raise
 
-        logger.info("Request ID %s status set to %s.", request.id, request.status)
+        logger.info(
+            "Request ID %s status set to %s.",
+            request.id,
+            request.status,
+            extra={"request": request.serialize_logging()},
+        )
 
     def set_request_status(self, request: PolytopeRequest, status: Status) -> None:
         """Set the status of a request and update the request store"""

--- a/polytope_server/common/request_store/mongodb_request_store.py
+++ b/polytope_server/common/request_store/mongodb_request_store.py
@@ -73,7 +73,7 @@ class MongoRequestStore(request_store.RequestStore):
 
         logging.info(
             "Request ID {} added to request store.".format(request.id),
-            extra={"request": request.serialize_logging()},
+            extra={"request": request.serialize_logging(), "request_id": request.id},
         )
 
     def remove_request(self, id):

--- a/polytope_server/common/request_store/mongodb_request_store.py
+++ b/polytope_server/common/request_store/mongodb_request_store.py
@@ -71,7 +71,10 @@ class MongoRequestStore(request_store.RequestStore):
                 RequestStatusChange(request_id=request.id, status=request.status, user_id=request.user.id)
             )
 
-        logging.info("Request ID {} status set to {}.".format(request.id, request.status))
+        logging.info(
+            "Request ID {} added to request store.".format(request.id),
+            extra={"request": request.serialize_logging()},
+        )
 
     def remove_request(self, id):
         result = self.store.find_one_and_delete({"id": id})
@@ -197,7 +200,7 @@ class MongoRequestStore(request_store.RequestStore):
 
         logging.info(
             "Request ID {} updated on request store. Status is {}.".format(request.id, request.status),
-            extra={"request": request.serialize()},
+            extra={"request": request.serialize_logging()},
         )
 
         return res

--- a/polytope_server/frontend/common/data_transfer.py
+++ b/polytope_server/frontend/common/data_transfer.py
@@ -50,6 +50,7 @@ class DataTransfer:
             verb=Verb.RETRIEVE,
             user_request=str(payload["request"]),
         )
+        logging.info("Received user request", extra={"request_id": request.id, "user_request": request.user_request})
         try:
             self.request_store.add_request(request)
         except Exception:
@@ -73,6 +74,7 @@ class DataTransfer:
             verb=Verb.ARCHIVE,
             user_request=str(payload["request"]),
         )
+        logging.info("Received user request", extra={"request_id": request.id, "user_request": request.user_request})
 
         if url not in (None, ""):
             request.set_status(Status.WAITING)

--- a/polytope_server/frontend/common/data_transfer.py
+++ b/polytope_server/frontend/common/data_transfer.py
@@ -57,7 +57,6 @@ class DataTransfer:
             raise ServerError("Error while attempting to add new request to request store")
 
         response = self.construct_response(request)
-        logging.info("Retrieve request added to store: {}".format(request.id), extra={"request_id": request.id})
         return RequestAccepted(response)
 
     def request_upload(self, http_request: Request, user: User, collection: str):
@@ -85,7 +84,6 @@ class DataTransfer:
             raise ServerError("Error while attempting to add new request to request store")
 
         response = self.construct_response(request)
-        logging.info("Archive request added to store: {}".format(request.id), extra={"request_id": request.id})
         return RequestAccepted(response)
 
     def query_request(self, user: User, id: str) -> Response:
@@ -159,11 +157,6 @@ class DataTransfer:
         """
 
         response = self.construct_response(request)
-        logging.info(
-            "Request succeeded, redirecting to %s",
-            response["location"],
-            extra={"request_id": request.id, "location": response["location"]},
-        )
         return RequestRedirected(response)
 
     def construct_response(self, request: PolytopeRequest) -> dict:
@@ -203,7 +196,6 @@ class DataTransfer:
 
     def revoke_request(self, user: User, id: str):
         n = self.request_store.revoke_request(user, id)
-        logging.info("Request {} successfully revoked by user {}".format(id, user.username))
         return RequestSucceeded(f"Successfully revoked {n} requests")
 
     def get_request(self, id: str) -> PolytopeRequest | None:

--- a/polytope_server/frontend/flask_handler.py
+++ b/polytope_server/frontend/flask_handler.py
@@ -82,9 +82,17 @@ class FlaskHandler(frontend.FrontendHandler):
 
         data_transfer = DataTransfer(request_store, staging)
 
+        def log_error(error, status_code: int, message: str):
+            logging.exception(
+                message,
+                error,
+                str(error),
+                extra={"http.status": status_code, "error.code": type(error).__name__},
+            )
+
         @handler.errorhandler(Exception)
         def default_error_handler(error):
-            logging.exception("Unexpected error: %s %s", error, str(error))
+            log_error(error, 500, "Unexpected error: %s %s")
             return (
                 json.dumps({"message": str(error)}),
                 500,
@@ -93,7 +101,7 @@ class FlaskHandler(frontend.FrontendHandler):
 
         @handler.errorhandler(HTTPException)
         def handle_error(error):
-            logging.exception("HTTP error: %s %s", error, error.description)
+            log_error(error, error.code, "HTTP error: %s %s")
             return (
                 json.dumps({"message": str(error.description)}),
                 error.code,

--- a/polytope_server/frontend/flask_handler.py
+++ b/polytope_server/frontend/flask_handler.py
@@ -117,7 +117,11 @@ class FlaskHandler(frontend.FrontendHandler):
         @handler.route("/api/v1/test", methods=["GET"])
         def test():
             if request.method == "GET":
-                return RequestSucceeded("Polytope server is alive")
+                return (
+                    json.dumps({"message": "Polytope server is alive"}),
+                    200,
+                    {"Content-Type": "application/json"},
+                )
 
         @handler.route(
             "/api/v1/user",

--- a/polytope_server/worker/worker.py
+++ b/polytope_server/worker/worker.py
@@ -169,10 +169,10 @@ class Worker:
                 self.queue.ack(self.queue_msg)
 
                 self.update_status("idle")
-                await self.terminate()
 
                 self.queue_msg = None
                 self.request = None
+                await self.terminate()
 
     async def terminate(self) -> NoReturn:
         if timeout := self.config.get("timeout"):

--- a/polytope_server/worker/worker.py
+++ b/polytope_server/worker/worker.py
@@ -223,7 +223,7 @@ class Worker:
 
         logging.debug(
             "Processing request on collection {}".format(collection.name),
-            extra={"collection": collection.name, "request": request.serialize()},
+            extra={"collection": collection.name, "request": request.serialize_logging()},
         )
 
         input_data = self.fetch_input_data(request.url)

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from unittest import mock
 
@@ -57,6 +58,27 @@ def test_add_request(mocked_aws):
     assert r2.user == r1.user
     assert r2.verb == r1.verb
     assert r2.status == r1.status
+
+
+def test_add_request_logs_serialize_logging_payload(mocked_aws, caplog):
+    store = dynamodb_request_store.DynamoDBRequestStore()
+    u1 = user.User("some-user", "some-realm")
+    r1 = request.PolytopeRequest(
+        user=u1,
+        collection="test-collection",
+        verb=request.Verb.RETRIEVE,
+        status=request.Status.QUEUED,
+        user_request="raw-user-request",
+    )
+    r1.coerced_request = {"param": "167"}
+
+    caplog.set_level(logging.INFO)
+
+    store.add_request(r1)
+
+    record = next(r for r in caplog.records if "added to request store" in r.getMessage())
+    assert record.getMessage() == f"Request ID {r1.id} added to request store."
+    assert record.__dict__["request"] == r1.serialize_logging()
 
 
 def test_add_request_duplicate(mocked_aws):
@@ -130,6 +152,27 @@ def test_update(mocked_aws):
     assert r3.user.attributes["test"] == "updated"
 
     _test_update_request(store)
+
+
+def test_update_logs_serialize_logging_payload(mocked_aws, caplog):
+    store = dynamodb_request_store.DynamoDBRequestStore()
+    u1 = user.User("user1", "realm1")
+    r1 = request.PolytopeRequest(
+        user=u1,
+        collection="test-collection",
+        status=request.Status.WAITING,
+        user_request="raw-user-request",
+    )
+    r1.coerced_request = {"param": "167"}
+    store.add_request(r1)
+    caplog.clear()
+
+    caplog.set_level(logging.INFO)
+    r1.status = request.Status.PROCESSED
+    store.update_request(r1)
+
+    record = next(r for r in caplog.records if "status set to" in r.getMessage())
+    assert record.__dict__["request"] == r1.serialize_logging()
 
 
 def test_metric_store(mocked_aws):

--- a/tests/unit/test_flask_handler.py
+++ b/tests/unit/test_flask_handler.py
@@ -1,0 +1,57 @@
+import logging
+
+from polytope_server.common.user import User
+from polytope_server.frontend.flask_handler import FlaskHandler
+
+
+class FakeAuth:
+    def authenticate(self, auth_header: str) -> User:
+        return User(username="alice", realm="ecmwf")
+
+
+class MissingRequestStore:
+    def get_request(self, request_id):
+        return None
+
+
+class ExplodingRequestStore:
+    def get_requests(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_http_exception_logs_structured_status_and_error_code(caplog):
+    app = FlaskHandler().create_handler(
+        request_store=MissingRequestStore(),
+        auth=FakeAuth(),
+        staging=object(),
+        collections={},
+        proxy_support=False,
+    )
+
+    caplog.set_level(logging.ERROR)
+
+    response = app.test_client().get("/api/v1/requests/missing", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 404
+    record = next(r for r in caplog.records if r.getMessage().startswith("HTTP error:"))
+    assert record.__dict__["http.status"] == 404
+    assert record.__dict__["error.code"] == "NotFound"
+
+
+def test_unexpected_exception_logs_structured_status_and_error_code(caplog):
+    app = FlaskHandler().create_handler(
+        request_store=ExplodingRequestStore(),
+        auth=FakeAuth(),
+        staging=object(),
+        collections={},
+        proxy_support=False,
+    )
+
+    caplog.set_level(logging.ERROR)
+
+    response = app.test_client().get("/api/v1/user", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 500
+    record = next(r for r in caplog.records if r.getMessage().startswith("Unexpected error:"))
+    assert record.__dict__["http.status"] == 500
+    assert record.__dict__["error.code"] == "RuntimeError"

--- a/tests/unit/test_flask_handler.py
+++ b/tests/unit/test_flask_handler.py
@@ -55,3 +55,21 @@ def test_unexpected_exception_logs_structured_status_and_error_code(caplog):
     record = next(r for r in caplog.records if r.getMessage().startswith("Unexpected error:"))
     assert record.__dict__["http.status"] == 500
     assert record.__dict__["error.code"] == "RuntimeError"
+
+
+def test_healthcheck_does_not_log_success(caplog):
+    app = FlaskHandler().create_handler(
+        request_store=MissingRequestStore(),
+        auth=FakeAuth(),
+        staging=object(),
+        collections={},
+        proxy_support=False,
+    )
+
+    caplog.set_level(logging.INFO)
+
+    response = app.test_client().get("/api/v1/test")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "Polytope server is alive"}
+    assert all(record.getMessage() != "Polytope server is alive" for record in caplog.records)

--- a/tests/unit/test_mongodb_request_store.py
+++ b/tests/unit/test_mongodb_request_store.py
@@ -1,7 +1,11 @@
+import logging
+
 import mongomock
 import pytest
 
+from polytope_server.common.request import PolytopeRequest, Status
 from polytope_server.common.request_store.mongodb_request_store import MongoRequestStore
+from polytope_server.common.user import User
 
 from .test_request_store import (
     _test_get_active_requests,
@@ -56,3 +60,40 @@ def test_get_request_ids(mongomock_request_store):
 
 def test_remove_requests(mongomock_request_store):
     _test_remove_requests(mongomock_request_store)
+
+
+def test_add_request_logs_serialize_logging_payload(mongomock_request_store, caplog):
+    req = PolytopeRequest(
+        user=User("test-user", "test-realm"),
+        collection="test-collection",
+        status=Status.WAITING,
+        user_request="raw-user-request",
+    )
+    req.coerced_request = {"param": "167"}
+
+    caplog.set_level(logging.INFO)
+
+    mongomock_request_store.add_request(req)
+
+    record = next(r for r in caplog.records if "added to request store" in r.getMessage())
+    assert record.getMessage() == f"Request ID {req.id} added to request store."
+    assert record.__dict__["request"] == req.serialize_logging()
+
+
+def test_update_request_logs_serialize_logging_payload(mongomock_request_store, caplog):
+    req = PolytopeRequest(
+        user=User("test-user", "test-realm"),
+        collection="test-collection",
+        status=Status.WAITING,
+        user_request="raw-user-request",
+    )
+    req.coerced_request = {"param": "167"}
+    mongomock_request_store.add_request(req)
+    caplog.clear()
+
+    caplog.set_level(logging.INFO)
+    req.status = Status.PROCESSED
+    mongomock_request_store.update_request(req)
+
+    record = next(r for r in caplog.records if "updated on request store" in r.getMessage())
+    assert record.__dict__["request"] == req.serialize_logging()

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -71,3 +71,27 @@ class Test:
         r1 = request.PolytopeRequest(user=self.user, verb=request.Verb.RETRIEVE)
         r2 = deepcopy(r1)
         assert r1 == r2
+
+    def test_serialize_logging_truncates_long_strings(self):
+        r1 = request.PolytopeRequest(user=self.user, verb=request.Verb.RETRIEVE)
+        r1.coerced_request = {"param": "x" * 1005}
+
+        d = r1.serialize_logging()
+
+        assert d["coerced_request"]["param"] == ("x" * 1000) + "...<truncated>"
+
+    def test_serialize_logging_summarizes_oversized_lists_recursively(self):
+        r1 = request.PolytopeRequest(user=self.user, verb=request.Verb.RETRIEVE)
+        r1.coerced_request = {
+            "feature": {
+                "points": list(range(105)),
+            }
+        }
+
+        d = r1.serialize_logging()
+
+        assert d["coerced_request"]["feature"]["points"] == {
+            "_summary": "list",
+            "count": 105,
+            "preview": list(range(10)),
+        }

--- a/tests/unit/test_worker_shutdown.py
+++ b/tests/unit/test_worker_shutdown.py
@@ -1,0 +1,104 @@
+import asyncio as aio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import polytope_server.worker.worker as worker_module
+from polytope_server.common.request import PolytopeRequest, Status
+
+
+class FakeQueueMessage:
+    def __init__(self, request_id):
+        self.body = {"id": request_id}
+
+
+class FakeQueue:
+    def __init__(self, request_id):
+        self.message = FakeQueueMessage(request_id)
+        self.acked = []
+        self.nacked = []
+        self.dequeued = False
+
+    def dequeue(self):
+        if self.dequeued:
+            return None
+        self.dequeued = True
+        return self.message
+
+    def ack(self, message):
+        self.acked.append(message)
+
+    def nack(self, message):
+        self.nacked.append(message)
+
+
+class FakeRequestStore:
+    def __init__(self, request):
+        self.request = request
+        self.updated = []
+
+    def get_request(self, request_id):
+        assert request_id == self.request.id
+        return self.request
+
+    def set_request_status(self, request, status):
+        request.status = status
+
+    def update_request(self, request):
+        self.updated.append(request)
+
+
+def test_listen_queue_clears_request_state_before_graceful_termination(monkeypatch):
+    monkeypatch.setattr(worker_module.collection, "create_collections", lambda config: {})
+    monkeypatch.setattr(worker_module.staging, "create_staging", lambda config: object())
+    monkeypatch.setattr(worker_module.request_store, "create_request_store", lambda *args, **kwargs: None)
+
+    worker = worker_module.Worker(
+        {
+            "worker": {},
+            "collections": {},
+            "staging": {},
+            "request_store": {},
+            "metric_store": {},
+        }
+    )
+    request = PolytopeRequest()
+    request.status = Status.QUEUED
+    worker.queue = FakeQueue(request.id)
+    worker.request_store = FakeRequestStore(request)
+    monkeypatch.setattr(worker, "process_request", lambda request: None)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        with pytest.raises(worker_module.TaskGroupTermination):
+            aio.run(worker.listen_queue(executor))
+
+    assert worker.request is None
+    assert worker.queue_msg is None
+
+
+def test_on_process_terminated_reschedules_inflight_processing_request(monkeypatch):
+    monkeypatch.setattr(worker_module.collection, "create_collections", lambda config: {})
+    monkeypatch.setattr(worker_module.staging, "create_staging", lambda config: object())
+    monkeypatch.setattr(worker_module.request_store, "create_request_store", lambda *args, **kwargs: None)
+
+    worker = worker_module.Worker(
+        {
+            "worker": {},
+            "collections": {},
+            "staging": {},
+            "request_store": {},
+            "metric_store": {},
+        }
+    )
+    request = PolytopeRequest()
+    request.status = Status.PROCESSING
+    queue = FakeQueue(request.id)
+    worker.queue = queue
+    worker.queue_msg = queue.message
+    worker.request = request
+    worker.request_store = FakeRequestStore(request)
+
+    worker.on_process_terminated()
+
+    assert request.status == Status.QUEUED
+    assert queue.nacked == [queue.message]


### PR DESCRIPTION
### Description
- no more double entries on request.processed
- added properly formatted request.Waiting logs
- added frontend http error codes in logs
- removed a spam logs like broker saying a user has reached their quota of requests, frontend reporting it's alive, etc
- logs now contain a summary for a long array in the request. The full array is logged once at the time of coercion. That's also the only time the user_request field is logged anymore. This allows splunk to parse our logs.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
