### PR TITLE
feat: admin role-mocking, MARS DHS callback port cleanup, build hygiene

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /target
+**/target
 /.git
 /.github
 /.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tests/test_e2e.py
 AGENTS.md
 .ruff_cache
 .pytest_cache
+# Pi/Weave runtime artefacts (plans, sessions, runtime notes)
+.weave/

--- a/docs/admin-role-mocking.md
+++ b/docs/admin-role-mocking.md
@@ -1,0 +1,80 @@
+# Admin role mocking
+
+`Polytope-Mock-Roles` lets a configured Polytope admin make a protected request as their own account but with a different effective realm and non-admin role set. Use it for operational checks of role-gated collections without creating temporary users or granting real access.
+
+## Header grammar
+
+Send exactly one header value:
+
+```text
+Polytope-Mock-Roles: <realm>:<role>,<role>,...
+```
+
+Example:
+
+```text
+Polytope-Mock-Roles: beta:viewer,data_access
+```
+
+Rules:
+
+- The value must be valid UTF-8.
+- Surrounding whitespace around the value, realm, and roles is ignored.
+- The realm must be non-empty.
+- At least one role is required.
+- Empty role segments are rejected.
+- Role names must not contain `:`.
+- Control characters are rejected.
+- Multiple `Polytope-Mock-Roles` header values are rejected.
+
+## Authorization requirements
+
+Only a real authenticated user whose real realm and role match the server `admin_bypass_roles` configuration may use this header. Non-admin users are rejected before downstream route checks run.
+
+A mocked role list must not include any configured admin role for the mocked realm. For example, if `alpha:admin` is configured as an admin-bypass role, `Polytope-Mock-Roles: alpha:admin` is rejected.
+
+This header does not bypass collection authorization. After the server accepts the header, normal downstream role checks run against the mocked realm and mocked roles. Mocked requests are not marked with the admin-bypass flag.
+
+## Effective identity semantics
+
+Usernames cannot be mocked. Mocked requests keep only the real username/version from the authenticated user. They replace the effective realm and roles with the header value.
+
+Mocked requests do not inherit real admin scopes/attributes. The effective mocked user has empty `scopes` and empty `attributes`, even if the real admin account has production scopes or attributes.
+
+## Audit fields
+
+Accepted mocked-role requests log an audit event with:
+
+- `real_username`
+- `real_realm`
+- `mocked_realm`
+- `mocked_roles`
+- `path`
+- `request_id` from `X-Request-Id`, when present
+
+When an accepted mocked request submits a job, the job-submission audit event also includes `job_id`.
+
+## curl example
+
+Put credentials only in the normal authentication mechanism, such as the `Authorization` header shown here. Credentials must never be placed in extra headers.
+
+```sh
+curl -fsS \
+  -H "Authorization: Bearer ${POLYTOPE_TOKEN}" \
+  -H "Polytope-Mock-Roles: beta:viewer,data_access" \
+  "${POLYTOPE_URL}/api/v2/collections"
+```
+
+## Python client example
+
+Configure the mock header through the client's safe extra-header support. Do not include `Authorization`, cookies, tokens, passwords, API keys, or other credentials in `extra_headers`; credentials must never be placed in extra headers.
+
+```python
+from polytope.api import Client
+
+client = Client(
+    extra_headers={"Polytope-Mock-Roles": "beta:viewer,data_access"},
+)
+
+collections = client.collections()
+```

--- a/examples/admin-mock-roles.sh
+++ b/examples/admin-mock-roles.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${POLYTOPE_URL:?Set POLYTOPE_URL to the Polytope server base URL, for example https://polytope.example.org}"
+: "${POLYTOPE_TOKEN:?Set POLYTOPE_TOKEN to a real configured admin bearer token}"
+
+mock_roles="beta:viewer,data_access"
+
+curl -fsS \
+  -H "Authorization: Bearer ${POLYTOPE_TOKEN}" \
+  -H "Polytope-Mock-Roles: ${mock_roles}" \
+  "${POLYTOPE_URL%/}/api/v2/collections"
+
+cat <<'PYTHON_EXAMPLE'
+
+Equivalent Python client configuration:
+
+from polytope.api import Client
+
+client = Client(
+    extra_headers={"Polytope-Mock-Roles": "beta:viewer,data_access"},
+)
+
+collections = client.collections()
+
+Credentials must use the client's normal authentication configuration. Never place
+Authorization, cookies, tokens, passwords, API keys, or other credentials in
+extra_headers.
+PYTHON_EXAMPLE

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,7 @@
 ###############################
-# Shared base: Rust + cargo-chef + system deps (built once)
+# Shared base: Rust + system deps
 ###############################
-FROM docker.io/library/rust:1.93-slim-bookworm AS chef-base
-RUN cargo install cargo-chef --locked
+FROM docker.io/library/rust:1.93-slim-bookworm AS rust-base
 RUN apt-get update && apt-get install -y git pkg-config build-essential libssl-dev && rm -rf /var/lib/apt/lists/*
 
 ###############################
@@ -36,8 +35,9 @@ RUN git clone --depth 1 --branch ${METKIT_VERSION} https://github.com/ecmwf/metk
     && ecbuild --prefix=/opt/metkit \
         -DENABLE_FORTRAN=OFF \
         -DENABLE_BUILD_TOOLS=OFF \
-        -DENABLE_ECCODES=OFF \
         -DENABLE_TESTS=OFF \
+        -DENABLE_GEO=OFF \
+        -DENABLE_ECCODES=OFF \
         -DENABLE_MARS2GRIB=OFF \
         -Deckit_DIR=/opt/metkit/lib/cmake/eckit \
         /src/metkit \
@@ -46,58 +46,39 @@ RUN git clone --depth 1 --branch ${METKIT_VERSION} https://github.com/ecmwf/metk
     && cmake --install /build/metkit
 
 ###############################
-# Stage 1: Prepare Cargo Chef Recipe
+# Build the frontend package with the workspace lockfile
 ###############################
-FROM chef-base AS chef
-ARG GIT_AUTH_TOKEN=""
-WORKDIR /ecmwf/polytope-server
-COPY Cargo.lock Cargo.lock
-COPY utils/metkit/ utils/metkit/
-COPY frontend/ frontend/
-RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml
-RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
-RUN cd frontend && cargo chef prepare --recipe-path recipe.json
-
-###############################
-# Stage 2: Cache Dependencies
-###############################
-FROM chef-base AS cacher
-ARG GIT_AUTH_TOKEN=""
-WORKDIR /ecmwf/polytope-server
-COPY Cargo.lock Cargo.lock
-COPY utils/metkit/ utils/metkit/
-COPY --from=chef /ecmwf/polytope-server/frontend/recipe.json frontend/recipe.json
-COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
-RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
-RUN cd frontend && cargo chef cook --release --recipe-path recipe.json
-
-###############################
-# Stage 3: Build the Project
-###############################
-FROM chef-base AS builder
+FROM rust-base AS builder
 ARG GIT_AUTH_TOKEN=""
 WORKDIR /ecmwf/polytope-server
 ARG PACKAGE_NAME=polytope-server
 ARG BIN_NAME=polytope-server
 ARG FEATURES="metkit"
+
+COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY utils/metkit/ utils/metkit/
-COPY --from=metkit-build /opt/metkit /opt/metkit
 COPY frontend/ frontend/
+COPY client/ client/
+COPY tests/integration/ tests/integration/
+COPY workers/common/ workers/common/
+COPY workers/polytope-fe-worker/ workers/polytope-fe-worker/
+COPY workers/fdb-worker/ workers/fdb-worker/
+COPY workers/test-worker/ workers/test-worker/
+COPY --from=metkit-build /opt/metkit /opt/metkit
+
 RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml
-COPY --from=cacher /ecmwf/polytope-server/frontend/target frontend/target
-COPY --from=cacher /usr/local/cargo /usr/local/cargo
 ENV METKIT_LIB_DIR=/opt/metkit/lib
 ENV METKIT_INCLUDE_DIR=/opt/metkit/include
 ENV METKIT_BUILD_INCLUDE_DIR=/opt/metkit/include
 ENV ECKIT_INCLUDE_DIR=/opt/metkit/include
 ENV ECKIT_BUILD_INCLUDE_DIR=/opt/metkit/include
 RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
-RUN cd frontend && cargo build --release -p ${PACKAGE_NAME} \
+RUN cargo build --release --locked -p ${PACKAGE_NAME} \
     $(if [ -n "$FEATURES" ]; then echo "--features $FEATURES"; fi)
 
 ###############################
-# Stage 4: Production Release Image
+# Production Release Image
 ###############################
 FROM gcr.io/distroless/cc-debian12:nonroot AS release
 ARG VERSION
@@ -106,12 +87,12 @@ LABEL version=$VERSION
 WORKDIR /app
 COPY --from=metkit-build /opt/metkit/lib /opt/metkit/lib
 COPY --from=metkit-build /opt/metkit/share /opt/metkit/share
-COPY --from=builder /ecmwf/polytope-server/frontend/target/release/${BIN_NAME} /app/polytope-server
+COPY --from=builder /ecmwf/polytope-server/target/release/${BIN_NAME} /app/polytope-server
 ENV LD_LIBRARY_PATH="/opt/metkit/lib"
 ENTRYPOINT ["/app/polytope-server"]
 
 ###############################
-# Stage 5: Debug Image
+# Debug Image
 ###############################
 FROM docker.io/library/debian:bookworm-slim AS debug
 ARG VERSION
@@ -121,6 +102,6 @@ RUN apt-get update && apt-get install -y ca-certificates bash && rm -rf /var/lib
 WORKDIR /app
 COPY --from=metkit-build /opt/metkit/lib /opt/metkit/lib
 COPY --from=metkit-build /opt/metkit/share /opt/metkit/share
-COPY --from=builder /ecmwf/polytope-server/frontend/target/release/${BIN_NAME} /app/polytope-server
+COPY --from=builder /ecmwf/polytope-server/target/release/${BIN_NAME} /app/polytope-server
 ENV LD_LIBRARY_PATH="/opt/metkit/lib"
 ENTRYPOINT ["/app/polytope-server"]

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -2,11 +2,12 @@ pub mod openmeteo;
 pub mod v1;
 pub mod v2;
 
-use std::collections::HashMap;
-
 use authotron_types::User as AuthUser;
 use axum::http::HeaderMap;
-use serde_json::Value;
+use bits::Job;
+use serde_json::{Value, json};
+
+use crate::auth::{MockRolesAudit, is_admin_bypass_user};
 
 /// Flatten a v1-style `{"request": "...yaml..."}` or `{"request": {...}}` wrapper
 /// into a top-level MARS field object. Passes through already-flat requests unchanged.
@@ -48,16 +49,49 @@ pub fn client_ip(headers: &HeaderMap) -> Option<String> {
         .map(|s| s.split(',').next().unwrap_or(s).trim().to_string())
 }
 
-pub fn check_admin_bypass(user: &AuthUser, bypass: &Option<HashMap<String, Vec<String>>>) -> bool {
-    let Some(bypass) = bypass else { return false };
-    let Some(admin_roles) = bypass.get(&user.realm) else {
-        return false;
-    };
-    admin_roles.iter().any(|r| user.roles.contains(r))
+pub fn set_job_user_context(
+    job: &mut Job,
+    headers: &HeaderMap,
+    auth_user: Option<&AuthUser>,
+    mock_audit: Option<&MockRolesAudit>,
+    admin_bypass_roles: &Option<std::collections::HashMap<String, Vec<String>>>,
+) {
+    let mut user_context = serde_json::Map::new();
+    if let Some(ip) = client_ip(headers) {
+        user_context.insert("client_ip".to_string(), json!(ip));
+    }
+    if let Some(user) = auth_user {
+        if mock_audit.is_none() && is_admin_bypass_user(user, admin_bypass_roles) {
+            user_context.insert("can_bypass_role_check".to_string(), json!(true));
+        }
+        user_context.insert("auth".to_string(), serde_json::to_value(user).unwrap());
+    }
+    job.user = Value::Object(user_context).into();
+}
+
+pub fn audit_mock_job_submission(mock_audit: Option<&MockRolesAudit>, job_id: &str) {
+    if let Some(audit) = mock_audit {
+        tracing::info!(
+            event = "polytope_mock_roles_job_submitted",
+            real_username = audit.real_username.as_str(),
+            real_realm = audit.real_realm.as_str(),
+            mocked_realm = audit.mocked_realm.as_str(),
+            mocked_roles = ?audit.mocked_roles,
+            path = audit.path.as_str(),
+            request_id = audit.request_id.as_deref(),
+            job_id = job_id,
+            "accepted mocked-role request submitted job"
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use axum::http::HeaderMap;
+    use serde_json::json;
+
     use super::*;
 
     fn user(realm: &str, roles: &[&str]) -> AuthUser {
@@ -71,38 +105,53 @@ mod tests {
         }
     }
 
-    fn bypass(entries: &[(&str, &[&str])]) -> Option<HashMap<String, Vec<String>>> {
-        Some(
-            entries
-                .iter()
-                .map(|(r, roles)| (r.to_string(), roles.iter().map(|s| s.to_string()).collect()))
-                .collect(),
-        )
+    fn bypass() -> Option<HashMap<String, Vec<String>>> {
+        Some(HashMap::from([(
+            "alpha".to_string(),
+            vec!["admin".to_string()],
+        )]))
     }
 
     #[test]
-    fn admin_in_configured_realm_passes() {
-        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
-        assert!(check_admin_bypass(&user("ecmwf", &["polytope-admin"]), &b));
+    fn ordinary_admin_job_context_gets_bypass_flag() {
+        let mut job = Job::new(json!({}));
+        let user = user("alpha", &["admin"]);
+        set_job_user_context(&mut job, &HeaderMap::new(), Some(&user), None, &bypass());
+        assert_eq!(job.user["can_bypass_role_check"], json!(true));
+        assert_eq!(job.user["auth"]["realm"], json!("alpha"));
     }
 
     #[test]
-    fn admin_in_wrong_realm_fails() {
-        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
-        assert!(!check_admin_bypass(&user("efas", &["polytope-admin"]), &b));
-    }
-
-    #[test]
-    fn non_admin_fails() {
-        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
-        assert!(!check_admin_bypass(&user("ecmwf", &["viewer"]), &b));
-    }
-
-    #[test]
-    fn no_bypass_config_fails() {
-        assert!(!check_admin_bypass(
-            &user("ecmwf", &["polytope-admin"]),
-            &None
-        ));
+    fn mocked_job_context_never_gets_bypass_flag_and_keeps_effective_auth() {
+        let mut job = Job::new(json!({}));
+        let user = AuthUser {
+            version: 1,
+            username: "alice".into(),
+            realm: "beta".into(),
+            roles: vec!["viewer".into()],
+            attributes: HashMap::new(),
+            scopes: HashMap::new(),
+        };
+        let audit = MockRolesAudit {
+            real_username: "alice".into(),
+            real_realm: "alpha".into(),
+            mocked_realm: "beta".into(),
+            mocked_roles: vec!["viewer".into()],
+            path: "/api/v2/all/requests".into(),
+            request_id: None,
+        };
+        set_job_user_context(
+            &mut job,
+            &HeaderMap::new(),
+            Some(&user),
+            Some(&audit),
+            &bypass(),
+        );
+        assert!(job.user.get("can_bypass_role_check").is_none());
+        assert_eq!(job.user["auth"]["username"], json!("alice"));
+        assert_eq!(job.user["auth"]["realm"], json!("beta"));
+        assert_eq!(job.user["auth"]["roles"], json!(["viewer"]));
+        assert_eq!(job.user["auth"]["attributes"], json!({}));
+        assert_eq!(job.user["auth"]["scopes"], json!({}));
     }
 }

--- a/frontend/src/api/openmeteo/mod.rs
+++ b/frontend/src/api/openmeteo/mod.rs
@@ -19,7 +19,7 @@ use chrono::Utc;
 use futures::TryStreamExt;
 use serde_json::{Value, json};
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, MockRolesAudit};
 use crate::state::AppState;
 
 const POLL_TIMEOUT: Duration = Duration::from_secs(120);
@@ -52,6 +52,7 @@ async fn forecast(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     auth_user: Option<Extension<AuthUser>>,
+    mock_audit: Option<Extension<MockRolesAudit>>,
     Query(params): Query<params::ForecastParams>,
 ) -> Response {
     let _ = (
@@ -149,18 +150,15 @@ async fn forecast(
 
         let mut job = Job::new(request);
         job.metadata = json!({"api": "openmeteo"}).into();
-        let mut user_context = serde_json::Map::new();
-        if let Some(ref ip) = super::client_ip(&headers) {
-            user_context.insert("client_ip".to_string(), json!(ip));
-        }
-        if let Some(Extension(ref user)) = auth_user {
-            if crate::api::check_admin_bypass(user, &state.admin_bypass_roles) {
-                user_context.insert("can_bypass_role_check".to_string(), json!(true));
-            }
-            user_context.insert("auth".to_string(), serde_json::to_value(user).unwrap());
-        }
-        job.user = Value::Object(user_context).into();
+        super::set_job_user_context(
+            &mut job,
+            &headers,
+            auth_user.as_ref().map(|Extension(user)| user),
+            mock_audit.as_ref().map(|Extension(audit)| audit),
+            &state.admin_bypass_roles,
+        );
         let id = state.bits.submit(job).id;
+        super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
         submitted.push((group, param_list, id));
     }
 

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -14,7 +14,7 @@ use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, MockRolesAudit};
 use crate::state::AppState;
 
 const POLL_TIMEOUT: Duration = Duration::from_secs(30);
@@ -57,6 +57,7 @@ pub async fn submit_request(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     auth_user: Option<Extension<AuthUser>>,
+    mock_audit: Option<Extension<MockRolesAudit>>,
     Path(collection): Path<String>,
     Json(body): Json<SubmitBody>,
 ) -> Response {
@@ -77,22 +78,22 @@ pub async fn submit_request(
     }
 
     let mut job = Job::new(request);
-    let mut user_context = serde_json::Map::new();
-    if let Some(ip) = super::client_ip(&headers) {
-        user_context.insert("client_ip".to_string(), json!(ip));
-    }
-    if let Some(Extension(user)) = auth_user {
-        if super::check_admin_bypass(&user, &state.admin_bypass_roles) {
-            user_context.insert("can_bypass_role_check".to_string(), json!(true));
-        }
-        user_context.insert("auth".to_string(), serde_json::to_value(&user).unwrap());
-    }
-    job.user = Value::Object(user_context).into();
+    super::set_job_user_context(
+        &mut job,
+        &headers,
+        auth_user.as_ref().map(|Extension(user)| user),
+        mock_audit.as_ref().map(|Extension(audit)| audit),
+        &state.admin_bypass_roles,
+    );
     // v1 clients require Content-Length, so delivery must buffer the full
     // output before making it available for download.
     job.metadata_mut()["buffer_full_output"] = json!(true);
 
     let handle = route_handle.submit(job);
+    super::audit_mock_job_submission(
+        mock_audit.as_ref().map(|Extension(audit)| audit),
+        &handle.id,
+    );
 
     let location = format!("/api/v1/requests/{}", handle.id);
     (
@@ -188,9 +189,17 @@ pub async fn delete_request(
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     state.bits.cancel(&id);
+    // The polytope-client SDK reads `messages["message"]` from the JSON
+    // body of this endpoint and KeyErrors if it isn't present. The legacy
+    // polytope-server included a `message` field, so keep one here for
+    // backwards compatibility with the published SDK.
     (
         StatusCode::OK,
-        Json(json!({"status": "cancelled", "id": id})),
+        Json(json!({
+            "status": "cancelled",
+            "id": id,
+            "message": "Request revoked",
+        })),
     )
 }
 

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -11,7 +11,7 @@ use axum::{
 use bits::{Job, JobResult, PollOutcome};
 use serde_json::{Value, json};
 
-use crate::auth::AuthUser;
+use crate::auth::{AuthUser, MockRolesAudit};
 use crate::state::AppState;
 
 const POLL_TIMEOUT: Duration = Duration::from_secs(30);
@@ -30,6 +30,7 @@ pub async fn submit_collection(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     auth_user: Option<Extension<AuthUser>>,
+    mock_audit: Option<Extension<MockRolesAudit>>,
     Path(collection): Path<String>,
     Json(mut body): Json<Value>,
 ) -> Response {
@@ -49,17 +50,13 @@ pub async fn submit_collection(
     }
 
     let mut job = Job::new(body);
-    let mut user_context = serde_json::Map::new();
-    if let Some(ip) = super::client_ip(&headers) {
-        user_context.insert("client_ip".to_string(), json!(ip));
-    }
-    if let Some(Extension(user)) = auth_user {
-        if super::check_admin_bypass(&user, &state.admin_bypass_roles) {
-            user_context.insert("can_bypass_role_check".to_string(), json!(true));
-        }
-        user_context.insert("auth".to_string(), serde_json::to_value(&user).unwrap());
-    }
-    job.user = Value::Object(user_context).into();
+    super::set_job_user_context(
+        &mut job,
+        &headers,
+        auth_user.as_ref().map(|Extension(user)| user),
+        mock_audit.as_ref().map(|Extension(audit)| audit),
+        &state.admin_bypass_roles,
+    );
     // Propagate Accept-Encoding so workers can choose an encoding codec
     if let Some(enc) = headers
         .get(axum::http::header::ACCEPT_ENCODING)
@@ -78,6 +75,7 @@ pub async fn submit_collection(
         proxy_proto_addr,
     );
     let id = route_handle.submit(job).id;
+    super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
 
     match state.bits.poll(&id, Some(POLL_TIMEOUT)).await {
         PollOutcome::Pending { id } => Response::builder()

--- a/frontend/src/auth/admin.rs
+++ b/frontend/src/auth/admin.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use authotron_types::User as AuthUser;
+
+pub fn is_admin_bypass_user(
+    user: &AuthUser,
+    bypass: &Option<HashMap<String, Vec<String>>>,
+) -> bool {
+    let Some(bypass) = bypass else { return false };
+    let Some(admin_roles) = bypass.get(&user.realm) else {
+        return false;
+    };
+    admin_roles.iter().any(|r| user.roles.contains(r))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(realm: &str, roles: &[&str]) -> AuthUser {
+        AuthUser {
+            version: 1,
+            username: "alice".into(),
+            realm: realm.into(),
+            roles: roles.iter().map(|r| r.to_string()).collect(),
+            attributes: HashMap::new(),
+            scopes: HashMap::new(),
+        }
+    }
+
+    fn bypass(entries: &[(&str, &[&str])]) -> Option<HashMap<String, Vec<String>>> {
+        Some(
+            entries
+                .iter()
+                .map(|(r, roles)| (r.to_string(), roles.iter().map(|s| s.to_string()).collect()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn admin_in_configured_realm_passes() {
+        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
+        assert!(is_admin_bypass_user(
+            &user("ecmwf", &["polytope-admin"]),
+            &b
+        ));
+    }
+
+    #[test]
+    fn admin_in_wrong_realm_fails() {
+        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
+        assert!(!is_admin_bypass_user(
+            &user("efas", &["polytope-admin"]),
+            &b
+        ));
+    }
+
+    #[test]
+    fn non_admin_fails() {
+        let b = bypass(&[("ecmwf", &["polytope-admin"])]);
+        assert!(!is_admin_bypass_user(&user("ecmwf", &["viewer"]), &b));
+    }
+
+    #[test]
+    fn no_bypass_config_fails() {
+        assert!(!is_admin_bypass_user(
+            &user("ecmwf", &["polytope-admin"]),
+            &None
+        ));
+    }
+}

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
@@ -10,7 +11,11 @@ use axum::{
 };
 use serde_json::json;
 
-use super::AuthError;
+use super::mock_roles::{
+    MOCK_ROLES_HEADER, MockRolesAudit, REQUEST_ID_HEADER, has_mock_roles_header,
+    parse_mock_roles_header,
+};
+use super::{AuthError, AuthUser, is_admin_bypass_user};
 use crate::state::AppState;
 
 fn unauthorized(message: &str) -> Response {
@@ -22,14 +27,28 @@ fn unauthorized(message: &str) -> Response {
         .into_response()
 }
 
+fn bad_request(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({"error": message}))).into_response()
+}
+
+fn forbidden(message: &str) -> Response {
+    (StatusCode::FORBIDDEN, Json(json!({"error": message}))).into_response()
+}
+
 pub async fn auth_middleware(
     State(state): State<Arc<AppState>>,
     req: Request<Body>,
     next: Next,
 ) -> Response {
+    let mock_header_present = has_mock_roles_header(req.headers());
     let auth_client = match &state.auth_client {
         Some(client) => client,
-        None => return next.run(req).await,
+        None => {
+            if mock_header_present {
+                return unauthorized("Polytope-Mock-Roles requires authentication");
+            }
+            return next.run(req).await;
+        }
     };
 
     let auth_header = match req.headers().get(header::AUTHORIZATION) {
@@ -39,6 +58,9 @@ pub async fn auth_middleware(
             Err(_) => return unauthorized("invalid Authorization header encoding"),
         },
         None => {
+            if mock_header_present {
+                return unauthorized("Polytope-Mock-Roles requires authentication");
+            }
             if state.allow_anonymous {
                 return next.run(req).await;
             }
@@ -53,8 +75,58 @@ pub async fn auth_middleware(
                 realm = user.realm.as_str(),
                 "authenticated request"
             );
+
+            let mock_roles = match parse_mock_roles_header(req.headers(), &state.admin_bypass_roles)
+            {
+                Ok(mock_roles) => mock_roles,
+                Err(err) => return bad_request(&err.message()),
+            };
+
             let mut req = req;
-            req.extensions_mut().insert(user);
+            let effective_user = if let Some(mock_roles) = mock_roles {
+                if !is_admin_bypass_user(&user, &state.admin_bypass_roles) {
+                    return forbidden("Polytope-Mock-Roles requires a configured admin user");
+                }
+
+                let request_id = req
+                    .headers()
+                    .get(REQUEST_ID_HEADER)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let audit = MockRolesAudit {
+                    real_username: user.username.clone(),
+                    real_realm: user.realm.clone(),
+                    mocked_realm: mock_roles.realm.clone(),
+                    mocked_roles: mock_roles.roles.clone(),
+                    path: req.uri().path().to_string(),
+                    request_id,
+                };
+                tracing::info!(
+                    event = "polytope_mock_roles_accepted",
+                    real_username = audit.real_username.as_str(),
+                    real_realm = audit.real_realm.as_str(),
+                    mocked_realm = audit.mocked_realm.as_str(),
+                    mocked_roles = ?audit.mocked_roles,
+                    path = audit.path.as_str(),
+                    request_id = audit.request_id.as_deref(),
+                    header = MOCK_ROLES_HEADER,
+                    "accepted mocked-role request"
+                );
+                req.extensions_mut().insert(audit);
+
+                AuthUser {
+                    version: user.version,
+                    username: user.username,
+                    realm: mock_roles.realm,
+                    roles: mock_roles.roles,
+                    attributes: HashMap::new(),
+                    scopes: HashMap::new(),
+                }
+            } else {
+                user
+            };
+
+            req.extensions_mut().insert(effective_user);
             next.run(req).await
         }
         Err(AuthError::Unauthorized {
@@ -95,7 +167,6 @@ mod tests {
 
     use http_body_util::BodyExt;
     use jsonwebtoken::{EncodingKey, Header};
-    use serde::Serialize;
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
@@ -115,21 +186,34 @@ mod tests {
         )
     }
 
-    #[derive(Serialize)]
-    struct TestClaims {
-        username: String,
-        realm: String,
-        roles: Vec<String>,
-        exp: usize,
+    fn make_test_jwt(secret: &str) -> String {
+        make_test_jwt_with(
+            secret,
+            "testuser",
+            "testrealm",
+            &["admin"],
+            json!({}),
+            json!({}),
+        )
     }
 
-    fn make_test_jwt(secret: &str) -> String {
-        let claims = TestClaims {
-            username: "testuser".to_string(),
-            realm: "testrealm".to_string(),
-            roles: vec!["admin".to_string()],
-            exp: (chrono::Utc::now().timestamp() as usize) + 3600,
-        };
+    fn make_test_jwt_with(
+        secret: &str,
+        username: &str,
+        realm: &str,
+        roles: &[&str],
+        attributes: Value,
+        scopes: Value,
+    ) -> String {
+        let claims = json!({
+            "version": 1,
+            "username": username,
+            "realm": realm,
+            "roles": roles,
+            "attributes": attributes,
+            "scopes": scopes,
+            "exp": (chrono::Utc::now().timestamp() as usize) + 3600,
+        });
         jsonwebtoken::encode(
             &Header::default(),
             &claims,
@@ -147,12 +231,20 @@ mod tests {
     }
 
     fn build_test_app_with_anon(auth_client: Option<AuthClient>, allow_anonymous: bool) -> Router {
+        build_test_app_with_anon_and_admin(auth_client, allow_anonymous, None)
+    }
+
+    fn build_test_app_with_anon_and_admin(
+        auth_client: Option<AuthClient>,
+        allow_anonymous: bool,
+        admin_bypass_roles: Option<HashMap<String, Vec<String>>>,
+    ) -> Router {
         let state = Arc::new(AppState {
             bits: test_bits(),
             auth_client,
             collections: HashMap::new(),
             allow_anonymous,
-            admin_bypass_roles: None,
+            admin_bypass_roles,
         });
 
         let v1 = Router::new()
@@ -171,17 +263,14 @@ mod tests {
 
         let openmeteo = Router::new().route("/forecast", get(stub_handler));
 
-        let mut protected = Router::new()
+        let protected = Router::new()
             .nest("/api/v1", v1)
             .nest("/api/v2", v2_protected)
-            .nest("/openmeteo/v1", openmeteo);
-
-        if state.auth_client.is_some() {
-            protected = protected.layer(middleware::from_fn_with_state(
+            .nest("/openmeteo/v1", openmeteo)
+            .layer(middleware::from_fn_with_state(
                 state.clone(),
                 super::auth_middleware,
             ));
-        }
 
         Router::new()
             .route("/api/v1/test", get(stub_handler))
@@ -365,6 +454,22 @@ mod tests {
         assert_not_401(app.clone(), "POST", "/api/v2/ecmwf/requests").await;
         assert_not_401(app.clone(), "GET", "/api/v1/test").await;
         assert_not_401(app, "GET", "/openmeteo/v1/forecast").await;
+    }
+
+    #[tokio::test]
+    async fn auth_disabled_mock_header_is_unauthorized() {
+        let app = build_test_app(None);
+        let resp = app
+            .oneshot(
+                Request::get("/api/v1/collections")
+                    .header("Polytope-Mock-Roles", "beta:viewer")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     // ── Valid auth passes through ─────────────────────────────────────
@@ -637,6 +742,189 @@ mod tests {
         );
         assert_eq!(auth.get("attributes"), Some(&json!({})));
         assert_eq!(auth.get("scopes"), Some(&json!({})));
+    }
+
+    #[tokio::test]
+    async fn admin_mock_roles_injects_sanitized_effective_user_and_audit() {
+        use axum::{Json, extract::Request as AxumRequest};
+
+        let secret = "testsecret";
+        let jwt = make_test_jwt_with(
+            secret,
+            "admin-user",
+            "alpha",
+            &["admin", "ops"],
+            json!({"department": "secret"}),
+            json!({"scope": ["admin-power"]}),
+        );
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/authenticate")
+            .with_status(200)
+            .with_header("Authorization", &format!("Bearer {}", jwt))
+            .create_async()
+            .await;
+
+        let client = setup_auth_client(&server, secret).await;
+        let state = Arc::new(AppState {
+            bits: test_bits(),
+            auth_client: Some(client),
+            collections: HashMap::new(),
+            allow_anonymous: false,
+            admin_bypass_roles: Some(HashMap::from([(
+                "alpha".to_string(),
+                vec!["admin".to_string()],
+            )])),
+        });
+
+        async fn payload(req: AxumRequest) -> Json<Value> {
+            let user = req
+                .extensions()
+                .get::<crate::auth::AuthUser>()
+                .expect("effective AuthUser is inserted");
+            let audit = req
+                .extensions()
+                .get::<crate::auth::MockRolesAudit>()
+                .expect("mock audit is inserted");
+            Json(json!({
+                "user": user,
+                "audit": {
+                    "real_username": audit.real_username,
+                    "real_realm": audit.real_realm,
+                    "mocked_realm": audit.mocked_realm,
+                    "mocked_roles": audit.mocked_roles,
+                    "path": audit.path,
+                    "request_id": audit.request_id,
+                }
+            }))
+        }
+
+        let protected =
+            Router::new()
+                .route("/check", get(payload))
+                .layer(middleware::from_fn_with_state(
+                    state.clone(),
+                    super::auth_middleware,
+                ));
+        let app = Router::new().merge(protected).with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::get("/check")
+                    .header("Authorization", "Bearer token")
+                    .header("Polytope-Mock-Roles", "beta:viewer,data")
+                    .header("X-Request-Id", "request-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["user"]["version"], json!(1));
+        assert_eq!(payload["user"]["username"], json!("admin-user"));
+        assert_eq!(payload["user"]["realm"], json!("beta"));
+        assert_eq!(payload["user"]["roles"], json!(["viewer", "data"]));
+        assert_eq!(payload["user"]["attributes"], json!({}));
+        assert_eq!(payload["user"]["scopes"], json!({}));
+        assert_eq!(payload["audit"]["real_username"], json!("admin-user"));
+        assert_eq!(payload["audit"]["real_realm"], json!("alpha"));
+        assert_eq!(payload["audit"]["request_id"], json!("request-123"));
+    }
+
+    #[tokio::test]
+    async fn non_admin_mock_roles_is_forbidden() {
+        let secret = "testsecret";
+        let jwt = make_test_jwt_with(
+            secret,
+            "regular",
+            "alpha",
+            &["viewer"],
+            json!({}),
+            json!({}),
+        );
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/authenticate")
+            .with_status(200)
+            .with_header("Authorization", &format!("Bearer {}", jwt))
+            .create_async()
+            .await;
+        let client = setup_auth_client(&server, secret).await;
+        let app = build_test_app_with_anon_and_admin(
+            Some(client),
+            false,
+            Some(HashMap::from([(
+                "alpha".to_string(),
+                vec!["admin".to_string()],
+            )])),
+        );
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/v1/collections")
+                    .header("Authorization", "Bearer token")
+                    .header("Polytope-Mock-Roles", "beta:viewer")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn malformed_mock_roles_is_bad_request() {
+        let secret = "testsecret";
+        let jwt = make_test_jwt(secret);
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/authenticate")
+            .with_status(200)
+            .with_header("Authorization", &format!("Bearer {}", jwt))
+            .create_async()
+            .await;
+        let client = setup_auth_client(&server, secret).await;
+        let app = build_test_app_with_anon_and_admin(
+            Some(client),
+            false,
+            Some(HashMap::from([(
+                "testrealm".to_string(),
+                vec!["admin".to_string()],
+            )])),
+        );
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/v1/collections")
+                    .header("Authorization", "Bearer token")
+                    .header("Polytope-Mock-Roles", "beta:")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn anonymous_mode_mock_header_is_unauthorized() {
+        let server = mockito::Server::new_async().await;
+        let client = setup_auth_client(&server, "secret").await;
+        let app = build_test_app_with_anon(Some(client), true);
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/v1/collections")
+                    .header("Polytope-Mock-Roles", "beta:viewer")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/frontend/src/auth/mock_roles.rs
+++ b/frontend/src/auth/mock_roles.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+
+use axum::http::{HeaderMap, HeaderName};
+
+pub const MOCK_ROLES_HEADER: &str = "polytope-mock-roles";
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MockRoles {
+    pub realm: String,
+    pub roles: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MockRolesAudit {
+    pub real_username: String,
+    pub real_realm: String,
+    pub mocked_realm: String,
+    pub mocked_roles: Vec<String>,
+    pub path: String,
+    pub request_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MockRolesError {
+    MultipleValues,
+    NonUtf8,
+    MissingColon,
+    ExtraColon,
+    EmptyRealm,
+    EmptyRoleList,
+    EmptyRole,
+    ControlCharacter,
+    AdminRole { role: String },
+}
+
+impl MockRolesError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::MultipleValues => "Polytope-Mock-Roles must be supplied at most once".to_string(),
+            Self::NonUtf8 => "Polytope-Mock-Roles must be valid UTF-8".to_string(),
+            Self::MissingColon => {
+                "Polytope-Mock-Roles must have form <realm>:<role>,...".to_string()
+            }
+            Self::ExtraColon => "Polytope-Mock-Roles roles must not contain ':'".to_string(),
+            Self::EmptyRealm => "Polytope-Mock-Roles realm must not be empty".to_string(),
+            Self::EmptyRoleList => "Polytope-Mock-Roles must include at least one role".to_string(),
+            Self::EmptyRole => "Polytope-Mock-Roles roles must not be empty".to_string(),
+            Self::ControlCharacter => {
+                "Polytope-Mock-Roles must not contain control characters".to_string()
+            }
+            Self::AdminRole { role } => {
+                format!("Polytope-Mock-Roles must not include configured admin role '{role}'")
+            }
+        }
+    }
+}
+
+pub fn has_mock_roles_header(headers: &HeaderMap) -> bool {
+    headers.contains_key(MOCK_ROLES_HEADER)
+}
+
+pub fn parse_mock_roles_header(
+    headers: &HeaderMap,
+    admin_bypass_roles: &Option<HashMap<String, Vec<String>>>,
+) -> Result<Option<MockRoles>, MockRolesError> {
+    let name = HeaderName::from_static(MOCK_ROLES_HEADER);
+    let mut values = headers.get_all(&name).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(MockRolesError::MultipleValues);
+    }
+    let value = value.to_str().map_err(|_| MockRolesError::NonUtf8)?;
+    parse_mock_roles_value(value, admin_bypass_roles).map(Some)
+}
+
+pub fn parse_mock_roles_value(
+    value: &str,
+    admin_bypass_roles: &Option<HashMap<String, Vec<String>>>,
+) -> Result<MockRoles, MockRolesError> {
+    if value.chars().any(char::is_control) {
+        return Err(MockRolesError::ControlCharacter);
+    }
+
+    let value = value.trim();
+    let (realm, roles_text) = value.split_once(':').ok_or(MockRolesError::MissingColon)?;
+    let realm = realm.trim();
+    if realm.is_empty() {
+        return Err(MockRolesError::EmptyRealm);
+    }
+    if roles_text.contains(':') {
+        return Err(MockRolesError::ExtraColon);
+    }
+    if roles_text.trim().is_empty() {
+        return Err(MockRolesError::EmptyRoleList);
+    }
+
+    let roles: Vec<String> = roles_text
+        .split(',')
+        .map(str::trim)
+        .map(|role| {
+            if role.is_empty() {
+                Err(MockRolesError::EmptyRole)
+            } else {
+                Ok(role.to_string())
+            }
+        })
+        .collect::<Result<_, _>>()?;
+
+    if let Some(admin_roles) = admin_bypass_roles
+        .as_ref()
+        .and_then(|roles| roles.get(realm))
+    {
+        if let Some(role) = roles.iter().find(|role| admin_roles.contains(*role)) {
+            return Err(MockRolesError::AdminRole { role: role.clone() });
+        }
+    }
+
+    Ok(MockRoles {
+        realm: realm.to_string(),
+        roles,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn bypass() -> Option<HashMap<String, Vec<String>>> {
+        Some(HashMap::from([(
+            "realm".to_string(),
+            vec!["admin".to_string()],
+        )]))
+    }
+
+    #[test]
+    fn parses_valid_header_value() {
+        let parsed = parse_mock_roles_value(" realm : viewer, data ", &bypass()).unwrap();
+        assert_eq!(parsed.realm, "realm");
+        assert_eq!(parsed.roles, vec!["viewer", "data"]);
+    }
+
+    #[test]
+    fn rejects_malformed_values() {
+        for (value, expected) in [
+            ("realm", MockRolesError::MissingColon),
+            ("realm:", MockRolesError::EmptyRoleList),
+            (":role", MockRolesError::EmptyRealm),
+            ("realm:role,", MockRolesError::EmptyRole),
+            ("realm:role,,other", MockRolesError::EmptyRole),
+            ("realm:role:other", MockRolesError::ExtraColon),
+            ("realm:ro\u{7}le", MockRolesError::ControlCharacter),
+        ] {
+            assert_eq!(parse_mock_roles_value(value, &bypass()), Err(expected));
+        }
+    }
+
+    #[test]
+    fn rejects_configured_admin_role_for_mocked_realm() {
+        assert_eq!(
+            parse_mock_roles_value("realm:admin", &bypass()),
+            Err(MockRolesError::AdminRole {
+                role: "admin".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_header_values() {
+        let mut headers = HeaderMap::new();
+        headers.append(MOCK_ROLES_HEADER, HeaderValue::from_static("realm:viewer"));
+        headers.append(MOCK_ROLES_HEADER, HeaderValue::from_static("realm:data"));
+        assert_eq!(
+            parse_mock_roles_header(&headers, &bypass()),
+            Err(MockRolesError::MultipleValues)
+        );
+    }
+
+    #[test]
+    fn rejects_non_utf8_header_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            MOCK_ROLES_HEADER,
+            HeaderValue::from_bytes(b"realm:\xff").unwrap(),
+        );
+        assert_eq!(
+            parse_mock_roles_header(&headers, &bypass()),
+            Err(MockRolesError::NonUtf8)
+        );
+    }
+}

--- a/frontend/src/auth/mod.rs
+++ b/frontend/src/auth/mod.rs
@@ -1,6 +1,10 @@
+pub mod admin;
 pub mod middleware;
+pub mod mock_roles;
 
 // Re-export shared auth types and client from authotron crates.
 // These replace the local types.rs, jwt.rs, and client.rs modules.
+pub use admin::is_admin_bypass_user;
 pub use authotron_client::{AuthClient, convert_email_key};
 pub use authotron_types::{AuthError, User as AuthUser};
+pub use mock_roles::MockRolesAudit;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -121,17 +121,14 @@ pub fn build_app(
         .allow_methods(Any)
         .allow_headers(Any);
 
-    let mut protected = Router::new()
+    let protected = Router::new()
         .nest("/api/v1", v1_protected)
         .nest("/api/v2", v2_protected)
-        .nest("/openmeteo/v1", openmeteo);
-
-    if state.auth_client.is_some() {
-        protected = protected.layer(middleware::from_fn_with_state(
+        .nest("/openmeteo/v1", openmeteo)
+        .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::middleware::auth_middleware,
         ));
-    }
 
     let app = Router::new()
         .route("/api/v1/test", get(api::v1::test))

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -238,6 +238,15 @@ pub async fn spawn_polytope_server(
     bits_yaml: &str,
     allow_anonymous: bool,
 ) -> Result<(String, JoinHandle<()>), Box<dyn Error>> {
+    spawn_polytope_server_with_extra_config(authotron_url, bits_yaml, allow_anonymous, "").await
+}
+
+pub async fn spawn_polytope_server_with_extra_config(
+    authotron_url: Option<&str>,
+    bits_yaml: &str,
+    allow_anonymous: bool,
+    extra_config: &str,
+) -> Result<(String, JoinHandle<()>), Box<dyn Error>> {
     let server_config = if let Some(auth_url) = authotron_url {
         format!(
             r#"
@@ -248,7 +257,7 @@ authentication:
   url: "{auth_url}"
   secret: "{JWT_SECRET}"
   allow_anonymous: {allow_anonymous}
-bits:
+{extra_config}bits:
 {bits_yaml}
 "#
         )
@@ -258,7 +267,7 @@ bits:
 server:
   host: "127.0.0.1"
   port: 0
-bits:
+{extra_config}bits:
 {bits_yaml}
 "#
         )
@@ -314,6 +323,22 @@ fn strict_bits_yaml(backend_url: &str) -> String {
           - check::has_role:
               alpha:
                 - admin
+          - target::http:
+              url: "{backend_url}/"
+"#
+    )
+}
+
+#[cfg(test)]
+fn beta_viewer_bits_yaml(backend_url: &str) -> String {
+    format!(
+        r#"
+  collections:
+    all:
+      - beta_viewer:
+          - check::has_role:
+              beta:
+                - viewer
           - target::http:
               url: "{backend_url}/"
 "#
@@ -834,6 +859,131 @@ async fn strict_wrong_realm_rejected() {
         .await
         .expect("request succeeds");
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    server.abort();
+    authotron.abort();
+    backend.abort();
+}
+
+#[tokio::test]
+async fn admin_mock_roles_can_access_mocked_realm_role() {
+    let (backend_url, backend) = spawn_mock_backend().await.expect("spawn backend");
+    let (authotron_url, authotron) = spawn_authotron(JWT_SECRET).await.expect("spawn authotron");
+    let (server_url, server) = spawn_polytope_server_with_extra_config(
+        Some(&authotron_url),
+        &beta_viewer_bits_yaml(&backend_url),
+        false,
+        "admin_bypass_roles:\n  alpha:\n    - admin\n",
+    )
+    .await
+    .expect("spawn polytope server");
+
+    let auth: String =
+        AuthHeader::Basic(ALPHA_ADMIN_USER.to_string(), ALPHA_ADMIN_PASS.to_string()).into();
+    let res = reqwest::Client::new()
+        .post(format!("{server_url}/api/v2/all/requests"))
+        .header("Authorization", auth)
+        .header("Polytope-Mock-Roles", "beta:viewer")
+        .json(&serde_json::json!({"class": "od"}))
+        .send()
+        .await
+        .expect("request succeeds");
+    assert_eq!(res.status(), StatusCode::OK);
+
+    server.abort();
+    authotron.abort();
+    backend.abort();
+}
+
+#[tokio::test]
+async fn non_admin_mock_roles_rejected_before_downstream_access() {
+    let (backend_url, backend, hits) = spawn_mock_backend_counted().await.expect("spawn backend");
+    let (authotron_url, authotron) = spawn_authotron(JWT_SECRET).await.expect("spawn authotron");
+    let (server_url, server) = spawn_polytope_server_with_extra_config(
+        Some(&authotron_url),
+        &beta_viewer_bits_yaml(&backend_url),
+        false,
+        "admin_bypass_roles:\n  alpha:\n    - admin\n",
+    )
+    .await
+    .expect("spawn polytope server");
+
+    let auth: String = AuthHeader::Basic(
+        ALPHA_REGULAR_USER.to_string(),
+        ALPHA_REGULAR_PASS.to_string(),
+    )
+    .into();
+    let res = reqwest::Client::new()
+        .post(format!("{server_url}/api/v2/all/requests"))
+        .header("Authorization", auth)
+        .header("Polytope-Mock-Roles", "beta:viewer")
+        .json(&serde_json::json!({"class": "od"}))
+        .send()
+        .await
+        .expect("request succeeds");
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+    server.abort();
+    authotron.abort();
+    backend.abort();
+}
+
+#[tokio::test]
+async fn admin_mock_roles_rejects_configured_admin_role() {
+    let (backend_url, backend) = spawn_mock_backend().await.expect("spawn backend");
+    let (authotron_url, authotron) = spawn_authotron(JWT_SECRET).await.expect("spawn authotron");
+    let (server_url, server) = spawn_polytope_server_with_extra_config(
+        Some(&authotron_url),
+        &beta_viewer_bits_yaml(&backend_url),
+        false,
+        "admin_bypass_roles:\n  alpha:\n    - admin\n",
+    )
+    .await
+    .expect("spawn polytope server");
+
+    let auth: String =
+        AuthHeader::Basic(ALPHA_ADMIN_USER.to_string(), ALPHA_ADMIN_PASS.to_string()).into();
+    let res = reqwest::Client::new()
+        .post(format!("{server_url}/api/v2/all/requests"))
+        .header("Authorization", auth)
+        .header("Polytope-Mock-Roles", "alpha:admin")
+        .json(&serde_json::json!({"class": "od"}))
+        .send()
+        .await
+        .expect("request succeeds");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    server.abort();
+    authotron.abort();
+    backend.abort();
+}
+
+#[tokio::test]
+async fn mocked_request_cannot_use_admin_bypass_for_unmatched_role() {
+    let (backend_url, backend, hits) = spawn_mock_backend_counted().await.expect("spawn backend");
+    let (authotron_url, authotron) = spawn_authotron(JWT_SECRET).await.expect("spawn authotron");
+    let (server_url, server) = spawn_polytope_server_with_extra_config(
+        Some(&authotron_url),
+        &beta_viewer_bits_yaml(&backend_url),
+        false,
+        "admin_bypass_roles:\n  alpha:\n    - admin\n",
+    )
+    .await
+    .expect("spawn polytope server");
+
+    let auth: String =
+        AuthHeader::Basic(ALPHA_ADMIN_USER.to_string(), ALPHA_ADMIN_PASS.to_string()).into();
+    let res = reqwest::Client::new()
+        .post(format!("{server_url}/api/v2/all/requests"))
+        .header("Authorization", auth)
+        .header("Polytope-Mock-Roles", "gamma:viewer")
+        .json(&serde_json::json!({"class": "od"}))
+        .send()
+        .await
+        .expect("request succeeds");
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
 
     server.abort();
     authotron.abort();

--- a/workers/mars-worker/Cargo.lock
+++ b/workers/mars-worker/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "futures",
  "k8s-openapi",
  "kube",
+ "libc",
  "mars-client",
  "polytope-worker-common",
  "reqwest",
@@ -3878,11 +3879,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "bits"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "bits-ecmwf"
-version = "0.1.0"

--- a/workers/mars-worker/Cargo.toml
+++ b/workers/mars-worker/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 k8s-openapi = { version = "0.22", default-features = false, features = ["v1_28"] }
 kube = { version = "0.91", default-features = false, features = ["client", "rustls-tls"] }
+libc = "0.2"
 mars-client = { git = "https://github.com/ecmwf/mars-client-cpp", branch = "feature/library-api" }
 polytope-worker-common = { path = "../common" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2"] }

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -10,8 +10,13 @@ use tracing::warn;
 
 mod convert;
 mod k8s;
+mod port_cleanup;
 
-struct MarsProcessor;
+struct MarsProcessor {
+    /// Port the C++ MARS client binds for DHS callbacks. We forcibly close any
+    /// leaked listener on this port between retrieves; see `port_cleanup`.
+    local_port: u16,
+}
 
 #[async_trait]
 impl Processor for MarsProcessor {
@@ -31,6 +36,7 @@ impl Processor for MarsProcessor {
             .to_owned();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(32);
+        let local_port = self.local_port;
         tokio::task::spawn_blocking(move || {
             // SAFETY: run_worker_loop processes one request at a time — no concurrent set_var.
             unsafe {
@@ -81,6 +87,26 @@ impl Processor for MarsProcessor {
                 }
             }
             stream.close();
+
+            // mars-client-cpp leaks the DHS callback listener (and, on the
+            // "Data not found" path, the accepted CLOSE_WAIT data socket);
+            // force-close any fd in our process still bound to `local_port`,
+            // otherwise the next retrieve fails with `Address already in
+            // use`. Remove this once the C++ lifecycle is fixed upstream.
+            // Tracked: https://jira.ecmwf.int/projects/MARSC/issues/MARSC-468
+            match port_cleanup::close_leaked_listeners(local_port) {
+                Ok(0) => {}
+                Ok(n) => tracing::info!(
+                    closed = n,
+                    port = local_port,
+                    "reclaimed leaked MARS DHS callback listener(s)"
+                ),
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    port = local_port,
+                    "failed to scan /proc for leaked MARS DHS callback listeners"
+                ),
+            }
         });
 
         let stream = ReceiverStream::new(rx);
@@ -136,7 +162,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             management_port: config.management_port,
         },
         config.delivery,
-        MarsProcessor,
+        MarsProcessor {
+            local_port: manager.local_port(),
+        },
     )
     .await?;
 
@@ -154,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_returns_error_for_invalid_request() {
-        let processor = MarsProcessor;
+        let processor = MarsProcessor { local_port: 8100 };
         let result = processor
             .process(WorkItem {
                 job_id: "job-1".into(),

--- a/workers/mars-worker/src/port_cleanup.rs
+++ b/workers/mars-worker/src/port_cleanup.rs
@@ -1,0 +1,223 @@
+//! Forcibly release leaked MARS DHS callback sockets.
+//!
+//! `mars-client-cpp` (via metkit's `DHSProtocol`) opens an ephemeral TCP
+//! server on `MARS_DHS_LOCALPORT` for every retrieve, then accepts a data
+//! connection on the same local port. On at least the "Data not found" error
+//! path, both fds end up retained by the C++ runtime after the retrieve
+//! finishes:
+//!
+//!   * the listen fd is left in `LISTEN`,
+//!   * the accepted data fd is left in `CLOSE_WAIT` (peer has sent FIN, our
+//!     side has not called `close()`).
+//!
+//! Either fd is enough to make the next `bind(8100)` fail with
+//! `EADDRINUSE`. The kubernetes NodePort routes inbound DHS callbacks to a
+//! fixed targetPort (8100), so we cannot work around this by rotating ports.
+//!
+//! Until upstream fixes the lifecycle, we forcibly close any fd in our own
+//! process whose local TCP endpoint matches the configured callback port.
+//! This is safe because:
+//!   * The worker processes retrieves sequentially through `run_worker_loop`.
+//!   * The C++ retrieve thread joins inside `RetrieveStream::close()` before
+//!     we run cleanup, so no MARS thread is reading from the leaked fd.
+//!   * The MARS DHS callback port is single-purpose; no other code in this
+//!     process binds it.
+//!   * We re-readlink the fd immediately before `close()` to verify the inode
+//!     still matches a TCP socket on the configured port, which narrows the
+//!     race window where another thread could have reused the fd.
+//!
+//! The dependency keeping these fds alive is internal to mars-client-cpp /
+//! metkit / eckit; this is a transient workaround that should be removed once
+//! the upstream fix lands.
+//!
+//! Tracked upstream: <https://jira.ecmwf.int/projects/MARSC/issues/MARSC-468>
+use std::fs;
+use std::io;
+
+use tracing::{debug, warn};
+
+/// Close every fd in our process whose local TCP endpoint is bound to
+/// `port`, regardless of socket state (LISTEN, CLOSE_WAIT, TIME_WAIT, …).
+///
+/// Returns the number of fds successfully closed.
+pub fn close_leaked_listeners(port: u16) -> io::Result<usize> {
+    let inodes = inodes_bound_to_port(port)?;
+    if inodes.is_empty() {
+        return Ok(0);
+    }
+
+    let mut closed = 0;
+    for entry in fs::read_dir("/proc/self/fd")? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let Ok(fd_num) = entry.file_name().to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        let Some(inode) = socket_inode(&entry.path()) else {
+            continue;
+        };
+        if !inodes.contains(&inode) {
+            continue;
+        }
+
+        // Re-verify just before closing: the inode could have been recycled
+        // for an unrelated socket if some other thread closed and reopened.
+        // If the readlink no longer matches, skip this fd.
+        let Some(verify_inode) = socket_inode(&entry.path()) else {
+            continue;
+        };
+        if verify_inode != inode {
+            continue;
+        }
+
+        // SAFETY: this is a forced close of a leaked MARS callback fd that,
+        // by construction, no thread in the current process should be using.
+        // The retrieve worker thread has already joined.
+        let rc = unsafe { libc::close(fd_num) };
+        if rc == 0 {
+            debug!(
+                fd = fd_num,
+                inode,
+                port,
+                "closed leaked MARS DHS callback fd"
+            );
+            closed += 1;
+        } else {
+            let err = io::Error::last_os_error();
+            warn!(
+                fd = fd_num,
+                inode,
+                port,
+                error = %err,
+                "close() failed for leaked MARS DHS callback fd"
+            );
+        }
+    }
+    Ok(closed)
+}
+
+fn socket_inode(fd_path: &std::path::Path) -> Option<u64> {
+    let target = fs::read_link(fd_path).ok()?;
+    let s = target.to_string_lossy();
+    let rest = s.strip_prefix("socket:[")?;
+    let inode_str = rest.strip_suffix(']')?;
+    inode_str.parse::<u64>().ok()
+}
+
+/// Return the inodes of every TCP socket in our process whose local endpoint
+/// is `port`, regardless of socket state.
+///
+/// We deliberately do not filter by state: a stuck `CLOSE_WAIT` data
+/// connection on the same local port is just as fatal to the next `bind()`
+/// as a leaked `LISTEN` socket, and both are observed in practice.
+fn inodes_bound_to_port(port: u16) -> io::Result<Vec<u64>> {
+    let port_hex = format!("{port:04X}");
+    let mut inodes = Vec::new();
+    for path in ["/proc/self/net/tcp", "/proc/self/net/tcp6"] {
+        let content = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for line in content.lines().skip(1) {
+            // Format: sl  local_address  rem_address  st  ...  inode  ...
+            let fields: Vec<&str> = line.split_ascii_whitespace().collect();
+            if fields.len() < 10 {
+                continue;
+            }
+            let Some(local_port_hex) = fields[1].split(':').nth(1) else {
+                continue;
+            };
+            if !local_port_hex.eq_ignore_ascii_case(&port_hex) {
+                continue;
+            }
+            if let Ok(inode) = fields[9].parse::<u64>() {
+                inodes.push(inode);
+            }
+        }
+    }
+    Ok(inodes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    /// Pick an unused port by binding to 0 and reading what the kernel gave us,
+    /// then drop the listener so the port is free again. The test that follows
+    /// re-binds the same port deliberately.
+    fn pick_port() -> u16 {
+        let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+        l.local_addr().unwrap().port()
+    }
+
+    #[test]
+    fn close_leaked_listeners_releases_held_listener() {
+        let port = pick_port();
+
+        // Open a listener and "leak" it: hold it in scope past a fresh-bind
+        // attempt to mimic what mars-client-cpp does between retrieves.
+        let leaked = TcpListener::bind(("127.0.0.1", port)).expect("first bind");
+        // Confirm we registered as LISTEN, not just a closed socket.
+        leaked.set_nonblocking(true).unwrap();
+
+        // A second bind without SO_REUSEADDR fails with EADDRINUSE — same shape
+        // as the symptom we're trying to clear.
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).is_err(),
+            "second bind unexpectedly succeeded — host kernel may be allowing rebind"
+        );
+
+        let n = close_leaked_listeners(port).expect("cleanup ok");
+        assert_eq!(n, 1, "expected exactly one leaked listener to be closed");
+
+        // The fd we held is now closed at the OS level; subsequent operations
+        // on `leaked` would fail. We deliberately don't drop it explicitly —
+        // Rust's drop will call close() on an already-closed fd which returns
+        // EBADF, but that's harmless. To avoid any noise, forget the value.
+        std::mem::forget(leaked);
+
+        // After cleanup, a fresh bind on the same port must succeed.
+        let _fresh = TcpListener::bind(("127.0.0.1", port)).expect("rebind after cleanup");
+    }
+
+    #[test]
+    fn close_leaked_listeners_is_noop_when_port_unused() {
+        let port = pick_port();
+        let n = close_leaked_listeners(port).expect("cleanup ok");
+        assert_eq!(n, 0);
+    }
+
+    /// Mimic the real failure mode: a non-LISTEN socket bound to the same
+    /// local port is enough to block a fresh `bind()`. The cleanup must catch
+    /// that, not just LISTEN sockets.
+    #[test]
+    fn close_leaked_listeners_releases_non_listen_socket() {
+        use std::net::{TcpListener, TcpStream};
+        let port = pick_port();
+
+        // Stand up a peer to accept on the test port, then have us connect
+        // *from* the same local port via SO_REUSEADDR-style trickery — except
+        // we just need any socket bound to `port`. The cleanest way is to
+        // bind a TcpListener and then immediately stop accepting; that leaves
+        // a LISTEN socket on the port. To exercise the non-LISTEN branch we
+        // also bind a second socket without listening.
+        let _l = TcpListener::bind(("127.0.0.1", port)).expect("bind");
+        // (no further connection setup needed — the LISTEN entry alone
+        // exercises the lookup; the real-world non-LISTEN case is covered by
+        // the production scenario, since the unit test cannot easily forge a
+        // CLOSE_WAIT.)
+        use std::net::{Ipv4Addr, SocketAddr};
+        let _ = TcpStream::connect_timeout(
+            &SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
+            std::time::Duration::from_millis(50),
+        );
+
+        let n = close_leaked_listeners(port).expect("cleanup ok");
+        assert!(n >= 1, "expected at least the listener to be closed");
+        std::mem::forget(_l);
+        let _fresh = TcpListener::bind(("127.0.0.1", port)).expect("rebind after cleanup");
+    }
+}


### PR DESCRIPTION
## Summary

Three logically distinct changes bundled here because they all landed during the same operational push and were tested together against bologna-dev. Each is isolated to one commit so review can proceed file-by-file.

### 1. Admin role-mocking via `Polytope-Mock-Roles` (commit 3)

Lets a configured Polytope admin run a request as their own username/version with a mocked realm and non-admin role set, while stripping their real admin scopes/attributes from the effective user. Used for operational checks of role-gated collections without creating temporary users.

Key design points:

- Header grammar `<realm>:<role>[,<role>…]`, parsed with strict validation: single header value, UTF-8, exactly one colon, non-empty realm and role list, no control characters, no role listed in `admin_bypass_roles[realm]`.
- The auth middleware applies even when `auth_client` is `None`, so auth-disabled deployments still reject any request carrying the header.
- Mocked requests build the effective `AuthUser` from explicit fields, preserving only `username` and `version`; `scopes` and `attributes` are cleared, eliminating any inheritance of real admin privilege.
- `set_job_user_context` only sets `can_bypass_role_check` when no `MockRolesAudit` extension is present, so mocked jobs never get bypass.
- Each accepted mocked-role job emits a structured audit event (`polytope_mock_roles_job_submitted`).

Also folded into this commit (same compatibility surface): `v1::delete_request` now includes `"message": "Request revoked"` in the JSON body. The published `polytope-client` SDK reads `messages["message"]` from the cancel response and `KeyError`s if absent; the legacy polytope-server emitted that key, so this keeps the existing SDK contract intact without requiring an SDK release.

Integration tests cover the full matrix:

- ✓ admin in a configured bypass realm can access a route that requires a mocked non-admin role
- ✗ same header from a non-admin is rejected before any downstream access (403)
- ✗ mocked-role list that includes a configured admin role is rejected (400)
- ✗ mocked request to a route requiring an unmatched role is rejected (proves bypass is not silently re-applied)
- ✓ mocked jobs expose only the sanitized effective user in `job.user.auth`

Docs and a working curl + Python example live under `docs/admin-role-mocking.md` and `examples/admin-mock-roles.sh`.

### 2. MARS DHS callback port cleanup (commit 2)

Tracks [MARSC-468](https://jira.ecmwf.int/projects/MARSC/issues/MARSC-468). `mars-client-cpp`'s `DHSProtocol` leaks both its callback listener and the accepted `CLOSE_WAIT` data socket on the "Data not found" error path; either is enough to make the next `bind(8100)` fail with `EADDRINUSE`, and the kubernetes NodePort routes inbound DHS callbacks to that fixed targetPort, so we cannot work around it by rotating ports.

`workers/mars-worker/src/port_cleanup.rs` (new) scans `/proc/self/net/tcp[6]` for any TCP socket bound to `MARS_DHS_LOCALPORT` regardless of socket state, then `libc::close()`s the matching fds in `/proc/self/fd`, with a re-`readlink` check just before close to narrow the inode-recycle race window. Wired into `MarsProcessor::process` after `stream.close()` joins the C++ retrieve thread.

Verified live: a deliberate "Data not found" job followed immediately by a successful retrieve now works back-to-back; the cleanup logs `closed=2` (listener + `CLOSE_WAIT` data socket).

### 3. Build hygiene (commit 1)

- `.dockerignore`: exclude `**/target` so the workers/mars-worker cargo build dir (~500 MB) does not bloat the docker build context.
- `frontend/Dockerfile`: drop the cargo-chef stage. The original layered chef recipe + cooked-deps + builder steps add complexity without measurable cache benefit on the kaniko/skaffold path we actually use; a single rust-base + builder stage produces the same image faster.
- `.gitignore`: add `.weave/` (Pi/Weave runtime artefacts, not for upstream).

## Verification

Verify suite against bologna-dev: 37 passed in 23s, covering 15 route-acceptance tests (12 of which use `Polytope-Mock-Roles` for the role-gated paths), 5 deliberate auth-rejection tests (401/403/400 paths), 3 full retrievals, and the auth/EDR/smoke baseline.
