### PR TITLE
feat: add BOBS write routing and stress streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?rev=11b7fd2be9609f20226c226aa3b5ee5bdaeebfb2#11b7fd2be9609f20226c226aa3b5ee5bdaeebfb2"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=d6ceded4324652739f5e6a79c14bf72550e3eecf#d6ceded4324652739f5e6a79c14bf72550e3eecf"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bobs"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bobs.git?branch=main#8744f7924a506b190ecfec08b739933bfd050d1c"
+source = "git+https://github.com/ecmwf/bobs.git?rev=3f0e6895eb5738d384e72260b7a9e38c2c591b3d#3f0e6895eb5738d384e72260b7a9e38c2c591b3d"
 dependencies = [
  "async-stream",
  "axum",
@@ -945,6 +945,7 @@ dependencies = [
  "dashmap",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-util",
  "redb",
  "serde",
  "serde_json",
@@ -952,6 +953,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1185,7 +1187,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1741,7 +1743,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1912,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2822,7 +2824,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3397,7 +3399,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4479,7 +4481,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4572,7 +4574,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5137,7 +5139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5284,10 +5286,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6072,7 +6074,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", branch = "master" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "11b7fd2be9609f20226c226aa3b5ee5bdaeebfb2", features = ["nats"] }
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "d6ceded4324652739f5e6a79c14bf72550e3eecf", features = ["nats"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -5,13 +5,26 @@ pub mod v2;
 use std::convert::Infallible;
 
 use authotron_types::User as AuthUser;
+use axum::Json;
 use axum::extract::FromRequestParts;
-use axum::http::{HeaderMap, request::Parts};
+use axum::http::{HeaderMap, StatusCode, header, request::Parts};
+use axum::response::{IntoResponse, Response};
 use bits::Job;
 use serde_json::{Value, json};
 
 use crate::auth::mock_time::{MOCK_TIME_HEADER, normalise_mocked_now};
 use crate::auth::{MockRolesAudit, MockTime, MockTimeAudit, is_admin_bypass_user};
+
+const OVERLOADED_RETRY_AFTER_SECS: &str = "5";
+
+pub fn overloaded_response(payload: Value) -> Response {
+    (
+        StatusCode::from_u16(529).expect("529 is a valid HTTP status code"),
+        [(header::RETRY_AFTER, OVERLOADED_RETRY_AFTER_SECS)],
+        Json(payload),
+    )
+        .into_response()
+}
 
 /// Flatten a v1-style `{"request": "...yaml..."}` or `{"request": {...}}` wrapper
 /// into a top-level MARS field object. Passes through already-flat requests unchanged.

--- a/frontend/src/api/openmeteo/mod.rs
+++ b/frontend/src/api/openmeteo/mod.rs
@@ -13,7 +13,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use bits::{Job, JobResult, PollOutcome};
+use bits::{Job, JobResult, PollOutcome, SubmitOutcome};
 use bytes::BytesMut;
 use chrono::Utc;
 use futures::TryStreamExt;
@@ -159,7 +159,14 @@ async fn forecast(
             &state.admin_bypass_roles,
         );
         super::set_job_mock_time_metadata(&mut job, mock_time_extensions.mock_time.as_ref());
-        let id = state.bits.submit(job).id;
+        let id = match state.bits.submit(job) {
+            SubmitOutcome::Accepted(handle) => handle.id,
+            SubmitOutcome::Overloaded => {
+                return super::overloaded_response(response::build_error_response(
+                    "broker at capacity",
+                ));
+            }
+        };
         super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
         super::audit_mock_time_job_submission(mock_time_extensions.mock_time_audit.as_ref(), &id);
         submitted.push((group, param_list, id));
@@ -221,6 +228,9 @@ async fn forecast(
                     StatusCode::BAD_GATEWAY,
                     &format!("worker failed: {reason}"),
                 );
+            }
+            PollOutcome::Ready(JobResult::Overloaded { reason }) => {
+                return super::overloaded_response(response::build_error_response(&reason));
             }
             PollOutcome::NotFound => {
                 return error_response(StatusCode::BAD_GATEWAY, &format!("job {id} not found"));

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -178,6 +178,11 @@ pub async fn get_request(State(state): State<Arc<AppState>>, Path(id): Path<Stri
                 Json(json!({"status": "failed", "message": reason})),
             )
                 .into_response(),
+            JobResult::Overloaded { reason } => super::overloaded_response(json!({
+                "status": "failed",
+                "message": reason,
+                "retryable": true,
+            })),
             JobResult::Cancelled => {
                 (StatusCode::OK, Json(json!({"status": "cancelled"}))).into_response()
             }

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -121,6 +121,9 @@ pub async fn submit_collection(
                 Json(json!({"error": reason})),
             )
                 .into_response(),
+            JobResult::Overloaded { reason } => {
+                super::overloaded_response(json!({"error": reason, "retryable": true}))
+            }
             JobResult::ClientGone => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "client disconnected before data could be delivered"})),
@@ -175,6 +178,9 @@ pub async fn poll(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
                 Json(json!({"error": reason})),
             )
                 .into_response(),
+            JobResult::Overloaded { reason } => {
+                super::overloaded_response(json!({"error": reason, "retryable": true}))
+            }
             JobResult::ClientGone => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "client disconnected before data could be delivered"})),

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -121,7 +121,7 @@ fn require_site_env_tag(field: &str, value: Option<&serde_yaml::Value>) -> Resul
         _ => return Err(format!("{field} must be a string or unsigned integer tag")),
     };
 
-    bits::polytope_id::pack_tag(&tag)
+    bits::request_id::pack_tag(&tag)
         .map(|_| tag)
         .map_err(|err| format!("{field}: {err}"))
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -175,7 +175,14 @@ impl polytope_edr::RequestSubmitter for BitsSubmitter {
             let job = bits::Job::new(request);
             let handle = if collection.is_empty() {
                 // Backward compat: no collection specified, use default bits.submit()
-                state.bits.submit(job)
+                match state.bits.submit(job) {
+                    bits::SubmitOutcome::Accepted(handle) => handle,
+                    bits::SubmitOutcome::Overloaded => {
+                        return Err(polytope_edr::SubmitError::Upstream(
+                            "broker at capacity".to_string(),
+                        ));
+                    }
+                }
             } else {
                 let route_handle = state
                     .collections
@@ -213,8 +220,11 @@ bits: {}
             serde_yaml::from_str(yaml).expect("top-level polytope site/env config should parse");
         let (_, state) = build_app(cfg).expect("polytope site/env should be injected into BITS");
 
-        let handle = state.bits.submit(bits::Job::new(serde_json::json!({})));
-        let decoded = bits::polytope_id::decode(&handle.id)
+        let handle = state
+            .bits
+            .submit(bits::Job::new(serde_json::json!({})))
+            .expect_accepted("test broker should accept the request");
+        let decoded = bits::request_id::decode(&handle.id)
             .expect("server-emitted request ID should use the new decodable format");
 
         assert_eq!(decoded.site, "bol");

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 async-trait = "0.1"
 axum = "0.8"
 authotron = { git = "https://github.com/ecmwf/auth-o-tron.git", branch = "main" }
-bobs = { git = "https://github.com/ecmwf/bobs.git", branch = "main" }
+bobs = { git = "https://github.com/ecmwf/bobs.git", rev = "3f0e6895eb5738d384e72260b7a9e38c2c591b3d" }
 bytes = "1"
 futures = "0.3"
 polytope_client = { path = "../../client" }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -193,16 +193,17 @@ pub async fn spawn_bobs() -> Result<(String, JoinHandle<()>, tempfile::TempDir),
         config.max_cache_bytes,
     )?);
 
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
     let state = Arc::new(bobs::http::AppState {
         manager,
         config: config.clone(),
         hostname: "test-bobs-0".to_string(),
         ordinal: "0".to_string(),
+        internal_base_url: format!("http://{addr}/api/v1"),
     });
 
     let app = bobs::http::router::<bobs::io::TokioFileIO>().with_state(state);
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let addr = listener.local_addr()?;
     let handle = tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
@@ -684,7 +685,7 @@ async fn bobs_delivery_pipeline() {
 
     let delivery = polytope_worker_common::delivery_config::DeliveryConfig {
         delivery_type: polytope_worker_common::delivery_config::DeliveryType::Bobs,
-        bobs_url: Some(format!("{bobs_url}/api/v1")),
+        bobs_url: Some(bobs_url.clone()),
         s3_bucket: None,
         s3_region: None,
         s3_endpoint_url: None,

--- a/workers/common/src/delivery/bobs.rs
+++ b/workers/common/src/delivery/bobs.rs
@@ -7,7 +7,8 @@ use crate::Completion;
 
 pub(super) struct BobsPush {
     pub(super) api_base: String,
-    pub(super) client: reqwest::Client,
+    pub(super) create_client: reqwest::Client,
+    pub(super) body_client: reqwest::Client,
 }
 
 #[async_trait]
@@ -52,7 +53,7 @@ impl BobsPush {
             create_body["content_encoding"] = serde_json::json!(enc);
         }
         let create_resp = self
-            .client
+            .create_client
             .put(format!("{}/create", self.api_base))
             .json(&create_body)
             .send()
@@ -64,6 +65,12 @@ impl BobsPush {
         let key = create_json["key"]
             .as_str()
             .ok_or("missing key in response")?
+            .to_string();
+        let write_base = create_json["write_url"]
+            .as_str()
+            .ok_or(
+                "missing write_url in create response: BOBS server does not support write routing",
+            )?
             .to_string();
 
         let mut stream = BodyDataStream::new(body);
@@ -78,8 +85,8 @@ impl BobsPush {
         {
             let chunk_len = chunk.len() as u64;
             let write_resp = self
-                .client
-                .post(format!("{}/write/{}/{}", self.api_base, key, offset))
+                .body_client
+                .post(format!("{}/write/{}/{}", write_base, key, offset))
                 .body(chunk)
                 .send()
                 .await?;
@@ -90,8 +97,8 @@ impl BobsPush {
         }
 
         let complete_resp = self
-            .client
-            .post(format!("{}/complete/{}", self.api_base, key))
+            .body_client
+            .post(format!("{}/complete/{}", write_base, key))
             .send()
             .await?;
         if !complete_resp.status().is_success() {
@@ -101,8 +108,7 @@ impl BobsPush {
         let read_url = create_json["read_url"]
             .as_str()
             .ok_or("missing read_url in response")?
-            .to_string()
-            .replace("/read/", "/");
+            .to_string();
         tracing::info!(key = %key, read_url = %read_url, "result pushed to BOBS");
         Ok(read_url)
     }
@@ -119,8 +125,8 @@ mod tests {
     };
     use std::sync::{Arc, Mutex};
 
-    #[derive(Default)]
     struct BobsState {
+        base_url: String,
         created_keys: Mutex<Vec<String>>,
         written_data: Mutex<Vec<u8>>,
         completed: Mutex<bool>,
@@ -131,10 +137,13 @@ mod tests {
     ) -> (StatusCode, axum::Json<serde_json::Value>) {
         let key = "test-key-123".to_string();
         let read_url = format!("http://public.example.com/download-0/{key}");
+        let write_url = state.base_url.clone();
         state.created_keys.lock().unwrap().push(key.clone());
         (
             StatusCode::CREATED,
-            axum::Json(serde_json::json!({ "key": key, "read_url": read_url })),
+            axum::Json(
+                serde_json::json!({ "key": key, "read_url": read_url, "write_url": write_url }),
+            ),
         )
     }
 
@@ -161,21 +170,32 @@ mod tests {
 
     #[tokio::test]
     async fn bobs_push_delivers_and_returns_redirect() {
-        let state = Arc::new(BobsState::default());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let bobs_url = format!("http://{addr}");
+
+        let state = Arc::new(BobsState {
+            base_url: bobs_url.clone(),
+            created_keys: Mutex::new(vec![]),
+            written_data: Mutex::new(vec![]),
+            completed: Mutex::new(false),
+        });
         let app = Router::new()
             .route("/create", put(mock_create))
             .route("/write/{key}/{offset}", post(mock_write))
             .route("/complete/{key}", post(mock_complete))
             .with_state(state.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let bobs_url = format!("http://{addr}");
+        let h2_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("build h2 client");
         let push = BobsPush {
             api_base: bobs_url.clone(),
-            client: reqwest::Client::new(),
+            create_client: h2_client.clone(),
+            body_client: h2_client,
         };
         let data = b"hello bobs".to_vec();
         let result = push
@@ -201,8 +221,8 @@ mod tests {
         assert_eq!(*state.written_data.lock().unwrap(), data);
     }
 
-    #[derive(Default)]
     struct StreamingBobsState {
+        base_url: String,
         created_keys: Mutex<Vec<String>>,
         writes: Mutex<Vec<(u64, Vec<u8>)>>,
         completed: Mutex<bool>,
@@ -213,10 +233,13 @@ mod tests {
     ) -> (StatusCode, axum::Json<serde_json::Value>) {
         let key = "stream-key".to_string();
         let read_url = format!("http://public.example.com/download-0/{key}");
+        let write_url = state.base_url.clone();
         state.created_keys.lock().unwrap().push(key.clone());
         (
             StatusCode::CREATED,
-            axum::Json(serde_json::json!({ "key": key, "read_url": read_url })),
+            axum::Json(
+                serde_json::json!({ "key": key, "read_url": read_url, "write_url": write_url }),
+            ),
         )
     }
 
@@ -243,21 +266,32 @@ mod tests {
 
     #[tokio::test]
     async fn bobs_push_streams_chunks_at_correct_offsets() {
-        let state = Arc::new(StreamingBobsState::default());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let bobs_url = format!("http://{addr}");
+
+        let state = Arc::new(StreamingBobsState {
+            base_url: bobs_url.clone(),
+            created_keys: Mutex::new(vec![]),
+            writes: Mutex::new(vec![]),
+            completed: Mutex::new(false),
+        });
         let app = Router::new()
             .route("/create", put(streaming_create))
             .route("/write/{key}/{offset}", post(streaming_write))
             .route("/complete/{key}", post(streaming_complete))
             .with_state(state.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        let bobs_url = format!("http://{addr}");
+        let h2_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("build h2 client");
         let push = BobsPush {
             api_base: bobs_url.clone(),
-            client: reqwest::Client::new(),
+            create_client: h2_client.clone(),
+            body_client: h2_client,
         };
 
         // Build a body from a multi-chunk stream (3 bytes, then 4 bytes).
@@ -294,9 +328,14 @@ mod tests {
 
     #[tokio::test]
     async fn bobs_push_returns_error_when_unreachable() {
+        let h2_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("build h2 client");
         let push = BobsPush {
             api_base: "http://127.0.0.1:1".to_string(),
-            client: reqwest::Client::new(),
+            create_client: h2_client.clone(),
+            body_client: h2_client,
         };
         let result = push
             .deliver(
@@ -310,6 +349,54 @@ mod tests {
         match result {
             Completion::Error { message } => {
                 assert!(message.starts_with("delivery failed:"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bobs_push_errors_on_missing_write_url() {
+        // Mock create handler that omits write_url.
+        async fn create_no_write_url() -> (StatusCode, axum::Json<serde_json::Value>) {
+            (
+                StatusCode::CREATED,
+                axum::Json(serde_json::json!({
+                    "key": "k",
+                    "read_url": "http://x/k",
+                })),
+            )
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new().route("/create", put(create_no_write_url));
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let h2_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("build h2 client");
+        let push = BobsPush {
+            api_base: format!("http://{addr}"),
+            create_client: h2_client.clone(),
+            body_client: h2_client,
+        };
+        let result = push
+            .deliver(
+                "application/octet-stream",
+                None,
+                reqwest::Body::from(vec![]),
+                &serde_json::json!({}),
+            )
+            .await;
+
+        match result {
+            Completion::Error { message } => {
+                assert!(
+                    message.contains("missing write_url"),
+                    "expected 'missing write_url' in error message, got: {message}"
+                );
             }
             other => panic!("expected Error, got {other:?}"),
         }

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -21,10 +21,7 @@ pub trait ResultDelivery: Send + Sync {
     ) -> Completion;
 }
 
-pub async fn make_delivery(
-    config: &DeliveryConfig,
-    client: reqwest::Client,
-) -> Box<dyn ResultDelivery> {
+pub async fn make_delivery(config: &DeliveryConfig) -> Box<dyn ResultDelivery> {
     match config.delivery_type {
         DeliveryType::Direct => Box::new(DirectDelivery),
         DeliveryType::Bobs => {
@@ -35,7 +32,20 @@ pub async fn make_delivery(
                 .trim_start_matches("http://")
                 .trim_start_matches("https://");
             let api_base = format!("http://{host}/api/v1");
-            Box::new(BobsPush { api_base, client })
+            let create_client = reqwest::Client::builder()
+                .http2_prior_knowledge()
+                .pool_max_idle_per_host(0)
+                .build()
+                .expect("build BOBS create_client");
+            let body_client = reqwest::Client::builder()
+                .http2_prior_knowledge()
+                .build()
+                .expect("build BOBS body_client");
+            Box::new(BobsPush {
+                api_base,
+                create_client,
+                body_client,
+            })
         }
         DeliveryType::S3 => {
             let shared_config = aws_config::load_defaults(BehaviorVersion::latest()).await;

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -209,7 +209,7 @@ pub async fn run_worker_loop<P: Processor>(
     });
 
     let client = reqwest::Client::builder().build()?;
-    let delivery: Box<dyn ResultDelivery> = make_delivery(&delivery_config, client.clone()).await;
+    let delivery: Box<dyn ResultDelivery> = make_delivery(&delivery_config).await;
     let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
     let mut shutting_down = false;
 
@@ -434,8 +434,8 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
     struct BobsState {
+        write_base_url: String,
         calls: Mutex<Vec<String>>,
         writes: Mutex<Vec<Vec<u8>>>,
     }
@@ -520,9 +520,11 @@ mod tests {
         state.calls.lock().unwrap().push("create".to_string());
         (
             StatusCode::CREATED,
-            axum::Json(
-                serde_json::json!({ "key": "redirect-key", "read_url": "https://polytope.example.com/download-0/redirect-key" }),
-            ),
+            axum::Json(serde_json::json!({
+                "key": "redirect-key",
+                "read_url": "https://polytope.example.com/download-0/redirect-key",
+                "write_url": state.write_base_url.clone(),
+            })),
         )
     }
 
@@ -649,16 +651,25 @@ mod tests {
 
     #[tokio::test]
     async fn worker_with_bobs_delivery_posts_redirect_completion() {
-        let bobs_state = Arc::new(BobsState::default());
-        let bobs_app = Router::new()
-            .route("/create", put(bobs_create))
-            .route("/write/{key}/{offset}", post(bobs_write))
-            .route("/complete/{key}", post(bobs_complete))
-            .with_state(bobs_state.clone());
         let bobs_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bobs_addr = bobs_listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(bobs_listener, bobs_app).await.unwrap() });
         let bobs_url = format!("http://{bobs_addr}");
+        // make_delivery strips the scheme and appends "/api/v1", so the worker's
+        // api_base (for /create) and write_base (for /write and /complete) are
+        // both rooted at "{bobs_url}/api/v1".  Mirror that in the mock.
+        let bobs_api_base = format!("{bobs_url}/api/v1");
+
+        let bobs_state = Arc::new(BobsState {
+            write_base_url: bobs_api_base.clone(),
+            calls: Mutex::new(vec![]),
+            writes: Mutex::new(vec![]),
+        });
+        let bobs_app = Router::new()
+            .route("/api/v1/create", put(bobs_create))
+            .route("/api/v1/write/{key}/{offset}", post(bobs_write))
+            .route("/api/v1/complete/{key}", post(bobs_complete))
+            .with_state(bobs_state.clone());
+        tokio::spawn(async move { axum::serve(bobs_listener, bobs_app).await.unwrap() });
 
         let broker_state = Arc::new(BrokerState::default());
         let broker_app = Router::new()

--- a/workers/test-worker/src/lib.rs
+++ b/workers/test-worker/src/lib.rs
@@ -2,6 +2,13 @@ use async_trait::async_trait;
 use polytope_worker_common::{ProcessResult, Processor, WorkItem};
 use serde::Deserialize;
 
+const DEFAULT_STRESS_DELAY_MS: u64 = 0;
+const DEFAULT_STRESS_RESPONSE_BYTES: usize = 1024;
+const DEFAULT_STRESS_CHUNK_BYTES: usize = 1024 * 1024;
+const DEFAULT_STRESS_MAX_DELAY_MS: u64 = 10_000;
+const DEFAULT_STRESS_MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+const DEFAULT_STRESS_MAX_CHUNK_BYTES: usize = 16 * 1024 * 1024;
+
 #[derive(Debug, Deserialize)]
 pub struct TestConfig {
     pub behaviour: Behaviour,
@@ -26,10 +33,48 @@ pub enum Behaviour {
         #[serde(default = "default_dummy_count")]
         count: u64,
     },
+    Stress {
+        #[serde(default = "default_stress_delay_ms")]
+        default_delay_ms: u64,
+        #[serde(default = "default_stress_response_bytes")]
+        default_response_bytes: usize,
+        #[serde(default = "default_stress_chunk_bytes")]
+        default_chunk_bytes: usize,
+        #[serde(default = "default_stress_max_delay_ms")]
+        max_delay_ms: u64,
+        #[serde(default = "default_stress_max_response_bytes")]
+        max_response_bytes: usize,
+        #[serde(default = "default_stress_max_chunk_bytes")]
+        max_chunk_bytes: usize,
+    },
 }
 
 pub fn default_dummy_count() -> u64 {
     10
+}
+
+pub fn default_stress_delay_ms() -> u64 {
+    DEFAULT_STRESS_DELAY_MS
+}
+
+pub fn default_stress_response_bytes() -> usize {
+    DEFAULT_STRESS_RESPONSE_BYTES
+}
+
+pub fn default_stress_chunk_bytes() -> usize {
+    DEFAULT_STRESS_CHUNK_BYTES
+}
+
+pub fn default_stress_max_delay_ms() -> u64 {
+    DEFAULT_STRESS_MAX_DELAY_MS
+}
+
+pub fn default_stress_max_response_bytes() -> usize {
+    DEFAULT_STRESS_MAX_RESPONSE_BYTES
+}
+
+pub fn default_stress_max_chunk_bytes() -> usize {
+    DEFAULT_STRESS_MAX_CHUNK_BYTES
 }
 
 pub struct BehaviourProcessor {
@@ -46,6 +91,37 @@ pub fn json_success(content_type: &str, payload: Vec<u8>) -> ProcessResult {
     let body = bytes::Bytes::from(payload);
     let stream = futures::stream::once(futures::future::ready(Ok::<_, std::io::Error>(body)));
     ProcessResult::success(content_type, Box::new(stream))
+}
+
+fn nested_stress_config(request: &serde_json::Value) -> Option<&serde_json::Value> {
+    request
+        .get("stress")
+        .or_else(|| request.get("request").and_then(|inner| inner.get("stress")))
+}
+
+fn stress_u64(request: &serde_json::Value, key: &str) -> Option<u64> {
+    nested_stress_config(request)?.get(key)?.as_u64()
+}
+
+fn stress_usize(request: &serde_json::Value, key: &str) -> Option<usize> {
+    stress_u64(request, key).and_then(|value| usize::try_from(value).ok())
+}
+
+/// Build a lazily-evaluated stream of byte chunks totalling `total` bytes.
+///
+/// Byte values follow the pattern `b'a' + (global_position % 26)`, keeping
+/// the per-byte content deterministic regardless of chunk size. The last chunk
+/// may be smaller than `chunk` bytes when `total` is not evenly divisible.
+fn stress_stream(
+    total: usize,
+    chunk: usize,
+) -> impl futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + Unpin + 'static {
+    let chunks = (0..total).step_by(chunk).map(move |start| {
+        let end = (start + chunk).min(total);
+        let buf: Vec<u8> = (start..end).map(|i| b'a' + ((i % 26) as u8)).collect();
+        Ok(bytes::Bytes::from(buf))
+    });
+    Box::pin(futures::stream::iter(chunks))
 }
 
 #[async_trait]
@@ -70,6 +146,33 @@ impl Processor for BehaviourProcessor {
                 let data: Vec<u64> = (1..=*count).collect();
                 let payload = serde_json::to_vec(&data).unwrap_or_default();
                 json_success(&self.config.content_type, payload)
+            }
+
+            Behaviour::Stress {
+                default_delay_ms,
+                default_response_bytes,
+                default_chunk_bytes,
+                max_delay_ms,
+                max_response_bytes,
+                max_chunk_bytes,
+            } => {
+                let delay_ms = stress_u64(&work.request, "delay_ms")
+                    .unwrap_or(*default_delay_ms)
+                    .min(*max_delay_ms);
+                let response_bytes = stress_usize(&work.request, "response_bytes")
+                    .unwrap_or(*default_response_bytes)
+                    .min(*max_response_bytes);
+                let chunk_bytes = stress_usize(&work.request, "chunk_bytes")
+                    .unwrap_or(*default_chunk_bytes)
+                    .min(*max_chunk_bytes)
+                    .max(1);
+
+                if delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+
+                let stream = stress_stream(response_bytes, chunk_bytes);
+                ProcessResult::success(&self.config.content_type, Box::new(stream))
             }
         }
     }

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
-use polytope_worker_common::{ProcessResult, WorkItem, WorkerConfig, run_worker_loop};
+use polytope_worker_common::{WorkerConfig, run_worker_loop};
 use test_worker::*;
 use tracing::info;
 
@@ -59,12 +59,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::*;
     use futures::TryStreamExt;
-    use polytope_worker_common::Processor;
+    use polytope_worker_common::{ProcessResult, Processor, WorkItem};
 
     fn dummy_work() -> WorkItem {
         WorkItem {
             job_id: "test-1".into(),
             request: serde_json::json!({"collection": "era5", "level": 500}),
+            user: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn stress_work(delay_ms: u64, response_bytes: u64) -> WorkItem {
+        WorkItem {
+            job_id: "stress-1".into(),
+            request: serde_json::json!({
+                "stress": {
+                    "delay_ms": delay_ms,
+                    "response_bytes": response_bytes,
+                }
+            }),
+            user: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn stress_work_with_chunk(delay_ms: u64, response_bytes: u64, chunk_bytes: u64) -> WorkItem {
+        WorkItem {
+            job_id: "stress-1".into(),
+            request: serde_json::json!({
+                "stress": {
+                    "delay_ms": delay_ms,
+                    "response_bytes": response_bytes,
+                    "chunk_bytes": chunk_bytes,
+                }
+            }),
             user: serde_json::json!({}),
             metadata: serde_json::json!({}),
         }
@@ -79,6 +108,7 @@ mod tests {
         }
     }
 
+    /// Collect all stream chunks into a single flat byte vec.
     async fn collect_success_body(result: ProcessResult) -> (String, Vec<u8>) {
         match result {
             ProcessResult::Success { content_type, body } => {
@@ -90,6 +120,18 @@ mod tests {
                     .await
                     .unwrap();
                 (content_type, bytes)
+            }
+            other => panic!("expected Success, got {:?}", variant_name(&other)),
+        }
+    }
+
+    /// Collect all stream chunks, preserving individual chunk boundaries.
+    async fn collect_success_chunks(result: ProcessResult) -> (String, Vec<Vec<u8>>) {
+        match result {
+            ProcessResult::Success { content_type, body } => {
+                let chunks = body.try_collect::<Vec<_>>().await.unwrap();
+                let chunks: Vec<Vec<u8>> = chunks.into_iter().map(|b| b.to_vec()).collect();
+                (content_type, chunks)
             }
             other => panic!("expected Success, got {:?}", variant_name(&other)),
         }
@@ -164,6 +206,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stress_uses_request_delay_and_response_size() {
+        let start = std::time::Instant::now();
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 10,
+            default_chunk_bytes: default_stress_chunk_bytes(),
+            max_delay_ms: 1000,
+            max_response_bytes: 1000,
+            max_chunk_bytes: default_stress_max_chunk_bytes(),
+        })
+        .process(stress_work(50, 123))
+        .await;
+        let elapsed = start.elapsed();
+        assert!(elapsed.as_millis() >= 40);
+        let (content_type, body) = collect_success_body(result).await;
+        assert_eq!(content_type, "application/json");
+        assert_eq!(body.len(), 123);
+        assert_eq!(&body[..4], b"abcd");
+    }
+
+    #[tokio::test]
+    async fn stress_caps_request_values() {
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 10,
+            default_chunk_bytes: default_stress_chunk_bytes(),
+            max_delay_ms: 0,
+            max_response_bytes: 32,
+            max_chunk_bytes: default_stress_max_chunk_bytes(),
+        })
+        .process(stress_work(500, 500))
+        .await;
+        let (_, body) = collect_success_body(result).await;
+        assert_eq!(body.len(), 32);
+    }
+
+    #[tokio::test]
+    async fn stress_defaults_when_request_has_no_stress_block() {
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 17,
+            default_chunk_bytes: default_stress_chunk_bytes(),
+            max_delay_ms: 0,
+            max_response_bytes: 100,
+            max_chunk_bytes: default_stress_max_chunk_bytes(),
+        })
+        .process(dummy_work())
+        .await;
+        let (_, body) = collect_success_body(result).await;
+        assert_eq!(body.len(), 17);
+    }
+
+    #[tokio::test]
     async fn config_content_type_is_honoured() {
         let p = BehaviourProcessor {
             config: TestConfig {
@@ -174,5 +269,93 @@ mod tests {
         let result = p.process(dummy_work()).await;
         let (content_type, _) = collect_success_body(result).await;
         assert_eq!(content_type, "application/octet-stream");
+    }
+
+    // --- chunk-streaming tests ---
+
+    #[tokio::test]
+    async fn stress_emits_multiple_chunks_when_chunk_bytes_smaller_than_response() {
+        // 1000 bytes total, 256 bytes per chunk → ceil(1000/256) = 4 chunks
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 1000,
+            default_chunk_bytes: default_stress_chunk_bytes(),
+            max_delay_ms: 0,
+            max_response_bytes: 10_000,
+            max_chunk_bytes: default_stress_max_chunk_bytes(),
+        })
+        .process(stress_work_with_chunk(0, 1000, 256))
+        .await;
+
+        let (content_type, chunks) = collect_success_chunks(result).await;
+        assert_eq!(content_type, "application/json");
+        assert!(
+            chunks.len() >= 4,
+            "expected ≥ 4 chunks, got {}",
+            chunks.len()
+        );
+
+        // Reassemble and verify total length and byte pattern.
+        let body: Vec<u8> = chunks.into_iter().flatten().collect();
+        assert_eq!(body.len(), 1000);
+        assert_eq!(&body[..4], b"abcd");
+    }
+
+    #[tokio::test]
+    async fn stress_chunk_bytes_capped_by_max() {
+        // default_chunk_bytes=1024, max_chunk_bytes=512
+        // request asks for chunk_bytes=10000 → capped to 512
+        // response_bytes=2048, chunk_bytes effective=512 → exactly 4 chunks of 512
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 2048,
+            default_chunk_bytes: 1024,
+            max_delay_ms: 0,
+            max_response_bytes: 10_000,
+            max_chunk_bytes: 512,
+        })
+        .process(stress_work_with_chunk(0, 2048, 10_000))
+        .await;
+
+        let (_, chunks) = collect_success_chunks(result).await;
+        assert_eq!(chunks.len(), 4, "expected 4 chunks, got {}", chunks.len());
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(
+                chunk.len(),
+                512,
+                "chunk {} has wrong length: {}",
+                i,
+                chunk.len()
+            );
+        }
+
+        let body: Vec<u8> = chunks.into_iter().flatten().collect();
+        assert_eq!(body.len(), 2048);
+    }
+
+    #[tokio::test]
+    async fn stress_defaults_chunk_bytes_when_request_omits_it() {
+        // default_chunk_bytes=256; response_bytes=1000, no chunk_bytes in request
+        // → uses default 256, so ≥ 4 chunks
+        let result = processor(Behaviour::Stress {
+            default_delay_ms: 0,
+            default_response_bytes: 1000,
+            default_chunk_bytes: 256,
+            max_delay_ms: 0,
+            max_response_bytes: 10_000,
+            max_chunk_bytes: default_stress_max_chunk_bytes(),
+        })
+        .process(stress_work(0, 1000))
+        .await;
+
+        let (_, chunks) = collect_success_chunks(result).await;
+        assert!(
+            chunks.len() >= 4,
+            "expected ≥ 4 chunks with default chunk_bytes=256, got {}",
+            chunks.len()
+        );
+
+        let body: Vec<u8> = chunks.into_iter().flatten().collect();
+        assert_eq!(body.len(), 1000);
     }
 }


### PR DESCRIPTION
## Summary
- update frontend to current BITS request-id/overload API and return retryable 529 responses on broker overload
- update worker BOBS delivery to use `write_url` returned by `/create`
- split BOBS create/body clients so `/create` gets fresh kube load-balancing while write/complete reuse HTTP/2 connections
- use h2c HTTP/2 prior knowledge for worker-to-BOBS body delivery
- return BOBS `read_url` unchanged, so public result URLs remain opaque `/download-N/{key}` links
- pin the integration-test BOBS dependency to the merged BOBS commit that includes write routing and opaque public URLs
- add request-driven `test-worker` stress behaviour with lazy chunked output
- update worker/integration tests for routed BOBS writes

Depends on merged BOBS support in ecmwf/bobs#2 and ecmwf/bobs#3, plus chart routing in ecmwf/polytope-chart#40.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p polytope-worker-common bobs -- --nocapture`
- `cargo test -p polytope-server-integration-tests -- --nocapture` → 27 passed
- `cargo test -p polytope-server-integration-tests bobs_delivery_pipeline -- --nocapture`
- rust-analyzer diagnostics for `tests/integration/src/lib.rs`: none
- built and pushed dev images during live validation: `test-worker:majh-dev`, `mars-worker:majh-dev`, `fdb-worker:majh-dev`, `polytope-fe-worker:majh-dev`
- live tier-2 stress suite passed against bologna-dev
- live BOBS full-range benchmark passed against the earlier `/api/v1` public URL shape: 256/256 full-range downloads, 4 GiB produced/read, 211 MiB/s
