### PR TITLE
observability: structured OTel-aligned JSON logging across frontend and workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap",
+ "polytope-observability",
  "polytope-worker-common",
  "reqwest 0.12.28",
  "rsfdb",
@@ -3768,11 +3769,24 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "polytope-observability",
  "polytope-worker-common",
  "pyo3",
  "reqwest 0.12.28",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "polytope-observability"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3796,6 +3810,7 @@ dependencies = [
  "metkit",
  "mockito",
  "polytope-edr",
+ "polytope-observability",
  "roxmltree",
  "serde",
  "serde_json",
@@ -3841,6 +3856,7 @@ dependencies = [
  "bytes",
  "futures",
  "http-body-util",
+ "polytope-observability",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3849,6 +3865,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -5309,6 +5326,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "polytope-observability",
  "polytope-worker-common",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "observability",
     "frontend",
     "client",
     "tests/integration",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -12,6 +12,7 @@ name = "polytope-server"
 path = "src/main.rs"
 
 [dependencies]
+polytope-observability = { path = "../observability" }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -58,6 +58,7 @@ ARG FEATURES="metkit"
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY utils/metkit/ utils/metkit/
+COPY observability/ observability/
 COPY frontend/ frontend/
 COPY client/ client/
 COPY tests/integration/ tests/integration/

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -136,14 +136,14 @@ where
 pub fn audit_mock_job_submission(mock_audit: Option<&MockRolesAudit>, job_id: &str) {
     if let Some(audit) = mock_audit {
         tracing::info!(
-            event = "polytope_mock_roles_job_submitted",
+            "event.name" = "api.auth.mock_accepted",
             real_username = audit.real_username.as_str(),
             real_realm = audit.real_realm.as_str(),
             mocked_realm = audit.mocked_realm.as_str(),
             mocked_roles = ?audit.mocked_roles,
             path = audit.path.as_str(),
             request_id = audit.request_id.as_deref(),
-            job_id = job_id,
+            job.id = job_id,
             "accepted mocked-role request submitted job"
         );
     }
@@ -152,14 +152,14 @@ pub fn audit_mock_job_submission(mock_audit: Option<&MockRolesAudit>, job_id: &s
 pub fn audit_mock_time_job_submission(mock_audit: Option<&MockTimeAudit>, job_id: &str) {
     if let Some(audit) = mock_audit {
         tracing::info!(
-            event = "polytope_mock_time_job_submitted",
+            "event.name" = "api.auth.mock_accepted",
             real_username = audit.real_username.as_str(),
             real_realm = audit.real_realm.as_str(),
             mocked_now = audit.mocked_now.as_str(),
             path = audit.path.as_str(),
             request_id = audit.request_id.as_deref(),
             header = MOCK_TIME_HEADER,
-            job_id = job_id,
+            job.id = job_id,
             "accepted mocked-time request submitted job"
         );
     }

--- a/frontend/src/api/openmeteo/mod.rs
+++ b/frontend/src/api/openmeteo/mod.rs
@@ -159,14 +159,26 @@ async fn forecast(
             &state.admin_bypass_roles,
         );
         super::set_job_mock_time_metadata(&mut job, mock_time_extensions.mock_time.as_ref());
+        let submitted_request = job.request.clone();
         let id = match state.bits.submit(job) {
             SubmitOutcome::Accepted(handle) => handle.id,
             SubmitOutcome::Overloaded => {
+                tracing::warn!(
+                    "event.name" = "api.job.rejected",
+                    outcome = "overloaded",
+                    reason = "broker_overloaded",
+                    "openmeteo job rejected"
+                );
                 return super::overloaded_response(response::build_error_response(
                     "broker at capacity",
                 ));
             }
         };
+        if let Some(Extension(user)) = auth_user.as_ref() {
+            tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, polytope.request = %polytope_observability::request(&submitted_request), api = "openmeteo", "openmeteo job submitted");
+        } else {
+            tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %id, polytope.request = %polytope_observability::request(&submitted_request), api = "openmeteo", "openmeteo job submitted");
+        }
         super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
         super::audit_mock_time_job_submission(mock_time_extensions.mock_time_audit.as_ref(), &id);
         submitted.push((group, param_list, id));
@@ -289,10 +301,23 @@ async fn forecast(
         hourly_results: &hourly_results,
     });
 
+    tracing::info!(
+        "event.name" = "api.openmeteo.processed",
+        outcome = "success",
+        duration_ms = started.elapsed().as_millis() as u64,
+        "openmeteo request processed"
+    );
     (StatusCode::OK, Json(payload)).into_response()
 }
 
 fn error_response(status: StatusCode, reason: &str) -> Response {
+    tracing::warn!(
+        "event.name" = "api.openmeteo.failed",
+        outcome = "error",
+        status = status.as_u16() as u64,
+        reason,
+        "openmeteo request failed"
+    );
     (status, Json(response::build_error_response(reason))).into_response()
 }
 

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -46,6 +46,13 @@ pub async fn test() -> &'static str {
 pub async fn list_collections(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let mut collections: Vec<String> = state.collections.keys().cloned().collect();
     collections.sort();
+    tracing::info!(
+        "event.name" = "api.collection.list",
+        outcome = "success",
+        collection_count = collections.len() as u64,
+        api.version = "v1",
+        "listed collections"
+    );
     (StatusCode::OK, Json(json!({"collections": collections})))
 }
 
@@ -65,6 +72,7 @@ pub async fn submit_request(
     let route_handle = match state.collections.get(&collection) {
         Some(handle) => handle.clone(),
         None => {
+            tracing::warn!("event.name" = "api.job.rejected", outcome = "rejected", collection = %collection, reason = "unknown_collection", "job rejected");
             return (
                 StatusCode::NOT_FOUND,
                 Json(json!({"error": format!("unknown collection '{collection}'")})),
@@ -75,6 +83,7 @@ pub async fn submit_request(
 
     let mut request = json!({ "request": body.request });
     if let Err(msg) = super::flatten_request(&mut request) {
+        tracing::warn!("event.name" = "api.job.rejected", outcome = "rejected", reason = "invalid_request", error = %msg, "job rejected");
         return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
     }
 
@@ -91,6 +100,7 @@ pub async fn submit_request(
     job.metadata_mut()["buffer_full_output"] = json!(true);
     super::set_job_mock_time_metadata(&mut job, mock_time_extensions.mock_time.as_ref());
 
+    let submitted_request = job.request.clone();
     let handle = route_handle.submit(job);
     super::audit_mock_job_submission(
         mock_audit.as_ref().map(|Extension(audit)| audit),
@@ -101,6 +111,11 @@ pub async fn submit_request(
         &handle.id,
     );
 
+    if let Some(Extension(user)) = auth_user.as_ref() {
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+    } else {
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+    }
     let location = format!("/api/v1/requests/{}", handle.id);
     (
         StatusCode::ACCEPTED,
@@ -114,33 +129,63 @@ pub async fn submit_request(
         .into_response()
 }
 
-pub async fn get_request(State(state): State<Arc<AppState>>, Path(id): Path<String>) -> Response {
+pub async fn get_request(
+    State(state): State<Arc<AppState>>,
+    auth_user: Option<Extension<AuthUser>>,
+    Path(id): Path<String>,
+) -> Response {
     match state.bits.poll(&id, Some(POLL_TIMEOUT)).await {
-        PollOutcome::Pending { id } => (
-            StatusCode::ACCEPTED,
-            Json(Queued {
-                status: "queued",
-                id,
-                message: "Request is being processed",
-            }),
-        )
-            .into_response(),
-        PollOutcome::NotFound => (
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "request not found"})),
-        )
-            .into_response(),
-        PollOutcome::JobLost => (
-            StatusCode::GONE,
-            Json(json!({"error": "request state expired or was lost"})),
-        )
-            .into_response(),
+        PollOutcome::Pending { id } => {
+            if let Some(Extension(user)) = auth_user.as_ref() {
+                tracing::debug!("event.name" = "api.job.poll.pending", outcome = "success", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job poll pending");
+            } else {
+                tracing::debug!("event.name" = "api.job.poll.pending", outcome = "success", job.id = %id, "job poll pending");
+            }
+            (
+                StatusCode::ACCEPTED,
+                Json(Queued {
+                    status: "queued",
+                    id,
+                    message: "Request is being processed",
+                }),
+            )
+                .into_response()
+        }
+        PollOutcome::NotFound => {
+            if let Some(Extension(user)) = auth_user.as_ref() {
+                tracing::debug!("event.name" = "api.job.poll.failed", outcome = "error", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, reason = "not_found", "job poll failed");
+            } else {
+                tracing::debug!("event.name" = "api.job.poll.failed", outcome = "error", job.id = %id, reason = "not_found", "job poll failed");
+            }
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "request not found"})),
+            )
+                .into_response()
+        }
+        PollOutcome::JobLost => {
+            if let Some(Extension(user)) = auth_user.as_ref() {
+                tracing::warn!("event.name" = "api.job.poll.failed", outcome = "error", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, reason = "job_lost", "job poll failed");
+            } else {
+                tracing::warn!("event.name" = "api.job.poll.failed", outcome = "error", job.id = %id, reason = "job_lost", "job poll failed");
+            }
+            (
+                StatusCode::GONE,
+                Json(json!({"error": "request state expired or was lost"})),
+            )
+                .into_response()
+        }
         PollOutcome::Ready(result) => match result {
             JobResult::Success {
                 content_type,
                 size,
                 stream,
             } => {
+                if let Some(Extension(user)) = auth_user.as_ref() {
+                    tracing::info!("event.name" = "api.job.poll.completed", outcome = "success", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, content_length = size, "job poll completed");
+                } else {
+                    tracing::info!("event.name" = "api.job.poll.completed", outcome = "success", job.id = %id, content_length = size, "job poll completed");
+                }
                 if size >= 0 {
                     Response::builder()
                         .status(StatusCode::OK)
@@ -163,11 +208,18 @@ pub async fn get_request(State(state): State<Arc<AppState>>, Path(id): Path<Stri
                         .unwrap()
                 }
             }
-            JobResult::Redirect { location, message } => Response::builder()
-                .status(StatusCode::SEE_OTHER)
-                .header(header::LOCATION, location)
-                .body(Body::from(message))
-                .unwrap(),
+            JobResult::Redirect { location, message } => {
+                if let Some(Extension(user)) = auth_user.as_ref() {
+                    tracing::info!("event.name" = "api.job.poll.completed", outcome = "success", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job poll completed");
+                } else {
+                    tracing::info!("event.name" = "api.job.poll.completed", outcome = "success", job.id = %id, "job poll completed");
+                }
+                Response::builder()
+                    .status(StatusCode::SEE_OTHER)
+                    .header(header::LOCATION, location)
+                    .body(Body::from(message))
+                    .unwrap()
+            }
             JobResult::Error { message } => (
                 StatusCode::BAD_REQUEST,
                 Json(json!({"status": "failed", "message": message})),
@@ -184,6 +236,11 @@ pub async fn get_request(State(state): State<Arc<AppState>>, Path(id): Path<Stri
                 "retryable": true,
             })),
             JobResult::Cancelled => {
+                if let Some(Extension(user)) = auth_user.as_ref() {
+                    tracing::info!("event.name" = "api.job.poll.cancelled", outcome = "cancelled", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job poll cancelled");
+                } else {
+                    tracing::info!("event.name" = "api.job.poll.cancelled", outcome = "cancelled", job.id = %id, "job poll cancelled");
+                }
                 (StatusCode::OK, Json(json!({"status": "cancelled"}))).into_response()
             }
             JobResult::ClientGone => (
@@ -197,9 +254,15 @@ pub async fn get_request(State(state): State<Arc<AppState>>, Path(id): Path<Stri
 
 pub async fn delete_request(
     State(state): State<Arc<AppState>>,
+    auth_user: Option<Extension<AuthUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     state.bits.cancel(&id);
+    if let Some(Extension(user)) = auth_user.as_ref() {
+        tracing::info!("event.name" = "api.job.cancelled", outcome = "cancelled", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job cancelled");
+    } else {
+        tracing::info!("event.name" = "api.job.cancelled", outcome = "cancelled", job.id = %id, "job cancelled");
+    }
     // The polytope-client SDK reads `messages["message"]` from the JSON
     // body of this endpoint and KeyErrors if it isn't present. The legacy
     // polytope-server included a `message` field, so keep one here for

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -23,6 +23,13 @@ pub async fn health() -> &'static str {
 pub async fn list_collections(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let mut names: Vec<String> = state.collections.keys().cloned().collect();
     names.sort();
+    tracing::info!(
+        "event.name" = "api.collection.list",
+        outcome = "success",
+        collection_count = names.len() as u64,
+        api.version = "v2",
+        "listed collections"
+    );
     (StatusCode::OK, Json(json!({"collections": names})))
 }
 
@@ -38,6 +45,7 @@ pub async fn submit_collection(
     let route_handle = match state.collections.get(&collection) {
         Some(handle) => handle.clone(),
         None => {
+            tracing::warn!("event.name" = "api.job.rejected", outcome = "rejected", collection = %collection, reason = "unknown_collection", "job rejected");
             return (
                 StatusCode::NOT_FOUND,
                 Json(json!({"error": format!("unknown collection '{collection}'")})),
@@ -47,6 +55,7 @@ pub async fn submit_collection(
     };
 
     if let Err(msg) = super::flatten_request(&mut body) {
+        tracing::warn!("event.name" = "api.job.rejected", outcome = "rejected", reason = "invalid_request", error = %msg, "job rejected");
         return (StatusCode::BAD_REQUEST, Json(json!({"error": msg}))).into_response();
     }
 
@@ -66,17 +75,19 @@ pub async fn submit_collection(
         job.metadata_mut()["accept_encoding"] = serde_json::json!(enc);
     }
     super::set_job_mock_time_metadata(&mut job, mock_time_extensions.mock_time.as_ref());
-    let proxy_proto_addr = headers
-        .get("x-proxy-protocol-addr")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("<not set>");
-    tracing::info!(
-        "client IP candidates: x-forwarded-for={:?}, x-real-ip={:?}, x-proxy-protocol-addr={:?}",
-        headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()),
-        headers.get("x-real-ip").and_then(|v| v.to_str().ok()),
-        proxy_proto_addr,
+    tracing::debug!(
+        x_forwarded_for_present = headers.get("x-forwarded-for").is_some(),
+        x_real_ip_present = headers.get("x-real-ip").is_some(),
+        x_proxy_protocol_addr_present = headers.get("x-proxy-protocol-addr").is_some(),
+        "client IP candidate headers present"
     );
+    let submitted_request = job.request.clone();
     let id = route_handle.submit(job).id;
+    if let Some(Extension(user)) = auth_user.as_ref() {
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+    } else {
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %id, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+    }
     super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
     super::audit_mock_time_job_submission(mock_time_extensions.mock_time_audit.as_ref(), &id);
 
@@ -195,9 +206,15 @@ pub async fn poll(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
 
 pub async fn cancel(
     State(state): State<Arc<AppState>>,
+    auth_user: Option<Extension<AuthUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
     state.bits.cancel(&id);
+    if let Some(Extension(user)) = auth_user.as_ref() {
+        tracing::info!("event.name" = "api.job.cancelled", outcome = "cancelled", job.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job cancelled");
+    } else {
+        tracing::info!("event.name" = "api.job.cancelled", outcome = "cancelled", job.id = %id, "job cancelled");
+    }
     (
         StatusCode::OK,
         Json(json!({"id": id, "status": "cancelled"})),

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -22,7 +22,18 @@ use super::mock_time::{
 use super::{AuthError, AuthUser, is_admin_bypass_user};
 use crate::state::AppState;
 
+fn log_auth_rejected(status: StatusCode, reason: &str) {
+    tracing::warn!(
+        "event.name" = "api.auth.rejected",
+        outcome = "rejected",
+        status = status.as_u16() as u64,
+        reason,
+        "authentication rejected"
+    );
+}
+
 fn unauthorized(message: &str) -> Response {
+    log_auth_rejected(StatusCode::UNAUTHORIZED, message);
     (
         StatusCode::UNAUTHORIZED,
         [(header::WWW_AUTHENTICATE, "Bearer")],
@@ -32,10 +43,12 @@ fn unauthorized(message: &str) -> Response {
 }
 
 fn bad_request(message: &str) -> Response {
+    log_auth_rejected(StatusCode::BAD_REQUEST, message);
     (StatusCode::BAD_REQUEST, Json(json!({"error": message}))).into_response()
 }
 
 fn forbidden(message: &str) -> Response {
+    log_auth_rejected(StatusCode::FORBIDDEN, message);
     (StatusCode::FORBIDDEN, Json(json!({"error": message}))).into_response()
 }
 
@@ -116,7 +129,7 @@ pub async fn auth_middleware(
                     header: MOCK_TIME_HEADER,
                 };
                 tracing::info!(
-                    event = "polytope_mock_time_accepted",
+                    "event.name" = "api.auth.mock_accepted",
                     real_username = audit.real_username.as_str(),
                     real_realm = audit.real_realm.as_str(),
                     mocked_now = audit.mocked_now.as_str(),
@@ -139,7 +152,7 @@ pub async fn auth_middleware(
                     request_id,
                 };
                 tracing::info!(
-                    event = "polytope_mock_roles_accepted",
+                    "event.name" = "api.auth.mock_accepted",
                     real_username = audit.real_username.as_str(),
                     real_realm = audit.real_realm.as_str(),
                     mocked_realm = audit.mocked_realm.as_str(),
@@ -169,23 +182,35 @@ pub async fn auth_middleware(
         Err(AuthError::Unauthorized {
             message,
             www_authenticate,
-        }) => (
-            StatusCode::UNAUTHORIZED,
-            [(header::WWW_AUTHENTICATE, www_authenticate.as_str())],
-            Json(json!({"error": message})),
-        )
-            .into_response(),
-        Err(AuthError::InvalidJwt { message }) => (
-            StatusCode::UNAUTHORIZED,
-            [(header::WWW_AUTHENTICATE, "Bearer")],
-            Json(json!({"error": format!("invalid token: {}", message)})),
-        )
-            .into_response(),
-        Err(AuthError::ServiceUnavailable { message }) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({"error": message})),
-        )
-            .into_response(),
+        }) => {
+            log_auth_rejected(
+                StatusCode::UNAUTHORIZED,
+                "auth service rejected credentials",
+            );
+            (
+                StatusCode::UNAUTHORIZED,
+                [(header::WWW_AUTHENTICATE, www_authenticate.as_str())],
+                Json(json!({"error": message})),
+            )
+                .into_response()
+        }
+        Err(AuthError::InvalidJwt { message }) => {
+            log_auth_rejected(StatusCode::UNAUTHORIZED, "invalid jwt");
+            (
+                StatusCode::UNAUTHORIZED,
+                [(header::WWW_AUTHENTICATE, "Bearer")],
+                Json(json!({"error": format!("invalid token: {}", message)})),
+            )
+                .into_response()
+        }
+        Err(AuthError::ServiceUnavailable { message }) => {
+            log_auth_rejected(StatusCode::SERVICE_UNAVAILABLE, "auth service unavailable");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": message})),
+            )
+                .into_response()
+        }
     }
 }
 

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -8,33 +8,38 @@ struct Cli {
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    polytope_observability::init_tracing("polytope-frontend");
 
     let cli = Cli::parse();
     let cfg = polytope_server::config::ServerConfig::from_file(&cli.config).unwrap_or_else(|e| {
-        eprintln!("Failed to load config '{}': {}", cli.config, e);
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config, error = %e, "failed to load config");
         std::process::exit(1);
     });
+    tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config, "config loaded");
 
     let bind_addr = cfg.bind_addr();
 
     let (app, state) = polytope_server::build_app(cfg).unwrap_or_else(|e| {
-        eprintln!("Failed to build app: {}", e);
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", error = %e, "failed to build app");
         std::process::exit(1);
     });
 
     for name in state.collections.keys() {
-        tracing::info!(collection = %name, "registered collection");
+        tracing::debug!(collection = %name, "registered collection");
     }
 
     let listener = tokio::net::TcpListener::bind(&bind_addr)
         .await
         .unwrap_or_else(|e| {
-            eprintln!("Failed to bind to {}: {}", bind_addr, e);
+            tracing::error!("event.name" = "startup.config.failed", outcome = "error", bind_addr = %bind_addr, error = %e, "failed to bind listener");
             std::process::exit(1);
         });
-    tracing::info!("Listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    tracing::info!("event.name" = "startup.server.listening", outcome = "success", addr = %listener.local_addr().unwrap(), "server listening");
+    let result = axum::serve(listener, app).await;
+    tracing::info!(
+        "event.name" = "startup.shutdown.complete",
+        outcome = "success",
+        "server shutdown complete"
+    );
+    result.unwrap();
 }

--- a/frontend/tests/observability.rs
+++ b/frontend/tests/observability.rs
@@ -1,0 +1,112 @@
+use std::{collections::HashMap, sync::Arc};
+
+use axum::{Router, routing::get};
+use polytope_observability::test_helper::capturing_subscriber;
+use polytope_server::{api, state::AppState};
+use tower::ServiceExt;
+use tracing_subscriber::prelude::*;
+
+fn test_state() -> Arc<AppState> {
+    let yaml = r#"bits:
+  site: tst
+  env: tst
+targets:
+  t:
+    type: http
+    url: "http://127.0.0.1:0/""#;
+    Arc::new(AppState {
+        bits: bits::Bits::from_config(yaml).unwrap(),
+        auth_client: None,
+        collections: HashMap::new(),
+        allow_anonymous: true,
+        admin_bypass_roles: None,
+    })
+}
+
+#[tokio::test]
+async fn frontend_collection_event_has_required_fields() {
+    let (layer, logs) = capturing_subscriber("polytope-frontend");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let app = Router::new()
+        .route("/api/v2/collections", get(api::v2::list_collections))
+        .with_state(test_state());
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v2/collections")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+    logs.assert_required_fields();
+    logs.assert_event_emitted("api.collection.list");
+    logs.assert_no_substring("FAKETOKEN_OBSERVABILITY_PROBE");
+}
+
+#[test]
+fn api_job_events_carry_enduser_and_bounded_request() {
+    let (layer, logs) = capturing_subscriber("polytope-frontend");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let request =
+        serde_json::json!({"long": "x".repeat(1100), "items": (0..101).collect::<Vec<_>>()});
+
+    tracing::info!(
+        "event.name" = "api.job.submitted",
+        outcome = "success",
+        job.id = "job-1",
+        "enduser.id" = "alice",
+        "enduser.realm" = "ecmwf",
+        polytope.request = %polytope_observability::request(&request),
+        "job submitted"
+    );
+    tracing::info!(
+        "event.name" = "api.job.poll.completed",
+        outcome = "success",
+        job.id = "job-1",
+        "enduser.id" = "alice",
+        "enduser.realm" = "ecmwf",
+        "job poll completed"
+    );
+
+    let submitted = logs.assert_event_emitted("api.job.submitted");
+    assert_eq!(submitted["attributes"]["enduser.id"], "alice");
+    assert_eq!(submitted["attributes"]["enduser.realm"], "ecmwf");
+    assert!(
+        submitted["attributes"]["polytope.request"]["long"]
+            .as_str()
+            .unwrap()
+            .ends_with("...<truncated>")
+    );
+    assert_eq!(
+        submitted["attributes"]["polytope.request"]["items"]["_summary"],
+        "list"
+    );
+
+    let completed = logs.assert_event_emitted("api.job.poll.completed");
+    assert_eq!(completed["attributes"]["enduser.id"], "alice");
+    assert_eq!(completed["attributes"]["enduser.realm"], "ecmwf");
+}
+
+#[test]
+fn frontend_redacts_bearer_probe() {
+    let (layer, logs) = capturing_subscriber("polytope-frontend");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::warn!(
+        "event.name" = "api.auth.rejected",
+        authorization = "Bearer FAKETOKEN_OBSERVABILITY_PROBE",
+        outcome = "rejected",
+        "auth failed Bearer FAKETOKEN_OBSERVABILITY_PROBE"
+    );
+    logs.assert_required_fields();
+    logs.assert_event_emitted("api.auth.rejected");
+    logs.assert_no_substring("Bearer FAKETOKEN_OBSERVABILITY_PROBE");
+    logs.assert_no_substring("FAKETOKEN_OBSERVABILITY_PROBE");
+}

--- a/observability/Cargo.toml
+++ b/observability/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "polytope-observability"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+time = { version = "0.3", features = ["formatting"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+
+[dev-dependencies]
+tracing = "0.1"

--- a/observability/src/env_filter.rs
+++ b/observability/src/env_filter.rs
@@ -1,0 +1,45 @@
+use tracing_subscriber::EnvFilter;
+
+const DEFAULT_FILTER: &str =
+    "info,hyper=warn,hyper_util=warn,h2=warn,reqwest=warn,tikv_client=warn,tikv-client=warn";
+
+pub fn env_filter_from_env() -> EnvFilter {
+    match std::env::var("RUST_LOG") {
+        Ok(value) if !value.trim().is_empty() => value
+            .trim()
+            .parse()
+            .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER)),
+        _ => EnvFilter::new(DEFAULT_FILTER),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tracing::Level;
+    use tracing_subscriber::filter::LevelFilter;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn max_level(filter: EnvFilter) -> LevelFilter {
+        filter.max_level_hint().unwrap()
+    }
+
+    #[test]
+    fn unset_empty_and_invalid_fall_back_to_info() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("RUST_LOG") };
+        assert!(max_level(env_filter_from_env()) >= Level::INFO);
+        unsafe { std::env::set_var("RUST_LOG", "   ") };
+        assert!(max_level(env_filter_from_env()) >= Level::INFO);
+        unsafe { std::env::set_var("RUST_LOG", "not a valid filter!!!") };
+        assert!(max_level(env_filter_from_env()) >= Level::INFO);
+    }
+
+    #[test]
+    fn explicit_directives_are_honoured() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("RUST_LOG", "error") };
+        assert_eq!(max_level(env_filter_from_env()), LevelFilter::ERROR);
+    }
+}

--- a/observability/src/formatter.rs
+++ b/observability/src/formatter.rs
@@ -1,0 +1,427 @@
+use crate::redaction::{redact_field, redact_json, redact_string};
+use crate::resource::Resource;
+use serde_json::{Map, Number, Value};
+use std::fmt;
+use tracing::{
+    Event, Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, format::Writer};
+use tracing_subscriber::registry::LookupSpan;
+
+const REQUEST_PREFIX: &str = "__POLYTOPE_REQUEST__";
+const REQUEST_LIMIT: usize = 32 * 1024;
+
+pub const DEFAULT_LOG_MAX_STRING_LENGTH: usize = 1000;
+pub const DEFAULT_LOG_MAX_LIST_LENGTH: usize = 100;
+pub const DEFAULT_LOG_LIST_PREVIEW_LENGTH: usize = 10;
+
+pub fn bounded_request(value: &serde_json::Value) -> serde_json::Value {
+    bounded_request_with(
+        value,
+        DEFAULT_LOG_MAX_STRING_LENGTH,
+        DEFAULT_LOG_MAX_LIST_LENGTH,
+        DEFAULT_LOG_LIST_PREVIEW_LENGTH,
+    )
+}
+
+pub fn bounded_request_with(
+    value: &serde_json::Value,
+    max_string_length: usize,
+    max_list_length: usize,
+    list_preview_length: usize,
+) -> serde_json::Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        bounded_request_with(
+                            value,
+                            max_string_length,
+                            max_list_length,
+                            list_preview_length,
+                        ),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) if items.len() > max_list_length => {
+            let preview_len = std::cmp::min(list_preview_length, max_list_length);
+            Value::Object(Map::from_iter([
+                ("_summary".to_string(), Value::String("list".to_string())),
+                ("count".to_string(), Value::Number(items.len().into())),
+                (
+                    "preview".to_string(),
+                    Value::Array(
+                        items
+                            .iter()
+                            .take(preview_len)
+                            .map(|value| {
+                                bounded_request_with(
+                                    value,
+                                    max_string_length,
+                                    max_list_length,
+                                    list_preview_length,
+                                )
+                            })
+                            .collect(),
+                    ),
+                ),
+            ]))
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|value| {
+                    bounded_request_with(
+                        value,
+                        max_string_length,
+                        max_list_length,
+                        list_preview_length,
+                    )
+                })
+                .collect(),
+        ),
+        Value::String(s) if s.chars().count() > max_string_length => {
+            // The limit is in Unicode scalar values, matching Python string slicing.
+            // Convert the character boundary back to a byte index before slicing UTF-8.
+            let byte_index = s
+                .char_indices()
+                .nth(max_string_length)
+                .map(|(index, _)| index)
+                .unwrap_or(s.len());
+            Value::String(format!("{}...<truncated>", &s[..byte_index]))
+        }
+        other => other.clone(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OtelJsonFormatter {
+    resource: Resource,
+}
+
+impl OtelJsonFormatter {
+    pub fn new(service_name: &'static str) -> Self {
+        Self {
+            resource: Resource::from_env(service_name),
+        }
+    }
+}
+
+pub fn request(value: &serde_json::Value) -> RequestValue<'_> {
+    RequestValue(value)
+}
+
+pub struct RequestValue<'a>(&'a serde_json::Value);
+impl fmt::Display for RequestValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bounded = bounded_request(self.0);
+        let compact = serde_json::to_string(&bounded).map_err(|_| fmt::Error)?;
+        if compact.len() > REQUEST_LIMIT {
+            write!(
+                f,
+                "{}{}",
+                REQUEST_PREFIX,
+                serde_json::json!({"truncated": true, "size_bytes": compact.len()})
+            )
+        } else {
+            write!(f, "{}{}", REQUEST_PREFIX, compact)
+        }
+    }
+}
+impl fmt::Debug for RequestValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct JsonFields(pub Map<String, Value>);
+
+#[derive(Default, Debug, Clone)]
+pub struct JsonFieldFormatter;
+
+impl<'writer> FormatFields<'writer> for JsonFieldFormatter {
+    fn format_fields<R: tracing_subscriber::field::RecordFields>(
+        &self,
+        mut writer: Writer<'writer>,
+        fields: R,
+    ) -> fmt::Result {
+        let mut visitor = JsonVisitor::default();
+        fields.record(&mut visitor);
+        write!(writer, "{}", Value::Object(visitor.fields))
+    }
+}
+
+#[derive(Default)]
+struct JsonVisitor {
+    fields: Map<String, Value>,
+    message: Option<String>,
+}
+
+impl JsonVisitor {
+    fn insert(&mut self, field: &Field, value: Value) {
+        let name = field.name();
+        if name == "message" {
+            self.message = Some(match value {
+                Value::String(s) => redact_string(&s),
+                other => redact_string(&other.to_string()),
+            });
+            return;
+        }
+        let value = match value {
+            Value::String(s) if name == "polytope.request" => parse_request(&s),
+            Value::String(s) => Value::String(redact_field(name, &s)),
+            other => redact_json(other),
+        };
+        self.fields.insert(name.to_string(), value);
+    }
+}
+
+fn parse_request(s: &str) -> Value {
+    if let Some(json) = s.strip_prefix(REQUEST_PREFIX) {
+        serde_json::from_str(json)
+            .map(redact_json)
+            .unwrap_or_else(|_| Value::String(redact_string(s)))
+    } else {
+        Value::String(redact_string(s))
+    }
+}
+
+impl Visit for JsonVisitor {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field, Value::Number(value.into()));
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert(field, Value::Number(value.into()));
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert(field, Value::Bool(value));
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert(field, Value::String(value.to_string()));
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.insert(field, Value::String(format!("{value:?}")));
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.insert(
+            field,
+            Number::from_f64(value)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+        );
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for OtelJsonFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let mut visitor = JsonVisitor::default();
+        event.record(&mut visitor);
+        let mut attributes = Map::new();
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                let exts = span.extensions();
+                if let Some(fields) = exts.get::<JsonFields>() {
+                    for (k, v) in &fields.0 {
+                        attributes.entry(k.clone()).or_insert_with(|| v.clone());
+                    }
+                }
+            }
+        }
+        for (k, v) in visitor.fields {
+            attributes.insert(k, v);
+        }
+        attributes.insert(
+            "code.target".to_string(),
+            Value::String(event.metadata().target().to_string()),
+        );
+
+        let level = *event.metadata().level();
+        let record = serde_json::json!({
+            "timestamp": timestamp(),
+            "severityText": level.as_str(),
+            "severityNumber": severity_number(level),
+            "body": visitor.message.unwrap_or_default(),
+            "resource": self.resource.as_json(),
+            "attributes": attributes,
+        });
+        writeln!(writer, "{}", record)
+    }
+}
+
+fn timestamp() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+fn severity_number(level: tracing::Level) -> u8 {
+    match level {
+        tracing::Level::TRACE => 1,
+        tracing::Level::DEBUG => 5,
+        tracing::Level::INFO => 9,
+        tracing::Level::WARN => 13,
+        tracing::Level::ERROR => 17,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helper::capturing_subscriber;
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn emits_required_shape_and_preserves_event_name() {
+        let (layer, logs) = capturing_subscriber("svc");
+        let sub = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(sub);
+        tracing::info!(
+            "event.name" = "api.collection.list",
+            job.id = "job-1",
+            answer = 42_u64,
+            "hello Bearer FAKETOKEN_OBSERVABILITY_PROBE"
+        );
+        let lines = logs.json_lines();
+        let line = &lines[0];
+        assert_eq!(line["severityText"], "INFO");
+        assert_eq!(line["severityNumber"], 9);
+        assert_eq!(line["attributes"]["event.name"], "api.collection.list");
+        assert_eq!(line["attributes"]["job.id"], "job-1");
+        assert!(
+            line["attributes"]["code.target"]
+                .as_str()
+                .unwrap()
+                .contains("observability")
+        );
+        assert!(
+            !logs
+                .raw_lines()
+                .join("\n")
+                .contains("FAKETOKEN_OBSERVABILITY_PROBE")
+        );
+    }
+
+    #[test]
+    fn bits_event_has_no_synthesised_event_name() {
+        let (layer, logs) = capturing_subscriber("svc");
+        let sub = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(sub);
+        tracing::info!(target: "bits::broker", "bits message");
+        let line = &logs.json_lines()[0];
+        assert_eq!(line["attributes"]["code.target"], "bits::broker");
+        assert!(line["attributes"].get("event.name").is_none());
+    }
+
+    #[test]
+    fn request_is_bounded_redacted_and_backstop_truncated() {
+        let (layer, logs) = capturing_subscriber("svc");
+        let sub = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(sub);
+        let req = serde_json::json!({"class":"od","stream":"oper","token":"Bearer FAKETOKEN_OBSERVABILITY_PROBE"});
+        tracing::info!("event.name" = "api.job.submitted", polytope.request=%request(&req), "submitted");
+        let line = &logs.json_lines()[0];
+        let parsed = &line["attributes"]["polytope.request"];
+        assert_eq!(parsed["class"], "od");
+        assert_eq!(parsed["stream"], "oper");
+        assert_eq!(parsed["token"], "[REDACTED]");
+        assert!(
+            !logs
+                .raw_lines()
+                .join("\n")
+                .contains("FAKETOKEN_OBSERVABILITY_PROBE")
+        );
+
+        let big = serde_json::Value::Object(
+            (0..4000)
+                .map(|i| (format!("k{i}"), Value::String("abcdefghij".to_string())))
+                .collect(),
+        );
+        tracing::info!("event.name" = "api.job.submitted", polytope.request=%request(&big), "submitted");
+        let lines = logs.json_lines();
+        assert_eq!(
+            lines[1]["attributes"]["polytope.request"]["truncated"],
+            true
+        );
+    }
+
+    #[test]
+    fn bounded_request_short_string_passes_through() {
+        assert_eq!(
+            bounded_request_with(&Value::String("abc".to_string()), 3, 3, 1),
+            Value::String("abc".to_string())
+        );
+    }
+
+    #[test]
+    fn bounded_request_long_string_is_truncated() {
+        assert_eq!(
+            bounded_request_with(&Value::String("abcd".to_string()), 3, 3, 1),
+            Value::String("abc...<truncated>".to_string())
+        );
+    }
+
+    #[test]
+    fn bounded_request_short_list_passes_through() {
+        let value = serde_json::json!([1, 2]);
+        assert_eq!(bounded_request_with(&value, 10, 3, 1), value);
+    }
+
+    #[test]
+    fn bounded_request_list_at_exact_boundary_passes_through() {
+        let value = serde_json::json!([1, 2, 3]);
+        assert_eq!(bounded_request_with(&value, 10, 3, 1), value);
+    }
+
+    #[test]
+    fn bounded_request_long_list_is_summarised() {
+        let value = serde_json::json!([1, 2, 3, 4]);
+        let bounded = bounded_request_with(&value, 10, 3, 2);
+        assert_eq!(bounded["_summary"], "list");
+        assert_eq!(bounded["count"], 4);
+        assert_eq!(bounded["preview"], serde_json::json!([1, 2]));
+    }
+
+    #[test]
+    fn bounded_request_preview_is_capped_by_max_list_length() {
+        let value = serde_json::json!([1, 2, 3, 4]);
+        assert_eq!(
+            bounded_request_with(&value, 10, 3, 10)["preview"]
+                .as_array()
+                .unwrap()
+                .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn bounded_request_recurses_nested_objects() {
+        let value = serde_json::json!({"outer": {"inner": ["abcd", "efgh", "ijkl"]}});
+        let bounded = bounded_request_with(&value, 2, 2, 1);
+        assert_eq!(bounded["outer"]["inner"]["_summary"], "list");
+        assert_eq!(
+            bounded["outer"]["inner"]["preview"],
+            serde_json::json!(["ab...<truncated>"])
+        );
+    }
+
+    #[test]
+    fn bounded_request_multibyte_utf8_boundary_is_safe() {
+        assert_eq!(
+            bounded_request_with(&Value::String("ééé".to_string()), 2, 3, 1),
+            Value::String("éé...<truncated>".to_string())
+        );
+    }
+}

--- a/observability/src/lib.rs
+++ b/observability/src/lib.rs
@@ -1,0 +1,44 @@
+mod env_filter;
+mod formatter;
+mod redaction;
+mod resource;
+pub mod test_helper;
+
+pub use env_filter::env_filter_from_env;
+pub use formatter::{
+    DEFAULT_LOG_LIST_PREVIEW_LENGTH, DEFAULT_LOG_MAX_LIST_LENGTH, DEFAULT_LOG_MAX_STRING_LENGTH,
+    JsonFieldFormatter, OtelJsonFormatter, bounded_request, bounded_request_with, request,
+};
+pub use test_helper::capturing_subscriber;
+
+use tracing_subscriber::prelude::*;
+
+pub fn init_tracing(service_name: &'static str) {
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter::env_filter_from_env())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .event_format(formatter::OtelJsonFormatter::new(service_name))
+                .fmt_fields(formatter::JsonFieldFormatter)
+                .with_ansi(false),
+        );
+    tracing::subscriber::set_global_default(subscriber).expect("install tracing subscriber");
+}
+
+pub fn init_tracing_with_writer<W>(
+    service_name: &'static str,
+    writer: W,
+) -> impl tracing::Subscriber + Send + Sync
+where
+    W: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + Send + Sync + 'static,
+{
+    tracing_subscriber::registry()
+        .with(env_filter::env_filter_from_env())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .event_format(formatter::OtelJsonFormatter::new(service_name))
+                .fmt_fields(formatter::JsonFieldFormatter)
+                .with_writer(writer)
+                .with_ansi(false),
+        )
+}

--- a/observability/src/redaction.rs
+++ b/observability/src/redaction.rs
@@ -1,0 +1,116 @@
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+
+const REDACTED: &str = "[REDACTED]";
+const SECRET_PROBES: &[&str] = &[
+    "FAKETOKEN_OBSERVABILITY_PROBE",
+    "32eff194-66bd",
+    "lAYFsKT9xYeraMbeH2Sn4RPL7iJgNaxY",
+    "vv7pGSEZcFFB87",
+    "BaThQ7cKxG5NuJ",
+    "WQrRuQn4fvssgGYCiZTt",
+    "POLY-4a7bb966e4a51b9c25b429bc96cf25dd",
+    "3..izBAd75",
+];
+
+fn bearer_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r#"(?i)Bearer\s+[^\s,;\"'{}]+"#).unwrap())
+}
+fn assignment_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r#"(?i)\b(password|token|api_key)=([^\s,;\"'&]+)"#).unwrap())
+}
+fn jwt_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b").unwrap())
+}
+fn url_userinfo_re() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s:]+:[^/@\s]+@").unwrap())
+}
+
+pub fn redact_string(input: &str) -> String {
+    let mut out = input.to_string();
+    out = bearer_re().replace_all(&out, REDACTED).into_owned();
+    out = assignment_re()
+        .replace_all(&out, "$1=[REDACTED]")
+        .into_owned();
+    out = jwt_re().replace_all(&out, REDACTED).into_owned();
+    out = url_userinfo_re()
+        .replace_all(&out, format!("$1{}@", REDACTED))
+        .into_owned();
+    for probe in SECRET_PROBES {
+        out = out.replace(probe, REDACTED);
+    }
+    out
+}
+
+pub fn redact_field(name: &str, value: &str) -> String {
+    if name.eq_ignore_ascii_case("authorization")
+        || name.to_ascii_lowercase().ends_with(".authorization")
+    {
+        REDACTED.to_string()
+    } else {
+        redact_string(value)
+    }
+}
+
+pub fn redact_json(value: Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(redact_string(&s)),
+        Value::Array(values) => Value::Array(values.into_iter().map(redact_json).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| {
+                    let redacted = if matches!(v, Value::String(_))
+                        && k.eq_ignore_ascii_case("authorization")
+                    {
+                        Value::String(REDACTED.to_string())
+                    } else {
+                        redact_json(v)
+                    };
+                    (k, redacted)
+                })
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_all_categories() {
+        let input = "Authorization: Bearer FAKETOKEN_OBSERVABILITY_PROBE password=hunter token=abc api_key=key eyJabc.def.ghi https://user:pass@example.com/path 32eff194-66bd";
+        let out = redact_string(input);
+        for forbidden in [
+            "FAKETOKEN_OBSERVABILITY_PROBE",
+            "hunter",
+            "token=abc",
+            "api_key=key",
+            "eyJabc.def.ghi",
+            "user:pass",
+            "32eff194-66bd",
+        ] {
+            assert!(!out.contains(forbidden), "leaked {forbidden} in {out}");
+        }
+        assert!(out.contains(REDACTED));
+    }
+
+    #[test]
+    fn authorization_field_is_fully_redacted() {
+        assert_eq!(redact_field("Authorization", "Basic abc"), REDACTED);
+    }
+
+    #[test]
+    fn nested_json_is_redacted() {
+        let value = serde_json::json!({"a":{"token":"Bearer FAKETOKEN_OBSERVABILITY_PROBE"}, "authorization":"abc"});
+        let raw = redact_json(value).to_string();
+        assert!(!raw.contains("FAKETOKEN_OBSERVABILITY_PROBE"));
+        assert!(!raw.contains("abc"));
+    }
+}

--- a/observability/src/resource.rs
+++ b/observability/src/resource.rs
@@ -1,0 +1,67 @@
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone)]
+pub struct Resource {
+    service_name: &'static str,
+    service_version: &'static str,
+    deployment_environment: Option<String>,
+    k8s_namespace_name: Option<String>,
+    k8s_pod_name: Option<String>,
+}
+
+impl Resource {
+    pub fn from_env(service_name: &'static str) -> Self {
+        Self {
+            service_name,
+            service_version: env!("CARGO_PKG_VERSION"),
+            deployment_environment: non_empty_env("POLYTOPE_ENV"),
+            k8s_namespace_name: non_empty_env("K8S_NAMESPACE_NAME"),
+            k8s_pod_name: non_empty_env("K8S_POD_NAME"),
+        }
+    }
+
+    pub fn as_json(&self) -> Value {
+        let mut map = Map::new();
+        map.insert("service.name".into(), self.service_name.into());
+        map.insert("service.version".into(), self.service_version.into());
+        if let Some(value) = &self.deployment_environment {
+            map.insert("deployment.environment".into(), value.clone().into());
+        }
+        if let Some(value) = &self.k8s_namespace_name {
+            map.insert("k8s.namespace.name".into(), value.clone().into());
+        }
+        if let Some(value) = &self.k8s_pod_name {
+            map.insert("k8s.pod.name".into(), value.clone().into());
+        }
+        Value::Object(map)
+    }
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn resource_reads_env_fields() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var("POLYTOPE_ENV", "dev");
+            std::env::set_var("K8S_NAMESPACE_NAME", "ns");
+            std::env::set_var("K8S_POD_NAME", "pod");
+        }
+        let json = Resource::from_env("svc").as_json();
+        assert_eq!(json["service.name"], "svc");
+        assert_eq!(json["deployment.environment"], "dev");
+        assert_eq!(json["k8s.namespace.name"], "ns");
+        assert_eq!(json["k8s.pod.name"], "pod");
+    }
+}

--- a/observability/src/test_helper.rs
+++ b/observability/src/test_helper.rs
@@ -1,0 +1,163 @@
+use crate::formatter::{JsonFieldFormatter, OtelJsonFormatter};
+use serde_json::Value;
+use std::io;
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone, Default)]
+pub struct CapturedLogs {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedLogs {
+    pub fn raw_lines(&self) -> Vec<String> {
+        let bytes = self.buffer.lock().unwrap().clone();
+        String::from_utf8_lossy(&bytes)
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+    pub fn json_lines(&self) -> Vec<Value> {
+        self.raw_lines()
+            .into_iter()
+            .map(|line| {
+                serde_json::from_str(&line).unwrap_or_else(|err| {
+                    panic!("captured log line was not valid JSON: {err}; line={line}")
+                })
+            })
+            .collect()
+    }
+    pub fn assert_required_fields(&self) {
+        for line in self.json_lines() {
+            assert!(
+                line.get("timestamp").and_then(Value::as_str).is_some(),
+                "missing timestamp: {line}"
+            );
+            assert!(
+                line.get("severityText").and_then(Value::as_str).is_some(),
+                "missing severityText: {line}"
+            );
+            assert!(
+                line.get("severityNumber").and_then(Value::as_u64).is_some(),
+                "missing severityNumber: {line}"
+            );
+            assert!(
+                line.get("body").and_then(Value::as_str).is_some(),
+                "missing body: {line}"
+            );
+            assert!(
+                line.pointer("/resource/service.name")
+                    .and_then(Value::as_str)
+                    .is_some(),
+                "missing resource.service.name: {line}"
+            );
+            assert!(
+                line.pointer("/resource/service.version")
+                    .and_then(Value::as_str)
+                    .is_some(),
+                "missing resource.service.version: {line}"
+            );
+            assert!(
+                line.pointer("/attributes/code.target")
+                    .and_then(Value::as_str)
+                    .is_some(),
+                "missing attributes.code.target: {line}"
+            );
+        }
+    }
+    pub fn assert_event_emitted(&self, event_name: &str) -> Value {
+        self.json_lines()
+            .into_iter()
+            .find(|line| line["attributes"]["event.name"] == event_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "event {event_name} was not emitted; events={:?}",
+                    self.event_names()
+                )
+            })
+    }
+    pub fn events_named(&self, event_name: &str) -> Vec<Value> {
+        self.json_lines()
+            .into_iter()
+            .filter(|line| line["attributes"]["event.name"] == event_name)
+            .collect()
+    }
+    pub fn assert_no_substring(&self, substring: &str) {
+        let raw = self.raw_lines().join("\n");
+        assert!(
+            !raw.contains(substring),
+            "captured logs contained forbidden substring"
+        );
+    }
+    fn event_names(&self) -> Vec<String> {
+        self.json_lines()
+            .iter()
+            .filter_map(|v| v["attributes"]["event.name"].as_str().map(str::to_string))
+            .collect()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct CaptureMakeWriter {
+    logs: CapturedLogs,
+}
+
+impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter {
+            buffer: self.logs.buffer.clone(),
+        }
+    }
+}
+
+pub struct CaptureWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub type CaptureLayer = tracing_subscriber::fmt::Layer<
+    tracing_subscriber::Registry,
+    JsonFieldFormatter,
+    OtelJsonFormatter,
+    CaptureMakeWriter,
+>;
+
+pub fn capturing_subscriber(service_name: &'static str) -> (CaptureLayer, CapturedLogs) {
+    let logs = CapturedLogs::default();
+    let writer = CaptureMakeWriter { logs: logs.clone() };
+    let layer = tracing_subscriber::fmt::layer()
+        .event_format(OtelJsonFormatter::new(service_name))
+        .fmt_fields(JsonFieldFormatter)
+        .with_writer(writer)
+        .with_ansi(false);
+    (layer, logs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::prelude::*;
+    #[test]
+    fn captures_json_and_helpers_work() {
+        let (layer, logs) = capturing_subscriber("svc");
+        let sub = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(sub);
+        tracing::info!(
+            "event.name" = "startup.config.loaded",
+            outcome = "success",
+            "loaded"
+        );
+        logs.assert_required_fields();
+        logs.assert_event_emitted("startup.config.loaded");
+        logs.assert_no_substring("FAKETOKEN_OBSERVABILITY_PROBE");
+    }
+}

--- a/observability/tests/test_helper.rs
+++ b/observability/tests/test_helper.rs
@@ -1,0 +1,17 @@
+use polytope_observability::test_helper::capturing_subscriber;
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn captured_logs_are_valid_json() {
+    let (layer, logs) = capturing_subscriber("svc");
+    let sub = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(sub);
+    tracing::warn!(
+        "event.name" = "startup.config.failed",
+        error = "Bearer FAKETOKEN_OBSERVABILITY_PROBE",
+        "failed"
+    );
+    logs.assert_required_fields();
+    logs.assert_event_emitted("startup.config.failed");
+    logs.assert_no_substring("FAKETOKEN_OBSERVABILITY_PROBE");
+}

--- a/workers/common/Cargo.toml
+++ b/workers/common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+polytope-observability = { path = "../../observability" }
 aws-config = { version = "1", default-features = false, features = ["rt-tokio", "credentials-process", "sso"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["rt-tokio", "http-1x", "rustls", "sigv4a"] }
 async-compression = { version = "0.4", features = ["tokio", "zstd", "gzip"] }
@@ -21,3 +22,4 @@ tokio-util = { version = "0.7", features = ["io"] }
 tower = "0.5"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/workers/common/src/delivery/bobs.rs
+++ b/workers/common/src/delivery/bobs.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use super::ResultDelivery;
+use super::{DeliveryContext, ResultDelivery, enduser_fields};
 use crate::Completion;
 
 pub(super) struct BobsPush {
@@ -17,20 +17,36 @@ impl ResultDelivery for BobsPush {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         metadata: &serde_json::Value,
+        context: DeliveryContext<'_>,
     ) -> Completion {
         let buffer_full =
             metadata.get("buffer_full_output").and_then(|v| v.as_bool()) == Some(true);
         match self
-            .push(content_type, content_encoding, body, buffer_full)
+            .push(
+                content_type,
+                content_encoding,
+                body,
+                buffer_full,
+                context.job_id,
+                context.user,
+            )
             .await
         {
             Ok(location) => Completion::Redirect {
                 location,
                 message: "result available for download".to_string(),
             },
-            Err(e) => Completion::Error {
-                message: format!("delivery failed: {e}"),
-            },
+            Err(e) => {
+                let (enduser_id, enduser_realm) = enduser_fields(context.user);
+                if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                    tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, error = %e, "result delivery failed");
+                } else {
+                    tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, error = %e, "result delivery failed");
+                }
+                Completion::Error {
+                    message: format!("delivery failed: {e}"),
+                }
+            }
         }
     }
 }
@@ -42,6 +58,8 @@ impl BobsPush {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         write_locked: bool,
+        job_id: &str,
+        user: &serde_json::Value,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let mut create_body = serde_json::json!({
             "content_type": content_type,
@@ -53,6 +71,7 @@ impl BobsPush {
         let create_resp = self
             .create_client
             .put(format!("{}/create", self.api_base))
+            .header("X-Polytope-Job-Id", job_id)
             .json(&create_body)
             .send()
             .await?;
@@ -77,6 +96,7 @@ impl BobsPush {
         let write_resp = self
             .body_client
             .post(format!("{}/write/{}/0", write_base, key))
+            .header("X-Polytope-Job-Id", job_id)
             .body(body)
             .send()
             .await?;
@@ -87,6 +107,7 @@ impl BobsPush {
         let complete_resp = self
             .body_client
             .post(format!("{}/complete/{}", write_base, key))
+            .header("X-Polytope-Job-Id", job_id)
             .send()
             .await?;
         if !complete_resp.status().is_success() {
@@ -97,7 +118,12 @@ impl BobsPush {
             .as_str()
             .ok_or("missing read_url in response")?
             .to_string();
-        tracing::info!(key = %key, read_url = %read_url, "result pushed to BOBS");
+        let (enduser_id, enduser_realm) = enduser_fields(user);
+        if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+            tracing::debug!("event.name" = "worker.delivery.completed", outcome = "success", job.id = %job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, bobs.key = %key, read_url = %read_url, "result pushed to BOBS");
+        } else {
+            tracing::debug!("event.name" = "worker.delivery.completed", outcome = "success", job.id = %job_id, bobs.key = %key, read_url = %read_url, "result pushed to BOBS");
+        }
         Ok(read_url)
     }
 }
@@ -108,7 +134,7 @@ mod tests {
     use axum::{
         Router,
         extract::{Path, State},
-        http::StatusCode,
+        http::{HeaderMap, StatusCode},
         routing::{post, put},
     };
     use std::sync::{Arc, Mutex};
@@ -118,14 +144,26 @@ mod tests {
         created_keys: Mutex<Vec<String>>,
         written_data: Mutex<Vec<u8>>,
         completed: Mutex<bool>,
+        job_headers: Mutex<Vec<String>>,
+    }
+
+    fn record_job_header(target: &Mutex<Vec<String>>, headers: &HeaderMap) {
+        let value = headers
+            .get("x-polytope-job-id")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        target.lock().unwrap().push(value);
     }
 
     async fn mock_create(
+        headers: HeaderMap,
         State(state): State<Arc<BobsState>>,
     ) -> (StatusCode, axum::Json<serde_json::Value>) {
         let key = "test-key-123".to_string();
         let read_url = format!("http://public.example.com/download-0/{key}");
         let write_url = state.base_url.clone();
+        record_job_header(&state.job_headers, &headers);
         state.created_keys.lock().unwrap().push(key.clone());
         (
             StatusCode::CREATED,
@@ -138,8 +176,10 @@ mod tests {
     async fn mock_write(
         Path((_key, _offset)): Path<(String, u64)>,
         State(state): State<Arc<BobsState>>,
+        headers: HeaderMap,
         body: axum::body::Body,
     ) -> StatusCode {
+        record_job_header(&state.job_headers, &headers);
         let data: Vec<u8> = axum::body::to_bytes(body, usize::MAX)
             .await
             .unwrap()
@@ -150,8 +190,10 @@ mod tests {
 
     async fn mock_complete(
         Path(_key): Path<String>,
+        headers: HeaderMap,
         State(state): State<Arc<BobsState>>,
     ) -> StatusCode {
+        record_job_header(&state.job_headers, &headers);
         *state.completed.lock().unwrap() = true;
         StatusCode::OK
     }
@@ -167,6 +209,7 @@ mod tests {
             created_keys: Mutex::new(vec![]),
             written_data: Mutex::new(vec![]),
             completed: Mutex::new(false),
+            job_headers: Mutex::new(vec![]),
         });
         let app = Router::new()
             .route("/create", put(mock_create))
@@ -192,6 +235,10 @@ mod tests {
                 None,
                 reqwest::Body::from(data.clone()),
                 &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                },
             )
             .await;
 
@@ -207,6 +254,10 @@ mod tests {
         }
         assert!(*state.completed.lock().unwrap());
         assert_eq!(*state.written_data.lock().unwrap(), data);
+        assert_eq!(
+            *state.job_headers.lock().unwrap(),
+            vec!["job-1", "job-1", "job-1"]
+        );
     }
 
     struct StreamingBobsState {
@@ -297,6 +348,10 @@ mod tests {
                 None,
                 body,
                 &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                },
             )
             .await;
 
@@ -335,6 +390,10 @@ mod tests {
                 None,
                 reqwest::Body::from(vec![]),
                 &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                },
             )
             .await;
 
@@ -380,6 +439,10 @@ mod tests {
                 None,
                 reqwest::Body::from(vec![]),
                 &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                },
             )
             .await;
 

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -4,6 +4,23 @@ use aws_config::BehaviorVersion;
 use crate::Completion;
 use crate::delivery_config::{DeliveryConfig, DeliveryType};
 
+#[derive(Debug, Clone, Copy)]
+pub struct DeliveryContext<'a> {
+    pub job_id: &'a str,
+    pub user: &'a serde_json::Value,
+}
+
+pub(crate) fn enduser_fields(user: &serde_json::Value) -> (Option<&str>, Option<&str>) {
+    (
+        user.get("auth")
+            .and_then(|auth| auth.get("username"))
+            .and_then(|value| value.as_str()),
+        user.get("auth")
+            .and_then(|auth| auth.get("realm"))
+            .and_then(|value| value.as_str()),
+    )
+}
+
 mod bobs;
 mod s3;
 
@@ -18,6 +35,7 @@ pub trait ResultDelivery: Send + Sync {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         metadata: &serde_json::Value,
+        context: DeliveryContext<'_>,
     ) -> Completion;
 }
 
@@ -105,6 +123,7 @@ impl ResultDelivery for DirectDelivery {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         metadata: &serde_json::Value,
+        _context: DeliveryContext<'_>,
     ) -> Completion {
         if metadata.get("buffer_full_output").and_then(|v| v.as_bool()) == Some(true) {
             return Completion::Error {

--- a/workers/common/src/delivery/s3.rs
+++ b/workers/common/src/delivery/s3.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::{
 };
 use bytes::BytesMut;
 
-use super::ResultDelivery;
+use super::{DeliveryContext, ResultDelivery};
 use crate::Completion;
 
 const S3_PART_SIZE_BYTES: usize = 5 * 1024 * 1024;
@@ -27,6 +27,7 @@ impl ResultDelivery for S3Push {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         _metadata: &serde_json::Value,
+        _context: DeliveryContext<'_>,
     ) -> Completion {
         match self.push(content_type, content_encoding, body).await {
             Ok(location) => Completion::Redirect {
@@ -246,6 +247,10 @@ mod tests {
                 Some("gzip"),
                 reqwest::Body::from(vec![1, 2, 3]),
                 &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                },
             )
             .await;
 

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod delivery_config;
 pub mod encoding;
 pub mod management;
 
-use crate::delivery::{ResultDelivery, make_delivery};
+use crate::delivery::{DeliveryContext, ResultDelivery, make_delivery};
 use crate::delivery_config::{Codec, DeliveryConfig};
 use crate::encoding::encode_stream;
 
@@ -138,6 +138,17 @@ pub struct WorkerConfig {
     pub worker_concurrency: usize,
 }
 
+fn enduser_fields(user: &serde_json::Value) -> (Option<&str>, Option<&str>) {
+    (
+        user.get("auth")
+            .and_then(|auth| auth.get("username"))
+            .and_then(|value| value.as_str()),
+        user.get("auth")
+            .and_then(|auth| auth.get("realm"))
+            .and_then(|value| value.as_str()),
+    )
+}
+
 impl WorkerConfig {
     pub fn work_url(&self) -> String {
         format!(
@@ -212,7 +223,7 @@ async fn worker_task<P: Processor + 'static>(
                 match result {
                     Ok(response) => response,
                     Err(err) => {
-                        tracing::warn!(broker_url = %config.broker_url, error = %err, "worker poll failed");
+                        tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, error = %err, "worker poll failed");
                         tokio::time::sleep(config.retry_backoff).await;
                         continue;
                     }
@@ -224,7 +235,7 @@ async fn worker_task<P: Processor + 'static>(
             continue;
         }
         if !response.status().is_success() {
-            tracing::warn!(broker_url = %config.broker_url, status = %response.status(), "worker poll returned unexpected status");
+            tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, status = %response.status(), "worker poll returned unexpected status");
             tokio::time::sleep(config.retry_backoff).await;
             continue;
         }
@@ -232,19 +243,26 @@ async fn worker_task<P: Processor + 'static>(
         let work: WorkItem = match response.json().await {
             Ok(work) => work,
             Err(err) => {
-                tracing::warn!(error = %err, "worker failed to decode work item");
+                tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", error = %err, "worker failed to decode work item");
                 tokio::time::sleep(config.retry_backoff).await;
                 continue;
             }
         };
 
-        tracing::info!(job_id = %work.job_id, "job started");
+        let (enduser_id, enduser_realm) = enduser_fields(&work.user);
+        if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job started");
+        } else {
+            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, "job started");
+        }
 
         let stop = std::sync::Arc::new(tokio::sync::Notify::new());
         let stop_heartbeat = stop.clone();
         let heartbeat_client = client.clone();
         let heartbeat_cfg = config.clone();
         let job_id = work.job_id.clone();
+        let heartbeat_enduser_id = enduser_id.map(str::to_string);
+        let heartbeat_enduser_realm = enduser_realm.map(str::to_string);
         let heartbeat = tokio::spawn(async move {
             loop {
                 tokio::select! {
@@ -253,8 +271,20 @@ async fn worker_task<P: Processor + 'static>(
                         match heartbeat_client.post(heartbeat_cfg.heartbeat_url(&job_id)).send().await {
                             Ok(resp) if resp.status() == StatusCode::OK => {}
                             Ok(resp) if resp.status() == StatusCode::NOT_FOUND => break,
-                            Ok(resp) => tracing::warn!(status=%resp.status(), job_id=%job_id, "heartbeat returned unexpected status"),
-                            Err(err) => tracing::warn!(error=%err, job_id=%job_id, "heartbeat request failed"),
+                            Ok(resp) => {
+                                if let (Some(enduser_id), Some(enduser_realm)) = (heartbeat_enduser_id.as_deref(), heartbeat_enduser_realm.as_deref()) {
+                                    tracing::warn!("event.name" = "worker.heartbeat.failed", outcome = "error", status=%resp.status(), job.id=%job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "heartbeat returned unexpected status")
+                                } else {
+                                    tracing::warn!("event.name" = "worker.heartbeat.failed", outcome = "error", status=%resp.status(), job.id=%job_id, "heartbeat returned unexpected status")
+                                }
+                            },
+                            Err(err) => {
+                                if let (Some(enduser_id), Some(enduser_realm)) = (heartbeat_enduser_id.as_deref(), heartbeat_enduser_realm.as_deref()) {
+                                    tracing::warn!("event.name" = "worker.heartbeat.failed", outcome = "error", error=%err, job.id=%job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "heartbeat request failed")
+                                } else {
+                                    tracing::warn!("event.name" = "worker.heartbeat.failed", outcome = "error", error=%err, job.id=%job_id, "heartbeat request failed")
+                                }
+                            },
                         }
                     }
                 }
@@ -274,11 +304,29 @@ async fn worker_task<P: Processor + 'static>(
                         content_encoding.as_deref(),
                         encoded,
                         &work.metadata,
+                        DeliveryContext {
+                            job_id: &work.job_id,
+                            user: &work.user,
+                        },
                     )
                     .await
             }
-            ProcessResult::Reject { reason } => Completion::Reject { reason },
-            ProcessResult::Error { message } => Completion::Error { message },
+            ProcessResult::Reject { reason } => {
+                if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                    tracing::warn!("event.name" = "worker.job.rejected", outcome = "rejected", job.id = %work.job_id, reason = %reason, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job rejected");
+                } else {
+                    tracing::warn!("event.name" = "worker.job.rejected", outcome = "rejected", job.id = %work.job_id, reason = %reason, "job rejected");
+                }
+                Completion::Reject { reason }
+            }
+            ProcessResult::Error { message } => {
+                if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                    tracing::error!("event.name" = "worker.job.failed", outcome = "error", job.id = %work.job_id, error = %message, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job failed");
+                } else {
+                    tracing::error!("event.name" = "worker.job.failed", outcome = "error", job.id = %work.job_id, error = %message, "job failed");
+                }
+                Completion::Error { message }
+            }
         };
 
         stop.notify_one();
@@ -331,9 +379,19 @@ async fn worker_task<P: Processor + 'static>(
                 (resp, "redirect")
             }
         };
-        tracing::info!(job_id = %work.job_id, outcome = outcome, "job completed");
+        if matches!(outcome, "data" | "redirect") {
+            if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job completed");
+            } else {
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, "job completed");
+            }
+        }
         if response.status() != StatusCode::OK && response.status() != StatusCode::NOT_FOUND {
-            tracing::warn!(status=%response.status(), job_id=%work.job_id, "worker completion returned unexpected status");
+            if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                tracing::error!("event.name" = "worker.job.failed", outcome = "error", status=%response.status(), job.id=%work.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "worker completion returned unexpected status");
+            } else {
+                tracing::error!("event.name" = "worker.job.failed", outcome = "error", status=%response.status(), job.id=%work.job_id, "worker completion returned unexpected status");
+            }
         }
     }
 
@@ -360,7 +418,12 @@ pub async fn run_worker_loop<P: Processor + 'static>(
             )
         });
     let management_port = management_listener.local_addr().unwrap().port();
-    tracing::info!(port = management_port, "management server listening");
+    tracing::info!(
+        "event.name" = "startup.server.listening",
+        outcome = "success",
+        port = management_port,
+        "management server listening"
+    );
     tokio::spawn(async move {
         axum::serve(management_listener, management_app)
             .await
@@ -398,10 +461,10 @@ pub async fn run_worker_loop<P: Processor + 'static>(
     let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
     tokio::select! {
         _ = sigterm.recv() => {
-            tracing::info!("received shutdown signal, completing in-flight work then exiting");
+            tracing::info!("event.name" = "startup.shutdown.received", outcome = "success", "received shutdown signal");
         }
         _ = tokio::signal::ctrl_c() => {
-            tracing::info!("received shutdown signal, completing in-flight work then exiting");
+            tracing::info!("event.name" = "startup.shutdown.received", outcome = "success", "received shutdown signal");
         }
     }
 
@@ -413,7 +476,11 @@ pub async fn run_worker_loop<P: Processor + 'static>(
             Err(err) => panic!("worker task failed: {err}"),
         }
     }
-    tracing::info!("graceful shutdown complete");
+    tracing::info!(
+        "event.name" = "startup.shutdown.complete",
+        outcome = "success",
+        "graceful shutdown complete"
+    );
 
     Ok(())
 }
@@ -433,6 +500,17 @@ mod tests {
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[test]
+    fn enduser_fields_extracts_username_and_realm_when_present() {
+        let user = serde_json::json!({"auth": {"username": "alice", "realm": "ecmwf"}});
+        assert_eq!(enduser_fields(&user), (Some("alice"), Some("ecmwf")));
+    }
+
+    #[test]
+    fn enduser_fields_omits_missing_user() {
+        assert_eq!(enduser_fields(&serde_json::json!({})), (None, None));
+    }
 
     #[derive(Default)]
     struct MockState {

--- a/workers/common/tests/observability.rs
+++ b/workers/common/tests/observability.rs
@@ -1,0 +1,35 @@
+use polytope_observability::test_helper::capturing_subscriber;
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn worker_events_have_required_fields_and_redact() {
+    let (layer, logs) = capturing_subscriber("polytope-worker-test");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::info!(
+        "event.name" = "worker.job.started",
+        outcome = "success",
+        job.id = "job-1",
+        "enduser.id" = "alice",
+        "enduser.realm" = "ecmwf",
+        "job started"
+    );
+    tracing::debug!(
+        "event.name" = "worker.delivery.completed",
+        outcome = "success",
+        job.id = "job-1",
+        bobs.key = "key",
+        read_url = "https://user:pass@example.com/result",
+        "delivery completed"
+    );
+
+    logs.assert_required_fields();
+    let started = logs.assert_event_emitted("worker.job.started");
+    assert_eq!(started["attributes"]["enduser.id"], "alice");
+    assert_eq!(started["attributes"]["enduser.realm"], "ecmwf");
+    assert!(started["attributes"].get("polytope.request").is_none());
+    logs.assert_event_emitted("worker.delivery.completed");
+    logs.assert_no_substring("FAKETOKEN_OBSERVABILITY_PROBE");
+    logs.assert_no_substring("user:pass");
+}

--- a/workers/fdb-worker/Cargo.toml
+++ b/workers/fdb-worker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+polytope-observability = { path = "../../observability" }
 async-trait = "0.1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }

--- a/workers/fdb-worker/Dockerfile
+++ b/workers/fdb-worker/Dockerfile
@@ -12,6 +12,7 @@ FROM chef-base AS chef
 ARG GIT_AUTH_TOKEN=""
 WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/fdb-worker/ workers/fdb-worker/
 RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml
@@ -27,6 +28,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 COPY --from=chef /ecmwf/polytope-server/workers/fdb-worker/recipe.json workers/fdb-worker/recipe.json
 COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
 RUN cd workers/fdb-worker && cargo chef cook --release --recipe-path recipe.json
@@ -40,6 +42,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 ARG PACKAGE_NAME=fdb-worker
 ARG BIN_NAME=fdb-worker
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/fdb-worker/ workers/fdb-worker/
 RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml

--- a/workers/fdb-worker/src/main.rs
+++ b/workers/fdb-worker/src/main.rs
@@ -5,7 +5,7 @@ use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, run_worker_loop};
 use rsfdb::{FDB, request::Request};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 struct FdbProcessor {
     fdb_config: String,
@@ -98,24 +98,21 @@ fn resolved_worker_concurrency(cli_value: usize) -> usize {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    polytope_observability::init_tracing("polytope-worker-fdb");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
     info!(worker_concurrency, "resolved worker concurrency");
-    let config = WorkerConfigFile::load(&cli.config_path)
-        .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
+    let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
+        std::process::exit(1);
+    });
+    tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config_path, "config loaded");
 
     let fdb_section = config.section("fdb").expect("config missing 'fdb' section");
     let fdb_config =
         serde_yml::to_string(fdb_section).expect("failed to serialize fdb config section");
 
-    info!(
-        path = cli.config_path,
-        fdb_config = fdb_config.as_str(),
-        "loaded config"
-    );
+    debug!(path = cli.config_path, "loaded fdb config section");
 
     run_worker_loop(
         WorkerConfig {

--- a/workers/mars-worker/Cargo.lock
+++ b/workers/mars-worker/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "kube",
  "libc",
  "mars-client",
+ "polytope-observability",
  "polytope-worker-common",
  "reqwest",
  "serde_json",
@@ -2124,6 +2125,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polytope-observability"
+version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "polytope-worker-common"
 version = "0.1.0"
 dependencies = [
@@ -2135,6 +2148,7 @@ dependencies = [
  "bytes",
  "futures",
  "http-body-util",
+ "polytope-observability",
  "reqwest",
  "serde",
  "serde_json",
@@ -2143,6 +2157,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.3",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2933,6 +2948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",

--- a/workers/mars-worker/Cargo.toml
+++ b/workers/mars-worker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+polytope-observability = { path = "../../observability" }
 async-trait = "0.1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }

--- a/workers/mars-worker/Dockerfile
+++ b/workers/mars-worker/Dockerfile
@@ -121,6 +121,7 @@ FROM chef-base AS chef
 ARG GIT_AUTH_TOKEN=""
 WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/mars-worker/ workers/mars-worker/
 RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml
@@ -143,6 +144,7 @@ ENV METKIT_INCLUDE_DIR=/opt/mars-client/include
 ENV METKIT_BUILD_INCLUDE_DIR=/opt/mars-client/include
 COPY --from=chef /ecmwf/polytope-server/workers/mars-worker/recipe.json workers/mars-worker/recipe.json
 COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
 RUN cd workers/mars-worker && cargo chef cook --release --recipe-path recipe.json
@@ -157,6 +159,7 @@ COPY Cargo.lock Cargo.lock
 ARG PACKAGE_NAME=mars-worker
 ARG BIN_NAME=mars-worker
 COPY --from=mars-libs /opt/mars-client /opt/mars-client
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/mars-worker/ workers/mars-worker/
 RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -153,17 +153,18 @@ fn resolved_worker_concurrency(cli_value: usize) -> usize {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    polytope_observability::init_tracing("polytope-worker-mars");
     mars_client::log_bridge::init();
 
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
     info!(worker_concurrency, "resolved worker concurrency");
 
-    let config = WorkerConfigFile::load(&cli.config_path)
-        .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
+    let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
+        std::process::exit(1);
+    });
+    tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config_path, "config loaded");
 
     let manager = NodePortManager::new(cli.mars_dhs_local_port).await?;
     // SAFETY: set once at startup before run_worker_loop spawns any processing threads;
@@ -173,7 +174,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::set_var("MARS_DHS_CALLBACK_HOST", manager.node_name());
         std::env::set_var("MARS_DHS_CALLBACK_PORT", manager.node_port().to_string());
     }
-    tracing::info!(
+    tracing::debug!(
         node_port = manager.node_port(),
         "NodePort service created, MARS DHS callback configured"
     );

--- a/workers/polytope-fe-worker/Cargo.toml
+++ b/workers/polytope-fe-worker/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+polytope-observability = { path = "../../observability" }
 async-trait = "0.1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }

--- a/workers/polytope-fe-worker/Dockerfile
+++ b/workers/polytope-fe-worker/Dockerfile
@@ -12,6 +12,7 @@ FROM chef-base AS chef
 ARG GIT_AUTH_TOKEN=""
 WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/polytope-fe-worker/ workers/polytope-fe-worker/
 RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml
@@ -27,6 +28,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 COPY --from=chef /ecmwf/polytope-server/workers/polytope-fe-worker/recipe.json workers/polytope-fe-worker/recipe.json
 COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
 RUN cd workers/polytope-fe-worker && cargo chef cook --release --recipe-path recipe.json
@@ -40,6 +42,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 ARG PACKAGE_NAME=polytope-fe-worker
 ARG BIN_NAME=polytope-fe-worker
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/polytope-fe-worker/ workers/polytope-fe-worker/
 RUN mkdir -p .cargo && echo '[net]' > .cargo/config.toml && echo 'git-fetch-with-cli = true' >> .cargo/config.toml

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -5,7 +5,7 @@ use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, r
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyTuple};
 use serde_json::json;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 struct PolytopeProcessor {
     config_path: String,
@@ -110,17 +110,18 @@ fn resolved_worker_concurrency(cli_value: usize) -> usize {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    polytope_observability::init_tracing("polytope-worker-polytope-fe");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
     info!(worker_concurrency, "resolved worker concurrency");
 
-    let config = WorkerConfigFile::load(&cli.config_path)
-        .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
+    let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
+        std::process::exit(1);
+    });
+    tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config_path, "config loaded");
 
-    info!(python_path = %cli.python_path, config_path = %cli.config_path, "initializing python interpreter");
+    debug!(python_path = %cli.python_path, config_path = %cli.config_path, "initializing python interpreter");
 
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| -> PyResult<()> {
@@ -129,13 +130,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         path.call_method1("insert", (0i32, &cli.python_path))?;
 
         let py_path: Vec<String> = path.extract()?;
-        info!(sys_path = ?py_path, "python sys.path configured");
+        debug!(sys_path = ?py_path, "python sys.path configured");
 
         let wrapper = py.import("run_polytope_worker")?;
-        info!("run_polytope_worker module imported");
+        debug!("run_polytope_worker module imported");
 
         wrapper.call_method1("_get_datasource", (&cli.config_path,))?;
-        info!("polytope datasource initialized");
+        debug!("polytope datasource initialized");
         Ok(())
     })?;
 

--- a/workers/test-worker/Cargo.toml
+++ b/workers/test-worker/Cargo.toml
@@ -8,6 +8,7 @@ name = "test_worker"
 path = "src/lib.rs"
 
 [dependencies]
+polytope-observability = { path = "../../observability" }
 async-trait = "0.1"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }

--- a/workers/test-worker/Dockerfile
+++ b/workers/test-worker/Dockerfile
@@ -12,6 +12,7 @@ FROM chef-base AS chef
 ARG GIT_AUTH_TOKEN=""
 WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/test-worker/ workers/test-worker/
 RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml
@@ -27,6 +28,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 COPY --from=chef /ecmwf/polytope-server/workers/test-worker/recipe.json workers/test-worker/recipe.json
 COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
 RUN cd workers/test-worker && cargo chef cook --release --recipe-path recipe.json
@@ -40,6 +42,7 @@ WORKDIR /ecmwf/polytope-server
 COPY Cargo.lock Cargo.lock
 ARG PACKAGE_NAME=test-worker
 ARG BIN_NAME=test-worker
+COPY observability/ observability/
 COPY workers/common/ workers/common/
 COPY workers/test-worker/ workers/test-worker/
 RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{WorkerConfig, run_worker_loop};
 use test_worker::*;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 #[derive(Parser)]
 struct Cli {
@@ -37,12 +37,15 @@ fn resolved_worker_concurrency(cli_value: usize) -> usize {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    polytope_observability::init_tracing("polytope-worker-test");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
     info!(worker_concurrency, "resolved worker concurrency");
-    let config = WorkerConfigFile::load(&cli.config_path)
-        .unwrap_or_else(|err| panic!("failed to load config at {}: {err}", cli.config_path));
+    let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
+        tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
+        std::process::exit(1);
+    });
+    tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config_path, "config loaded");
 
     let test_section = config
         .section("test")
@@ -52,12 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let test_config: TestConfig =
         serde_yml::from_value(test_section).expect("failed to parse 'test' config section");
 
-    info!(
-        path = cli.config_path,
-        behaviour = ?test_config.behaviour,
-        content_type = test_config.content_type.as_str(),
-        "loaded config"
-    );
+    debug!(path = cli.config_path, behaviour = ?test_config.behaviour, content_type = test_config.content_type.as_str(), "loaded test config section");
 
     run_worker_loop(
         WorkerConfig {


### PR DESCRIPTION
## Summary

Introduces a single internal-path `polytope-observability` crate consumed by `frontend` and every `workers/*` binary, replacing ad-hoc `tracing::info!` lines with a locked event taxonomy aligned with the [ECMWF Codex observability guidelines](https://github.com/ecmwf/codex/blob/main/Guidelines/Observability.md) and the OTel log data model.

## What changes

### New crate: `observability/`
- **`formatter`** — OTel-aligned JSON event writer. Fields: `timestamp` (RFC 3339 UTC), `severityText`, `severityNumber` (TRACE=1, DEBUG=5, INFO=9, WARN=13, ERROR=17), `body`, `resource`, `attributes`.
- **`resource`** — stable per-service block: `service.name`, `service.version`, `deployment.environment` (`POLYTOPE_ENV`), `k8s.namespace.name`, `k8s.pod.name`.
- **`redaction`** — in-app secret scrub. Authorization / Bearer, `password|token|api_key=` assignments, JWT-shaped tokens, URL userinfo, known test credentials. Applied recursively to strings AND JSON values.
- **`bounded_request*`** — port of the Python \`_bound_logging_value\` helper. Strings truncated at 1000 chars, lists summarised as \`{_summary, count, preview}\` past 100 items (first 10 shown). 32 KiB hard cap as backstop.
- **`env_filter`** — defaults \`info\`, accepts standard \`RUST_LOG\`.
- **`test_helper`** — capturing layer for per-crate tests.

### Wiring
- Frontend (\`frontend/src/api/{v1,v2,openmeteo/mod,mod}.rs\`, \`auth/middleware.rs\`, \`main.rs\`): every \`api.*\` event emits via the new formatter; \`enduser.id\` / \`enduser.realm\` attached from the authenticated \`AuthUser\` (absent on unauthenticated paths).
- Workers (\`workers/common/src/lib.rs\`, \`workers/common/src/delivery/{mod,bobs,s3}.rs\`, every worker \`main.rs\`): every \`worker.*\` event emits via the formatter; user fields extracted from \`WorkItem.user.auth.{username,realm}\` — no propagation changes needed.
- Worker → BOBS: \`X-Polytope-Job-Id\` header forwarded with the broker-issued id (server-side strict-validated in BOBS).
- Dockerfiles for frontend + every worker updated to copy the new \`observability/\` crate.

### Locked event taxonomy

| Family | Events |
| --- | --- |
| api | \`api.collection.list\`, \`api.auth.{rejected,mock_accepted}\`, \`api.job.{submitted,rejected,cancelled}\`, \`api.job.poll.{completed,pending(DEBUG),failed,cancelled}\` (with \`reason\` attribute), \`api.openmeteo.{processed,failed}\` |
| worker | \`worker.job.{started,completed,failed,rejected}\`, \`worker.delivery.{completed(DEBUG),failed}\`, \`worker.heartbeat.failed\`, \`worker.broker.poll.failed\` |
| startup | \`startup.config.{loaded,failed}\`, \`startup.server.listening\`, \`startup.shutdown.{received,complete}\` |

\`polytope.request\` payload is captured **only** on \`api.job.submitted\` (bounded and redacted).

\`job.id\` is the single cross-service correlator (frontend → worker → BOBS).