### PR TITLE
BOBS write routing, streaming POST, and per-pod worker concurrency

### DIFF
--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -222,6 +222,7 @@ pub async fn spawn_test_worker(
         heartbeat_interval: std::time::Duration::from_secs(30),
         retry_backoff: std::time::Duration::from_millis(100),
         management_port: 0,
+        worker_concurrency: 1,
     };
 
     let processor = test_worker::BehaviourProcessor::new(test_worker::TestConfig {

--- a/workers/common/src/delivery/bobs.rs
+++ b/workers/common/src/delivery/bobs.rs
@@ -1,6 +1,4 @@
 use async_trait::async_trait;
-use futures::TryStreamExt;
-use http_body_util::BodyDataStream;
 
 use super::ResultDelivery;
 use crate::Completion;
@@ -73,27 +71,17 @@ impl BobsPush {
             )?
             .to_string();
 
-        let mut stream = BodyDataStream::new(body);
-        let mut offset: u64 = 0;
-        while let Some(chunk) =
-            stream
-                .try_next()
-                .await
-                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-                    format!("body stream error: {e}").into()
-                })?
-        {
-            let chunk_len = chunk.len() as u64;
-            let write_resp = self
-                .body_client
-                .post(format!("{}/write/{}/{}", write_base, key, offset))
-                .body(chunk)
-                .send()
-                .await?;
-            if !write_resp.status().is_success() {
-                return Err(format!("write failed: {}", write_resp.status()).into());
-            }
-            offset += chunk_len;
+        // Stream the entire response body to BOBS as a single chunked HTTP/2
+        // request at offset 0. BOBS appends page-by-page as the body arrives;
+        // the worker no longer pays one round-trip per producer chunk.
+        let write_resp = self
+            .body_client
+            .post(format!("{}/write/{}/0", write_base, key))
+            .body(body)
+            .send()
+            .await?;
+        if !write_resp.status().is_success() {
+            return Err(format!("write failed: {}", write_resp.status()).into());
         }
 
         let complete_resp = self
@@ -265,7 +253,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bobs_push_streams_chunks_at_correct_offsets() {
+    async fn bobs_push_streams_whole_body_as_one_request() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let bobs_url = format!("http://{addr}");
@@ -294,7 +282,9 @@ mod tests {
             body_client: h2_client,
         };
 
-        // Build a body from a multi-chunk stream (3 bytes, then 4 bytes).
+        // Build a body from a multi-chunk producer stream. The delivery layer
+        // must coalesce these into one streamed HTTP request to BOBS, not
+        // emit one POST per producer chunk.
         let stream = futures::stream::iter(vec![
             Ok::<bytes::Bytes, std::io::Error>(bytes::Bytes::from_static(b"abc")),
             Ok(bytes::Bytes::from_static(b"defg")),
@@ -319,11 +309,13 @@ mod tests {
         assert!(*state.completed.lock().unwrap());
 
         let writes = state.writes.lock().unwrap();
-        assert_eq!(writes.len(), 2, "expected 2 streamed writes");
-        assert_eq!(writes[0].0, 0, "first chunk should be at offset 0");
-        assert_eq!(writes[0].1, b"abc");
-        assert_eq!(writes[1].0, 3, "second chunk should be at offset 3");
-        assert_eq!(writes[1].1, b"defg");
+        assert_eq!(
+            writes.len(),
+            1,
+            "expected exactly one streamed write covering the whole body"
+        );
+        assert_eq!(writes[0].0, 0, "write must start at offset 0");
+        assert_eq!(writes[0].1, b"abcdefg");
     }
 
     #[tokio::test]

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -134,6 +134,8 @@ pub struct WorkerConfig {
     pub heartbeat_interval: Duration,
     pub retry_backoff: Duration,
     pub management_port: u16,
+    /// Number of independent in-flight jobs processed by this worker pod. Must be at least 1.
+    pub worker_concurrency: usize,
 }
 
 impl WorkerConfig {
@@ -186,49 +188,24 @@ pub trait Processor: Send + Sync {
     async fn process(&self, work: WorkItem) -> ProcessResult;
 }
 
-pub async fn run_worker_loop<P: Processor>(
+async fn worker_task<P: Processor + 'static>(
     config: WorkerConfig,
-    delivery_config: DeliveryConfig,
-    processor: P,
+    client: reqwest::Client,
+    delivery: std::sync::Arc<dyn ResultDelivery>,
+    processor: std::sync::Arc<P>,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> Result<(), reqwest::Error> {
-    let management_app = management::router();
-    let management_listener = tokio::net::TcpListener::bind(("0.0.0.0", config.management_port))
-        .await
-        .unwrap_or_else(|err| {
-            panic!(
-                "failed to bind management server on port {}: {err}",
-                config.management_port
-            )
-        });
-    let management_port = management_listener.local_addr().unwrap().port();
-    tracing::info!(port = management_port, "management server listening");
-    tokio::spawn(async move {
-        axum::serve(management_listener, management_app)
-            .await
-            .unwrap();
-    });
-
-    let client = reqwest::Client::builder().build()?;
-    let delivery: Box<dyn ResultDelivery> = make_delivery(&delivery_config).await;
-    let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
-    let mut shutting_down = false;
-
     loop {
-        if shutting_down {
-            tracing::info!("graceful shutdown complete");
+        if *shutdown.borrow() {
             break;
         }
 
         let response = tokio::select! {
             biased;
-            _ = sigterm.recv() => {
-                tracing::info!("received shutdown signal, completing in-flight work then exiting");
-                shutting_down = true;
-                continue;
-            }
-            _ = tokio::signal::ctrl_c() => {
-                tracing::info!("received shutdown signal, completing in-flight work then exiting");
-                shutting_down = true;
+            changed = shutdown.changed() => {
+                if changed.is_ok() && *shutdown.borrow() {
+                    break;
+                }
                 continue;
             }
             result = client.get(config.work_url()).send() => {
@@ -363,6 +340,84 @@ pub async fn run_worker_loop<P: Processor>(
     Ok(())
 }
 
+pub async fn run_worker_loop<P: Processor + 'static>(
+    config: WorkerConfig,
+    delivery_config: DeliveryConfig,
+    processor: P,
+) -> Result<(), reqwest::Error> {
+    assert!(
+        config.worker_concurrency >= 1,
+        "worker_concurrency must be at least 1"
+    );
+
+    let management_app = management::router();
+    let management_listener = tokio::net::TcpListener::bind(("0.0.0.0", config.management_port))
+        .await
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed to bind management server on port {}: {err}",
+                config.management_port
+            )
+        });
+    let management_port = management_listener.local_addr().unwrap().port();
+    tracing::info!(port = management_port, "management server listening");
+    tokio::spawn(async move {
+        axum::serve(management_listener, management_app)
+            .await
+            .unwrap();
+    });
+
+    let client = reqwest::Client::builder().build()?;
+    let delivery: std::sync::Arc<dyn ResultDelivery> =
+        std::sync::Arc::from(make_delivery(&delivery_config).await);
+    let processor = std::sync::Arc::new(processor);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    let mut tasks = Vec::with_capacity(config.worker_concurrency);
+    for worker_index in 0..config.worker_concurrency {
+        let task_config = config.clone();
+        let task_client = client.clone();
+        let task_delivery = delivery.clone();
+        let task_processor = processor.clone();
+        let task_shutdown = shutdown_rx.clone();
+        tasks.push(tokio::spawn(async move {
+            tracing::debug!(worker_index, "worker task started");
+            let result = worker_task(
+                task_config,
+                task_client,
+                task_delivery,
+                task_processor,
+                task_shutdown,
+            )
+            .await;
+            tracing::debug!(worker_index, "worker task stopped");
+            result
+        }));
+    }
+
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+    tokio::select! {
+        _ = sigterm.recv() => {
+            tracing::info!("received shutdown signal, completing in-flight work then exiting");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("received shutdown signal, completing in-flight work then exiting");
+        }
+    }
+
+    let _ = shutdown_tx.send(true);
+    for task in tasks {
+        match task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => return Err(err),
+            Err(err) => panic!("worker task failed: {err}"),
+        }
+    }
+    tracing::info!("graceful shutdown complete");
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -374,7 +429,10 @@ mod tests {
         routing::{get, post, put},
     };
     use futures::TryStreamExt;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[derive(Default)]
     struct MockState {
@@ -617,6 +675,7 @@ mod tests {
             heartbeat_interval: Duration::from_millis(5),
             retry_backoff: Duration::from_millis(5),
             management_port: 0,
+            worker_concurrency: 1,
         };
 
         let run = tokio::spawn(run_worker_loop(
@@ -695,6 +754,7 @@ mod tests {
             heartbeat_interval: Duration::from_millis(5),
             retry_backoff: Duration::from_millis(5),
             management_port: 0,
+            worker_concurrency: 1,
         };
 
         let run = tokio::spawn(run_worker_loop(
@@ -771,6 +831,7 @@ mod tests {
             heartbeat_interval: Duration::from_millis(5),
             retry_backoff: Duration::from_millis(5),
             management_port: 0,
+            worker_concurrency: 1,
         };
 
         *broker_state.work_metadata.lock().unwrap() =
@@ -834,6 +895,7 @@ mod tests {
             heartbeat_interval: Duration::from_millis(5),
             retry_backoff: Duration::from_millis(5),
             management_port: 0,
+            worker_concurrency: 1,
         };
 
         let run = tokio::spawn(run_worker_loop(
@@ -894,6 +956,7 @@ mod tests {
             heartbeat_interval: Duration::from_millis(5),
             retry_backoff: Duration::from_millis(5),
             management_port: 0,
+            worker_concurrency: 1,
         };
 
         let run = tokio::spawn(run_worker_loop(
@@ -926,5 +989,173 @@ mod tests {
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].0, "error");
         assert!(!completions.iter().any(|(kind, _)| kind == "data"));
+    }
+
+    struct ConcurrentBrokerState {
+        polls: AtomicUsize,
+        completions: Mutex<Vec<String>>,
+    }
+
+    async fn concurrent_work(
+        State(state): State<Arc<ConcurrentBrokerState>>,
+    ) -> Result<axum::Json<WorkItem>, StatusCode> {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let poll = state.polls.fetch_add(1, Ordering::SeqCst);
+        if poll < 2 {
+            Ok(axum::Json(WorkItem {
+                job_id: format!("job-{}", poll + 1),
+                request: serde_json::json!({"index": poll}),
+                user: serde_json::json!({}),
+                metadata: serde_json::json!({}),
+            }))
+        } else {
+            Err(StatusCode::NO_CONTENT)
+        }
+    }
+
+    async fn concurrent_complete(
+        Path(job_id): Path<String>,
+        State(state): State<Arc<ConcurrentBrokerState>>,
+    ) -> StatusCode {
+        state.completions.lock().unwrap().push(job_id);
+        StatusCode::OK
+    }
+
+    struct ConcurrentProcessor {
+        concurrent_in_process: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        reached_two: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Processor for ConcurrentProcessor {
+        async fn process(&self, _work: WorkItem) -> ProcessResult {
+            let current = self.concurrent_in_process.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(current, Ordering::SeqCst);
+            if current >= 2 {
+                self.reached_two.notify_waiters();
+            }
+
+            self.release.notified().await;
+            self.concurrent_in_process.fetch_sub(1, Ordering::SeqCst);
+
+            let stream =
+                futures::stream::once(futures::future::ready(Ok::<bytes::Bytes, std::io::Error>(
+                    bytes::Bytes::from_static(b"ok"),
+                )));
+            ProcessResult::success("application/octet-stream", Box::new(stream))
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_loop_processes_jobs_concurrently_when_worker_concurrency_is_two() {
+        let state = Arc::new(ConcurrentBrokerState {
+            polls: AtomicUsize::new(0),
+            completions: Mutex::new(Vec::new()),
+        });
+        let app = Router::new()
+            .route("/work", get(concurrent_work))
+            .route("/heartbeat/{job_id}", post(heartbeat))
+            .route("/complete/data/{job_id}", post(concurrent_complete))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let concurrent_in_process = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let reached_two = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+
+        let config = WorkerConfig {
+            broker_url: format!("http://{addr}"),
+            poll_timeout_ms: 10,
+            heartbeat_interval: Duration::from_millis(5),
+            retry_backoff: Duration::from_millis(5),
+            management_port: 0,
+            worker_concurrency: 2,
+        };
+
+        let run = tokio::spawn(run_worker_loop(
+            config,
+            delivery_config::DeliveryConfig {
+                delivery_type: delivery_config::DeliveryType::Direct,
+                bobs_url: None,
+                s3_bucket: None,
+                s3_region: None,
+                s3_endpoint_url: None,
+                s3_force_path_style: None,
+                s3_access_key_id: None,
+                s3_secret_access_key: None,
+                s3_presigned_url_expiry_secs: None,
+                s3_public_url: None,
+                s3_key_prefix: String::new(),
+            },
+            ConcurrentProcessor {
+                concurrent_in_process,
+                peak: peak.clone(),
+                reached_two: reached_two.clone(),
+                release: release.clone(),
+            },
+        ));
+
+        tokio::time::timeout(Duration::from_secs(2), reached_two.notified())
+            .await
+            .unwrap();
+        release.notify_waiters();
+
+        for _ in 0..40 {
+            if state.completions.lock().unwrap().len() == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        run.abort();
+
+        assert!(peak.load(Ordering::SeqCst) >= 2);
+        let mut completions = state.completions.lock().unwrap().clone();
+        completions.sort();
+        assert_eq!(completions, vec!["job-1".to_string(), "job-2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn worker_loop_validates_nonzero_worker_concurrency() {
+        let config = WorkerConfig {
+            broker_url: "http://127.0.0.1:1".to_string(),
+            poll_timeout_ms: 10,
+            heartbeat_interval: Duration::from_millis(5),
+            retry_backoff: Duration::from_millis(5),
+            management_port: 0,
+            worker_concurrency: 0,
+        };
+
+        let run = tokio::spawn(run_worker_loop(
+            config,
+            delivery_config::DeliveryConfig {
+                delivery_type: delivery_config::DeliveryType::Direct,
+                bobs_url: None,
+                s3_bucket: None,
+                s3_region: None,
+                s3_endpoint_url: None,
+                s3_force_path_style: None,
+                s3_access_key_id: None,
+                s3_secret_access_key: None,
+                s3_presigned_url_expiry_secs: None,
+                s3_public_url: None,
+                s3_key_prefix: String::new(),
+            },
+            StubProcessor,
+        ));
+
+        let err = run.await.unwrap_err();
+        assert!(err.is_panic());
+        let message = if let Some(message) = err.try_into_panic().unwrap().downcast_ref::<&str>() {
+            (*message).to_string()
+        } else {
+            "".to_string()
+        };
+        assert!(message.contains("worker_concurrency"));
     }
 }

--- a/workers/fdb-worker/src/main.rs
+++ b/workers/fdb-worker/src/main.rs
@@ -5,7 +5,7 @@ use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, run_worker_loop};
 use rsfdb::{FDB, request::Request};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::info;
+use tracing::{info, warn};
 
 struct FdbProcessor {
     fdb_config: String,
@@ -75,6 +75,25 @@ struct Cli {
     heartbeat_secs: f64,
     #[arg(long, default_value = DEFAULT_CONFIG_PATH)]
     config_path: String,
+    #[arg(long, default_value_t = 1)]
+    worker_concurrency: usize,
+}
+
+fn resolved_worker_concurrency(cli_value: usize) -> usize {
+    match std::env::var("POLYTOPE_WORKER_CONCURRENCY") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(parsed) if parsed >= 1 => parsed,
+            _ => {
+                warn!(value = %value, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+                cli_value
+            }
+        },
+        Err(std::env::VarError::NotPresent) => cli_value,
+        Err(err) => {
+            warn!(error = %err, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+            cli_value
+        }
+    }
 }
 
 #[tokio::main]
@@ -83,6 +102,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
     let cli = Cli::parse();
+    let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
+    info!(worker_concurrency, "resolved worker concurrency");
     let config = WorkerConfigFile::load(&cli.config_path)
         .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
 
@@ -103,6 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             heartbeat_interval: std::time::Duration::from_secs_f64(cli.heartbeat_secs),
             retry_backoff: std::time::Duration::from_secs(1),
             management_port: config.management_port,
+            worker_concurrency,
         },
         config.delivery,
         FdbProcessor { fdb_config },

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -6,7 +6,7 @@ use mars_client::{Error as MarsError, MarsClient};
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, run_worker_loop};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::warn;
+use tracing::{info, warn};
 
 mod convert;
 mod k8s;
@@ -16,6 +16,7 @@ struct MarsProcessor {
     /// Port the C++ MARS client binds for DHS callbacks. We forcibly close any
     /// leaked listener on this port between retrieves; see `port_cleanup`.
     local_port: u16,
+    env_lock: std::sync::Arc<std::sync::Mutex<()>>,
 }
 
 #[async_trait]
@@ -37,8 +38,11 @@ impl Processor for MarsProcessor {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(32);
         let local_port = self.local_port;
+        let env_lock = self.env_lock.clone();
         tokio::task::spawn_blocking(move || {
-            // SAFETY: run_worker_loop processes one request at a time — no concurrent set_var.
+            let _env_guard = env_lock.lock().expect("MARS environment lock poisoned");
+            // SAFETY: this mutex serializes all per-request mutation of process environment
+            // variables used by the MARS client.
             unsafe {
                 std::env::set_var("MARS_USER_EMAIL", &mars_email);
                 std::env::set_var("MARS_USER_TOKEN", &mars_token);
@@ -126,6 +130,25 @@ struct Cli {
     mars_dhs_local_port: u16,
     #[arg(long, default_value = DEFAULT_CONFIG_PATH)]
     config_path: String,
+    #[arg(long, default_value_t = 1)]
+    worker_concurrency: usize,
+}
+
+fn resolved_worker_concurrency(cli_value: usize) -> usize {
+    match std::env::var("POLYTOPE_WORKER_CONCURRENCY") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(parsed) if parsed >= 1 => parsed,
+            _ => {
+                warn!(value = %value, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+                cli_value
+            }
+        },
+        Err(std::env::VarError::NotPresent) => cli_value,
+        Err(err) => {
+            warn!(error = %err, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+            cli_value
+        }
+    }
 }
 
 #[tokio::main]
@@ -136,6 +159,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     mars_client::log_bridge::init();
 
     let cli = Cli::parse();
+    let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
+    info!(worker_concurrency, "resolved worker concurrency");
 
     let config = WorkerConfigFile::load(&cli.config_path)
         .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
@@ -160,10 +185,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             heartbeat_interval: std::time::Duration::from_secs_f64(cli.heartbeat_secs),
             retry_backoff: std::time::Duration::from_secs(1),
             management_port: config.management_port,
+            worker_concurrency,
         },
         config.delivery,
         MarsProcessor {
             local_port: manager.local_port(),
+            env_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
         },
     )
     .await?;
@@ -182,7 +209,10 @@ mod tests {
 
     #[tokio::test]
     async fn process_returns_error_for_invalid_request() {
-        let processor = MarsProcessor { local_port: 8100 };
+        let processor = MarsProcessor {
+            local_port: 8100,
+            env_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
+        };
         let result = processor
             .process(WorkItem {
                 job_id: "job-1".into(),

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -87,6 +87,25 @@ struct Cli {
     python_path: String,
     #[arg(long, default_value = DEFAULT_CONFIG_PATH)]
     config_path: String,
+    #[arg(long, default_value_t = 1)]
+    worker_concurrency: usize,
+}
+
+fn resolved_worker_concurrency(cli_value: usize) -> usize {
+    match std::env::var("POLYTOPE_WORKER_CONCURRENCY") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(parsed) if parsed >= 1 => parsed,
+            _ => {
+                tracing::warn!(value = %value, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+                cli_value
+            }
+        },
+        Err(std::env::VarError::NotPresent) => cli_value,
+        Err(err) => {
+            tracing::warn!(error = %err, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+            cli_value
+        }
+    }
 }
 
 #[tokio::main]
@@ -95,6 +114,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
     let cli = Cli::parse();
+    let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
+    info!(worker_concurrency, "resolved worker concurrency");
 
     let config = WorkerConfigFile::load(&cli.config_path)
         .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
@@ -127,6 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             heartbeat_interval: std::time::Duration::from_secs_f64(cli.heartbeat_secs),
             retry_backoff: std::time::Duration::from_secs(1),
             management_port: config.management_port,
+            worker_concurrency,
         },
         config.delivery,
         PolytopeProcessor {

--- a/workers/test-worker/src/lib.rs
+++ b/workers/test-worker/src/lib.rs
@@ -107,21 +107,49 @@ fn stress_usize(request: &serde_json::Value, key: &str) -> Option<usize> {
     stress_u64(request, key).and_then(|value| usize::try_from(value).ok())
 }
 
+struct StressStream {
+    remaining: usize,
+    chunk: bytes::Bytes,
+}
+
+impl futures::Stream for StressStream {
+    type Item = Result<bytes::Bytes, std::io::Error>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.remaining == 0 {
+            return std::task::Poll::Ready(None);
+        }
+
+        let bytes_to_send = this.remaining.min(this.chunk.len());
+        this.remaining -= bytes_to_send;
+        let bytes = if bytes_to_send == this.chunk.len() {
+            this.chunk.clone()
+        } else {
+            this.chunk.slice(..bytes_to_send)
+        };
+        std::task::Poll::Ready(Some(Ok(bytes)))
+    }
+}
+
 /// Build a lazily-evaluated stream of byte chunks totalling `total` bytes.
 ///
-/// Byte values follow the pattern `b'a' + (global_position % 26)`, keeping
-/// the per-byte content deterministic regardless of chunk size. The last chunk
-/// may be smaller than `chunk` bytes when `total` is not evenly divisible.
+/// The stream reuses a fixed byte buffer for full-sized chunks so synthetic
+/// data generation does not become the throughput bottleneck being measured.
+/// The last chunk may be smaller than `chunk` bytes when `total` is not evenly
+/// divisible.
 fn stress_stream(
     total: usize,
     chunk: usize,
 ) -> impl futures::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + Unpin + 'static {
-    let chunks = (0..total).step_by(chunk).map(move |start| {
-        let end = (start + chunk).min(total);
-        let buf: Vec<u8> = (start..end).map(|i| b'a' + ((i % 26) as u8)).collect();
-        Ok(bytes::Bytes::from(buf))
-    });
-    Box::pin(futures::stream::iter(chunks))
+    let chunk_len = chunk.max(1).min(total).max(1);
+    StressStream {
+        remaining: total,
+        chunk: bytes::Bytes::from(vec![b'x'; chunk_len]),
+    }
 }
 
 #[async_trait]

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -223,7 +223,7 @@ mod tests {
         let (content_type, body) = collect_success_body(result).await;
         assert_eq!(content_type, "application/json");
         assert_eq!(body.len(), 123);
-        assert_eq!(&body[..4], b"abcd");
+        assert_eq!(&body[..4], b"xxxx");
     }
 
     #[tokio::test]
@@ -295,10 +295,10 @@ mod tests {
             chunks.len()
         );
 
-        // Reassemble and verify total length and byte pattern.
+        // Reassemble and verify total length and deterministic bytes.
         let body: Vec<u8> = chunks.into_iter().flatten().collect();
         assert_eq!(body.len(), 1000);
-        assert_eq!(&body[..4], b"abcd");
+        assert_eq!(&body[..4], b"xxxx");
     }
 
     #[tokio::test]

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{WorkerConfig, run_worker_loop};
 use test_worker::*;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Parser)]
 struct Cli {
@@ -14,12 +14,33 @@ struct Cli {
     heartbeat_secs: f64,
     #[arg(long, default_value = DEFAULT_CONFIG_PATH)]
     config_path: String,
+    #[arg(long, default_value_t = 1)]
+    worker_concurrency: usize,
+}
+
+fn resolved_worker_concurrency(cli_value: usize) -> usize {
+    match std::env::var("POLYTOPE_WORKER_CONCURRENCY") {
+        Ok(value) => match value.parse::<usize>() {
+            Ok(parsed) if parsed >= 1 => parsed,
+            _ => {
+                warn!(value = %value, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+                cli_value
+            }
+        },
+        Err(std::env::VarError::NotPresent) => cli_value,
+        Err(err) => {
+            warn!(error = %err, "ignoring invalid POLYTOPE_WORKER_CONCURRENCY");
+            cli_value
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
     let cli = Cli::parse();
+    let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
+    info!(worker_concurrency, "resolved worker concurrency");
     let config = WorkerConfigFile::load(&cli.config_path)
         .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
 
@@ -45,6 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             heartbeat_interval: std::time::Duration::from_secs_f64(cli.heartbeat_secs),
             retry_backoff: std::time::Duration::from_secs(1),
             management_port: config.management_port,
+            worker_concurrency,
         },
         config.delivery,
         BehaviourProcessor {


### PR DESCRIPTION
## Summary

Three commits, all driven by the in-cluster BOBS user-download benchmark and the polytope-config tier-2 stress harness.

### `feat: add BOBS write routing and stress streaming` (`07e515d`)

- Workers route to the right BOBS replica using the structured request-id.
- Streaming write path through BITS so test-worker output reaches BOBS without buffering the whole response in memory.

### `test: make stress-worker output cheap to generate` (`ce07286`)

- Replace per-byte synthetic stress payload generation with a lazy `Stream`.
- Reuse one fixed `Bytes` buffer for full chunks so test-worker CPU does not dominate BOBS throughput tests.
- Keep chunk boundaries and total byte counts deterministic.

### `Stream worker output to BOBS as one request and add per-pod worker concurrency` (`24fff3a`)

Two real bottlenecks in the producer pipeline, both fixed:

1. **Per-chunk POST loop replaced with one streaming POST.** `workers/common/src/delivery/bobs.rs` was issuing one POST per chunk to `/write/{key}/{offset}`; replaced with a single streaming POST through BOBS's accept-stream path. In-cluster benchmark: 230.8 MiB/s → 375.1 MiB/s (+63%), poll p50 15.8s → 10.1s.

2. **Per-pod worker concurrency.** `WorkerConfig.worker_concurrency: usize` is now a required, validated (≥1) field; `run_worker_loop` spawns N tasks sharing `Arc<P>` processor and `Arc<dyn ResultDelivery>` and uses `tokio::sync::watch` for graceful shutdown. Heartbeat-per-job preserved. CLI flag `--worker-concurrency` + env override `POLYTOPE_WORKER_CONCURRENCY` (default 1) on test-worker, fdb-worker, mars-worker, polytope-fe-worker.

   Tests:
   - `worker_loop_processes_jobs_concurrently_when_worker_concurrency_is_two`
   - `worker_loop_validates_nonzero_worker_concurrency`

   Concurrency=8 was tried in-cluster and pushed BOBS past the contention knee on the dev vsphere PVC: aggregate dropped to 285 MiB/s, read p50 1.79s → 6.84s p95. Default stays 1; the knob is there for deployments with faster storage.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo test -p polytope-worker-common` 5/5.
- `cargo test -p polytope-server-integration-tests` 27/27.
- `cargo test --workspace -- --nocapture` green.
- Image build for the in-cluster benchmark: `FIXED_TAG=majh-dev skaffold build -b eccr.ecmwf.int/polytope/test-worker` then `podman push eccr.ecmwf.int/polytope/test-worker:majh-dev`.
- In-cluster `polytope-config test_bobs_in_cluster_full_range_throughput` ran end-to-end at 375 MiB/s aggregate with these changes; standalone `bobs-benchmark` in-cluster reaches 378 MiB/s under the same fan-out, confirming the polytope pipeline is at parity with the BOBS-only ceiling on the dev cluster.
