### PR TITLE
Rust load generator + soak mode; FE-worker gribjump/metadata; worker/broker/frontend updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -265,12 +265,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authotron"
-version = "0.3.3"
-source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=main#0b82917f8fc147a14605cf5f8c33ad941ff7028f"
+version = "0.3.6"
+source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=main#025c96afe5d3edc11f51a0292c28874dc61d9264"
 dependencies = [
  "aide",
  "async-trait",
- "authotron-types",
+ "authotron-types 0.1.0 (git+https://github.com/ecmwf/auth-o-tron.git?branch=main)",
  "axum",
  "base64",
  "cached",
@@ -295,9 +295,9 @@ dependencies = [
 [[package]]
 name = "authotron-client"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=main#0b82917f8fc147a14605cf5f8c33ad941ff7028f"
+source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=fix%2Fcoalesce-auth-cache#8efcd06fe416bf0f56b8605e13904e6d7016f5c1"
 dependencies = [
- "authotron-types",
+ "authotron-types 0.1.0 (git+https://github.com/ecmwf/auth-o-tron.git?branch=fix%2Fcoalesce-auth-cache)",
  "chrono",
  "jsonwebtoken",
  "moka",
@@ -310,7 +310,16 @@ dependencies = [
 [[package]]
 name = "authotron-types"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=main#0b82917f8fc147a14605cf5f8c33ad941ff7028f"
+source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=fix%2Fcoalesce-auth-cache#8efcd06fe416bf0f56b8605e13904e6d7016f5c1"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "authotron-types"
+version = "0.1.0"
+source = "git+https://github.com/ecmwf/auth-o-tron.git?branch=main#025c96afe5d3edc11f51a0292c28874dc61d9264"
 dependencies = [
  "serde",
  "serde_json",
@@ -1187,7 +1196,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1743,7 +1752,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1914,7 +1923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2604,7 +2613,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2825,7 +2834,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3031,6 +3040,12 @@ checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3411,7 +3426,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3808,7 +3823,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "authotron-client",
- "authotron-types",
+ "authotron-types 0.1.0 (git+https://github.com/ecmwf/auth-o-tron.git?branch=fix%2Fcoalesce-auth-cache)",
  "axum",
  "bits",
  "bytes",
@@ -3971,6 +3986,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,8 +4016,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 2.0.18",
 ]
@@ -4081,7 +4120,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4119,7 +4158,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4501,6 +4540,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4508,8 +4560,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4602,7 +4654,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5167,7 +5219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5314,10 +5366,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys 0.60.2",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6103,7 +6155,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?rev=d6ceded4324652739f5e6a79c14bf72550e3eecf#d6ceded4324652739f5e6a79c14bf72550e3eecf"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=91738d28464cc14e8ee4bfba546c4d040b4768fd#91738d28464cc14e8ee4bfba546c4d040b4768fd"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2613,7 +2613,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4120,7 +4120,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4158,7 +4158,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "loadgen"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?rev=91738d28464cc14e8ee4bfba546c4d040b4768fd#91738d28464cc14e8ee4bfba546c4d040b4768fd"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=ec18c4c7b528cf1cb9e3ce4d7e2aa04bb3e37ac3#ec18c4c7b528cf1cb9e3ce4d7e2aa04bb3e37ac3"
 dependencies = [
  "async-nats",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "observability",
     "frontend",
+    "loadgen",
     "client",
     "tests/integration",
     "workers/common",

--- a/docs/job-metadata-options.md
+++ b/docs/job-metadata-options.md
@@ -1,0 +1,84 @@
+# Job Metadata Options
+
+## Overview
+
+Job metadata is a trusted server-side key-value store attached to each job. It carries configuration and policy decisions made by routing rules, authentication middleware, and other trusted server components. **Client requests cannot write to job metadata** — it is isolated from user-controllable input.
+
+## Trust Boundary
+
+Metadata exists on the server side of the trust boundary:
+
+- **Trusted sources**: Routing configuration, authentication middleware, admin override headers (after auth), transform actions in routing rules.
+- **Untrusted sources**: Client request JSON body, query parameters, most HTTP headers.
+
+Client-supplied fields such as `metadata`, `polytope_mars`, `pre_path`, `use_catalogue`, and similar keys in the request body **must never** be merged into `job.metadata`. The server treats these as part of the user-controlled request and routes/validates them separately.
+
+## Reserved Metadata Keys
+
+The following metadata keys are reserved for specific trusted purposes:
+
+- `cost`: Job cost estimation or billing data
+- `admin_overrides`: Admin-controlled overrides (e.g., `mock_now_rfc3339` for time mocking)
+- `accept_encoding`: Negotiated content encoding from HTTP headers
+- `buffer_full_output`: Flag to buffer complete output before delivery (e.g., for v1 API compatibility)
+- `polytope_mars`: Trusted datacube and options configuration for Polytope FE workers (see below)
+
+Additional keys may be added by specific transform actions or middleware components. Always preserve existing keys unless explicitly overwriting a single key by design.
+
+## The `set_metadata` Transform Action
+
+The `set_metadata` action allows routing configuration to write or overwrite a single top-level key in `job.metadata`. It is **config-only** — the value is supplied entirely by the routing YAML and never interpolates or merges data from the client request.
+
+### Configuration
+
+```yaml
+type: set_metadata
+key: <string>
+value: <any JSON value>
+```
+
+- `key`: The metadata key to write or overwrite.
+- `value`: The value to set. Can be any JSON type (object, array, string, number, boolean, null).
+
+### Behavior
+
+- Writes or **overwrites** only the specified `key` in `job.metadata`.
+- **Never** replaces the entire metadata map.
+- Preserves all other existing metadata keys.
+- If metadata is not an object (edge case), it is replaced with an empty object before writing the key.
+- **Does not** read, merge, or interpolate any fields from the client request.
+
+### Example: Setting Polytope MARS Options
+
+```yaml
+broker:
+  transforms:
+    - id: attach-climate-dt-fe-options
+      type: set_metadata
+      key: polytope_mars
+      value:
+        datacube: climate-dt
+        options:
+          axis_config:
+            class_time_step_type_to_steps: ...
+          pre_path:
+            - climate-dt
+          use_catalogue: catalogue1
+          engine_options:
+            datacube_version: 1
+```
+
+When this transform runs, `job.metadata["polytope_mars"]` is set to the configured object. The value is sourced **only** from the trusted routing configuration, never from client request fields such as `request.polytope_mars`, `request.metadata`, `request.pre_path`, or `request.use_catalogue`.
+
+## Usage in Workers
+
+Workers receive `job.metadata` as part of the work payload. The FE worker, for example, reads `metadata["polytope_mars"]` to overlay trusted datacube and options onto the per-request Polytope configuration, ensuring that dataset-specific FDB paths, catalogue selection, and engine options are controlled by routing policy rather than user input.
+
+## Security Considerations
+
+1. **Never merge request fields into metadata**. Client-supplied keys must remain in `job.request` only.
+2. **Preserve trusted keys**. When adding new metadata, do not overwrite `cost`, `admin_overrides`, or other reserved keys unless that is the explicit intent.
+3. **Config-only values**. Transform actions like `set_metadata` must only write static values from the routing configuration, never dynamically constructed values derived from the request.
+4. **Routing controls structure**. Critical options such as `pre_path`, `use_catalogue`, `datacube`, and `engine_options` must be supplied via metadata from trusted routing rules, not read from the client request JSON.
+
+By maintaining this separation, the server can safely route requests to dataset-specific configurations and enforce access policies without risking request-controlled structural options or privilege escalation.

--- a/examples/set-metadata-routing.yaml
+++ b/examples/set-metadata-routing.yaml
@@ -1,0 +1,123 @@
+# Example: Using set_metadata to Attach Trusted Job Metadata
+#
+# This example demonstrates how the `set_metadata` transform action attaches
+# trusted configuration to jobs during routing, without reading or merging
+# client request fields.
+#
+# Use case: A polytope deployment serves multiple datasets (climate-dt, extremes-dt, ng)
+# from a single worker pool. Each dataset requires different FDB paths, catalogue
+# selection, and datacube configuration. Routing rules discriminate by dataset and
+# attach the correct trusted options via job.metadata, which the FE worker then
+# reads to configure the Polytope data source.
+
+broker:
+  # Define reusable transforms for each dataset's metadata
+  transforms:
+    - id: attach-climate-dt-fe-options
+      type: set_metadata
+      key: polytope_mars
+      value:
+        datacube: climate-dt
+        options:
+          axis_config:
+            class_time_step_type_to_steps:
+              d1__4__an: [0]
+              d1__24__fc: [0, 6, 12, 18]
+          pre_path:
+            - climate-dt
+          use_catalogue: catalogue1
+          engine_options:
+            datacube_version: 1
+
+    - id: attach-extremes-dt-fe-options
+      type: set_metadata
+      key: polytope_mars
+      value:
+        datacube: extremes-dt
+        options:
+          axis_config:
+            class_time_step_type_to_steps:
+              d1__24__fc: [0]
+          pre_path:
+            - extremes-dt
+          use_catalogue: catalogue3
+          engine_options:
+            datacube_version: 2
+
+    - id: attach-ng-fe-options
+      type: set_metadata
+      key: polytope_mars
+      value:
+        datacube: ng
+        options:
+          axis_config:
+            class_time_step_type_to_steps:
+              ng__6__cf: [0, 6]
+          pre_path:
+            - ng
+          use_catalogue: catalogue4
+          engine_options:
+            datacube_version: 1
+
+  # Example routes: each dataset-specific route attaches its trusted metadata
+  # before forwarding to the worker pool. Client request fields like
+  # `polytope_mars`, `pre_path`, `use_catalogue` are NEVER read or merged.
+  routes:
+    - name: climate-dt-feature-extraction
+      match:
+        - check: match
+          request.dataset: [climate-dt]
+          request.class: [d1]
+        - check: has_key
+          keys: [feature, country]
+      actions:
+        # Normalize and validate request
+        - transform: metkit_expansion
+        # Attach trusted FE options for climate-dt (config-only, no request interpolation)
+        - transform: attach-climate-dt-fe-options
+        # Route to FE worker pool
+        - target: polytope_fe_pool
+
+    - name: extremes-dt-privileged-old-data
+      match:
+        - check: match
+          request.dataset: [extremes-dt]
+        - check: has_role
+          ecmwf: [polytope-admin, unrestricted-extremes]
+      actions:
+        - transform: metkit_expansion
+        # Attach trusted FE options for extremes-dt
+        - transform: attach-extremes-dt-fe-options
+        - target: polytope_fe_pool
+
+    - name: extremes-dt-recent-data-only
+      match:
+        - check: match
+          request.dataset: [extremes-dt]
+        - check: date_checker
+          allowed_values: ["< 15d"]
+      actions:
+        - transform: metkit_expansion
+        # Same trusted metadata; access is gated by date check, not by different config
+        - transform: attach-extremes-dt-fe-options
+        - target: polytope_fe_pool
+
+    - name: ng-direct-retrieval
+      match:
+        - check: match
+          request.dataset: [ng]
+          request.class: [ng]
+      actions:
+        - transform: metkit_expansion
+        # Attach trusted FE options for ng
+        - transform: attach-ng-fe-options
+        - target: polytope_fe_pool
+
+# Security note:
+# - The `value` field in each set_metadata transform is sourced ONLY from this
+#   trusted routing configuration file, never from client request JSON.
+# - Even if a client sends { "polytope_mars": {...}, "pre_path": "evil", ... },
+#   those fields remain in job.request and are NOT merged into job.metadata.
+# - The FE worker reads job.metadata["polytope_mars"] to configure the data source,
+#   ensuring that datacube selection, FDB paths, and catalogue choice are
+#   controlled by routing policy, not by user input.

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", branch = "master" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "d6ceded4324652739f5e6a79c14bf72550e3eecf", features = ["nats"] }
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "91738d28464cc14e8ee4bfba546c4d040b4768fd", features = ["nats"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", branch = "master" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "91738d28464cc14e8ee4bfba546c4d040b4768fd", features = ["nats"] }
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "ec18c4c7b528cf1cb9e3ce4d7e2aa04bb3e37ac3", features = ["nats"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -36,8 +36,11 @@ roxmltree = "0.20"
 metkit = { path = "../utils/metkit", optional = true }
 
 # Auth (shared crate from auth-o-tron workspace)
-authotron-client = { git = "https://github.com/ecmwf/auth-o-tron.git", branch = "main" }
-authotron-types = { git = "https://github.com/ecmwf/auth-o-tron.git", branch = "main" }
+# TEMP test pin: ecmwf/auth-o-tron#72 (single-flight auth cache). Revert to
+# branch = "main" once the PR merges. client/types are byte-identical to the
+# previously-pinned rev except for the cache fix.
+authotron-client = { git = "https://github.com/ecmwf/auth-o-tron.git", branch = "fix/coalesce-auth-cache" }
+authotron-types = { git = "https://github.com/ecmwf/auth-o-tron.git", branch = "fix/coalesce-auth-cache" }
 
 [features]
 default = []

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -61,6 +61,7 @@ COPY utils/metkit/ utils/metkit/
 COPY observability/ observability/
 COPY frontend/ frontend/
 COPY client/ client/
+COPY loadgen/ loadgen/
 COPY tests/integration/ tests/integration/
 COPY workers/common/ workers/common/
 COPY workers/polytope-fe-worker/ workers/polytope-fe-worker/

--- a/frontend/src/actions/mod.rs
+++ b/frontend/src/actions/mod.rs
@@ -10,4 +10,5 @@ mod date_check;
 mod schedule;
 mod transform_coercion;
 mod transform_defaults;
+mod transform_metadata;
 mod transform_patch;

--- a/frontend/src/actions/transform_metadata.rs
+++ b/frontend/src/actions/transform_metadata.rs
@@ -1,0 +1,192 @@
+use async_trait::async_trait;
+use bits::Job;
+use bits::actions::{ActionError, TransformAction, TransformResult};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetMetadata {
+    pub key: String,
+    pub value: Value,
+}
+
+#[async_trait]
+impl TransformAction for SetMetadata {
+    async fn execute(&self, job: &mut Job) -> Result<TransformResult, ActionError> {
+        let metadata = job.metadata_mut();
+
+        // Ensure metadata is an object; if not, replace with empty object
+        if !metadata.is_object() {
+            *metadata = serde_json::json!({});
+        }
+
+        // Write or overwrite only the configured key; preserve all other keys
+        metadata
+            .as_object_mut()
+            .expect("metadata is object after check")
+            .insert(self.key.clone(), self.value.clone());
+
+        Ok(TransformResult::Continue)
+    }
+}
+
+bits::register_action!(transform, "set_metadata", SetMetadata);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn writes_new_metadata_key() {
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "polytope_mars",
+            "value": {"datacube": "test", "options": {"foo": "bar"}}
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({}));
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        assert_eq!(
+            job.metadata["polytope_mars"],
+            json!({"datacube": "test", "options": {"foo": "bar"}})
+        );
+    }
+
+    #[tokio::test]
+    async fn overwrites_existing_key() {
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "polytope_mars",
+            "value": {"datacube": "new", "options": {"baz": "qux"}}
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({}));
+        job.metadata_mut()["polytope_mars"] =
+            json!({"datacube": "old", "options": {"old": "data"}});
+
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        assert_eq!(
+            job.metadata["polytope_mars"],
+            json!({"datacube": "new", "options": {"baz": "qux"}})
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_unrelated_trusted_metadata() {
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "polytope_mars",
+            "value": {"datacube": "test"}
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({}));
+        job.metadata_mut()["cost"] = json!(123);
+        job.metadata_mut()["admin_overrides"] = json!({"mock_now_rfc3339": "2040-05-06T07:08:09Z"});
+        job.metadata_mut()["accept_encoding"] = json!("gzip");
+        job.metadata_mut()["buffer_full_output"] = json!(true);
+
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        assert_eq!(job.metadata["polytope_mars"], json!({"datacube": "test"}));
+        assert_eq!(job.metadata["cost"], json!(123));
+        assert_eq!(
+            job.metadata["admin_overrides"],
+            json!({"mock_now_rfc3339": "2040-05-06T07:08:09Z"})
+        );
+        assert_eq!(job.metadata["accept_encoding"], json!("gzip"));
+        assert_eq!(job.metadata["buffer_full_output"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn handles_non_object_metadata() {
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "polytope_mars",
+            "value": {"datacube": "test"}
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({}));
+        *job.metadata_mut() = json!("not an object");
+
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        assert_eq!(job.metadata["polytope_mars"], json!({"datacube": "test"}));
+        assert!(job.metadata.is_object());
+    }
+
+    #[tokio::test]
+    async fn does_not_read_request_fields() {
+        // This test proves that the action only reads from its static config value,
+        // never from client request fields like metadata, polytope_mars, pre_path, or use_catalogue.
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "polytope_mars",
+            "value": {"datacube": "config-supplied", "options": {"source": "trusted-routing"}}
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({
+            "metadata": {"client": "should-not-appear"},
+            "polytope_mars": {"client": "should-not-appear"},
+            "pre_path": "client-controlled",
+            "use_catalogue": true
+        }));
+
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        // Only the config value appears in metadata, not the request fields
+        assert_eq!(
+            job.metadata["polytope_mars"],
+            json!({"datacube": "config-supplied", "options": {"source": "trusted-routing"}})
+        );
+        // Request fields are unchanged
+        assert_eq!(
+            job.request["metadata"],
+            json!({"client": "should-not-appear"})
+        );
+        assert_eq!(
+            job.request["polytope_mars"],
+            json!({"client": "should-not-appear"})
+        );
+        assert_eq!(job.request["pre_path"], json!("client-controlled"));
+        assert_eq!(job.request["use_catalogue"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn preserves_metadata_when_request_contains_similar_keys() {
+        // Prove that even when the request contains keys with similar names,
+        // only the config value is written to metadata
+        let action: SetMetadata = serde_json::from_value(json!({
+            "key": "cost",
+            "value": 999
+        }))
+        .unwrap();
+
+        let mut job = Job::new(json!({
+            "cost": 42,
+            "admin_overrides": {"client": "controlled"}
+        }));
+        job.metadata_mut()["existing_cost"] = json!(555);
+
+        let result = action.execute(&mut job).await.unwrap();
+
+        assert!(matches!(result, TransformResult::Continue));
+        // The config value overwrites the metadata key
+        assert_eq!(job.metadata["cost"], json!(999));
+        // But the request fields are untouched
+        assert_eq!(job.request["cost"], json!(42));
+        assert_eq!(
+            job.request["admin_overrides"],
+            json!({"client": "controlled"})
+        );
+        // Other metadata is preserved
+        assert_eq!(job.metadata["existing_cost"], json!(555));
+    }
+}

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::{
     Extension, Json,
@@ -101,7 +101,9 @@ pub async fn submit_request(
     super::set_job_mock_time_metadata(&mut job, mock_time_extensions.mock_time.as_ref());
 
     let submitted_request = job.request.clone();
+    let enqueue_started = Instant::now();
     let handle = route_handle.submit(job);
+    let enqueue_ms = enqueue_started.elapsed().as_millis() as u64;
     super::audit_mock_job_submission(
         mock_audit.as_ref().map(|Extension(audit)| audit),
         &handle.id,
@@ -112,9 +114,9 @@ pub async fn submit_request(
     );
 
     if let Some(Extension(user)) = auth_user.as_ref() {
-        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, enqueue_ms, "enduser.id" = %user.username, "enduser.realm" = %user.realm, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
     } else {
-        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
+        tracing::info!("event.name" = "api.job.submitted", outcome = "success", job.id = %handle.id, enqueue_ms, polytope.request = %polytope_observability::request(&submitted_request), "job submitted");
     }
     let location = format!("/api/v1/requests/{}", handle.id);
     (

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -115,6 +115,13 @@ pub async fn auth_middleware(
                 Ok(mock_user) => mock_user,
                 Err(err) => return bad_request(&err.message()),
             };
+            // A mock username must come with mock roles, so the synthetic
+            // identity never silently inherits the admin's realm/roles.
+            if mock_user.is_some() && mock_roles.is_none() {
+                return bad_request(
+                    "Polytope-Mock-User requires Polytope-Mock-Roles to set the mock identity's realm/roles",
+                );
+            }
 
             if (mock_roles.is_some() || mock_time.is_some() || mock_user.is_some())
                 && !is_admin_bypass_user(&user, &state.admin_bypass_roles)

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::{
     Json,
@@ -69,6 +70,9 @@ pub async fn auth_middleware(
         }
     };
 
+    let prof_t0 = Instant::now();
+    let prof_method = req.method().to_string();
+    let prof_path = req.uri().path().to_string();
     let auth_header = match req.headers().get(header::AUTHORIZATION) {
         Some(value) => match value.to_str() {
             Ok(s) if !s.is_empty() => s.to_string(),
@@ -86,7 +90,10 @@ pub async fn auth_middleware(
         }
     };
 
-    match auth_client.authenticate(&auth_header).await {
+    let prof_auth_started = Instant::now();
+    let prof_auth_result = auth_client.authenticate(&auth_header).await;
+    let prof_auth_ms = prof_auth_started.elapsed().as_millis() as u64;
+    match prof_auth_result {
         Ok(user) => {
             tracing::debug!(
                 username = user.username.as_str(),
@@ -177,7 +184,16 @@ pub async fn auth_middleware(
             };
 
             req.extensions_mut().insert(effective_user);
-            next.run(req).await
+            let prof_response = next.run(req).await;
+            tracing::debug!(
+                "event.name" = "api.request.profiled",
+                method = %prof_method,
+                path = %prof_path,
+                auth_ms = prof_auth_ms,
+                total_ms = prof_t0.elapsed().as_millis() as u64,
+                "request profiled"
+            );
+            prof_response
         }
         Err(AuthError::Unauthorized {
             message,

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -13,8 +13,8 @@ use axum::{
 use serde_json::json;
 
 use super::mock_roles::{
-    MOCK_ROLES_HEADER, MockRolesAudit, REQUEST_ID_HEADER, has_mock_roles_header,
-    parse_mock_roles_header,
+    MockRolesAudit, REQUEST_ID_HEADER, has_mock_roles_header, has_mock_user_header,
+    parse_mock_roles_header, parse_mock_user_header,
 };
 use super::mock_time::{
     MOCK_TIME_HEADER, MockTimeAudit, has_mock_time_header, normalise_mocked_now,
@@ -58,8 +58,9 @@ pub async fn auth_middleware(
     req: Request<Body>,
     next: Next,
 ) -> Response {
-    let mock_header_present =
-        has_mock_roles_header(req.headers()) || has_mock_time_header(req.headers());
+    let mock_header_present = has_mock_roles_header(req.headers())
+        || has_mock_time_header(req.headers())
+        || has_mock_user_header(req.headers());
     let auth_client = match &state.auth_client {
         Some(client) => client,
         None => {
@@ -110,8 +111,12 @@ pub async fn auth_middleware(
                 Ok(mock_time) => mock_time,
                 Err(err) => return bad_request(&err.message()),
             };
+            let mock_user = match parse_mock_user_header(req.headers()) {
+                Ok(mock_user) => mock_user,
+                Err(err) => return bad_request(&err.message()),
+            };
 
-            if (mock_roles.is_some() || mock_time.is_some())
+            if (mock_roles.is_some() || mock_time.is_some() || mock_user.is_some())
                 && !is_admin_bypass_user(&user, &state.admin_bypass_roles)
             {
                 return forbidden("Polytope mock headers require a configured admin user");
@@ -149,12 +154,17 @@ pub async fn auth_middleware(
                 req.extensions_mut().insert(audit);
             }
 
-            let effective_user = if let Some(mock_roles) = mock_roles {
+            let effective_user = if mock_roles.is_some() || mock_user.is_some() {
+                let mocked_username = mock_user.clone().unwrap_or_else(|| user.username.clone());
+                let (mocked_realm, mocked_roles) = match &mock_roles {
+                    Some(mock_roles) => (mock_roles.realm.clone(), mock_roles.roles.clone()),
+                    None => (user.realm.clone(), user.roles.clone()),
+                };
                 let audit = MockRolesAudit {
                     real_username: user.username.clone(),
                     real_realm: user.realm.clone(),
-                    mocked_realm: mock_roles.realm.clone(),
-                    mocked_roles: mock_roles.roles.clone(),
+                    mocked_realm: mocked_realm.clone(),
+                    mocked_roles: mocked_roles.clone(),
                     path,
                     request_id,
                 };
@@ -162,20 +172,20 @@ pub async fn auth_middleware(
                     "event.name" = "api.auth.mock_accepted",
                     real_username = audit.real_username.as_str(),
                     real_realm = audit.real_realm.as_str(),
+                    mocked_username = mocked_username.as_str(),
                     mocked_realm = audit.mocked_realm.as_str(),
                     mocked_roles = ?audit.mocked_roles,
                     path = audit.path.as_str(),
                     request_id = audit.request_id.as_deref(),
-                    header = MOCK_ROLES_HEADER,
-                    "accepted mocked-role request"
+                    "accepted mocked request"
                 );
                 req.extensions_mut().insert(audit);
 
                 AuthUser {
                     version: user.version,
-                    username: user.username,
-                    realm: mock_roles.realm,
-                    roles: mock_roles.roles,
+                    username: mocked_username,
+                    realm: mocked_realm,
+                    roles: mocked_roles,
                     attributes: HashMap::new(),
                     scopes: HashMap::new(),
                 }

--- a/frontend/src/auth/mock_roles.rs
+++ b/frontend/src/auth/mock_roles.rs
@@ -123,9 +123,98 @@ pub fn parse_mock_roles_value(
     })
 }
 
+pub const MOCK_USER_HEADER: &str = "polytope-mock-user";
+
+/// Mocked usernames must carry this prefix so an admin (via admin_bypass_roles)
+/// can only impersonate clearly-synthetic identities (e.g. load-test users),
+/// never a real account.
+pub const MOCK_USER_PREFIX: &str = "mock-";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MockUserError {
+    MultipleValues,
+    NonUtf8,
+    ControlCharacter,
+    Empty,
+    BadPrefix,
+    TooLong,
+}
+
+impl MockUserError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::MultipleValues => "Polytope-Mock-User must be supplied at most once".to_string(),
+            Self::NonUtf8 => "Polytope-Mock-User must be valid UTF-8".to_string(),
+            Self::ControlCharacter => {
+                "Polytope-Mock-User must not contain control characters".to_string()
+            }
+            Self::Empty => "Polytope-Mock-User must not be empty".to_string(),
+            Self::BadPrefix => format!("Polytope-Mock-User must start with '{MOCK_USER_PREFIX}'"),
+            Self::TooLong => "Polytope-Mock-User must be at most 64 characters".to_string(),
+        }
+    }
+}
+
+pub fn has_mock_user_header(headers: &HeaderMap) -> bool {
+    headers.contains_key(MOCK_USER_HEADER)
+}
+
+pub fn parse_mock_user_header(headers: &HeaderMap) -> Result<Option<String>, MockUserError> {
+    let name = HeaderName::from_static(MOCK_USER_HEADER);
+    let mut values = headers.get_all(&name).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(MockUserError::MultipleValues);
+    }
+    let value = value.to_str().map_err(|_| MockUserError::NonUtf8)?;
+    parse_mock_user_value(value).map(Some)
+}
+
+pub fn parse_mock_user_value(value: &str) -> Result<String, MockUserError> {
+    if value.chars().any(char::is_control) {
+        return Err(MockUserError::ControlCharacter);
+    }
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(MockUserError::Empty);
+    }
+    if value.len() > 64 {
+        return Err(MockUserError::TooLong);
+    }
+    if !value.starts_with(MOCK_USER_PREFIX) {
+        return Err(MockUserError::BadPrefix);
+    }
+    Ok(value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mock_user_accepts_mock_prefix_and_rejects_real_usernames() {
+        // Synthetic mock identities are accepted.
+        assert_eq!(parse_mock_user_value("mock-18").unwrap(), "mock-18");
+        assert_eq!(parse_mock_user_value("  mock-abc  ").unwrap(), "mock-abc");
+        // Real-looking usernames cannot be impersonated (no mock- prefix).
+        assert_eq!(parse_mock_user_value("majh"), Err(MockUserError::BadPrefix));
+        assert_eq!(
+            parse_mock_user_value("admin"),
+            Err(MockUserError::BadPrefix)
+        );
+        // Degenerate inputs are rejected.
+        assert_eq!(parse_mock_user_value(""), Err(MockUserError::Empty));
+        assert_eq!(
+            parse_mock_user_value("mock-\u{0007}x"),
+            Err(MockUserError::ControlCharacter)
+        );
+        assert_eq!(
+            parse_mock_user_value(&format!("mock-{}", "x".repeat(70))),
+            Err(MockUserError::TooLong)
+        );
+    }
     use axum::http::HeaderValue;
 
     fn bypass() -> Option<HashMap<String, Vec<String>>> {

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -132,6 +132,8 @@ pub struct HttpConfig {
     pub host: String,
     #[serde(default = "default_port")]
     pub port: u16,
+    #[serde(default)]
+    pub internal_poll_port: Option<u16>,
 }
 
 impl Default for HttpConfig {
@@ -139,6 +141,7 @@ impl Default for HttpConfig {
         Self {
             host: default_host(),
             port: default_port(),
+            internal_poll_port: None,
         }
     }
 }
@@ -194,6 +197,12 @@ impl ServerConfig {
 
     pub fn bind_addr(&self) -> String {
         format!("{}:{}", self.server.host, self.server.port)
+    }
+
+    pub fn internal_poll_bind_addr(&self) -> Option<String> {
+        self.server
+            .internal_poll_port
+            .map(|port| format!("{}:{}", self.server.host, port))
     }
 }
 
@@ -297,6 +306,26 @@ authentication:
         assert_eq!(auth.secret, "testsecret");
         assert_eq!(auth.timeout_ms, 5000);
         assert!(!auth.allow_anonymous);
+    }
+
+    #[test]
+    fn internal_poll_config_parses_port_and_bind_addr() {
+        let yaml = config_with_polytope(
+            r#"server:
+  host: "127.0.0.1"
+  port: 3000
+  internal_poll_port: 9002
+bits: {}
+"#,
+        );
+        let cfg: ServerConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        assert_eq!(cfg.server.internal_poll_port, Some(9002));
+        assert_eq!(cfg.bind_addr(), "127.0.0.1:3000");
+        assert_eq!(
+            cfg.internal_poll_bind_addr().as_deref(),
+            Some("127.0.0.1:9002")
+        );
     }
 
     #[test]

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -192,30 +192,49 @@ impl ServerConfig {
             serde_yaml::Value::String(self.polytope.env.clone()),
         );
 
-        if let Ok(pod_ip) = std::env::var("POD_IP")
-            && !pod_ip.trim().is_empty()
-        {
-            let worker_server_key = serde_yaml::Value::String("worker_server".to_string());
-            if let Some(worker_server) = inner
+        // A `worker_server` block means this broker dispatches to remote-pool
+        // workers, which must send completion/heartbeat callbacks back to THIS
+        // specific broker instance. bits derives that direct callback address
+        // from `advertised_addr`, which we populate from POD_IP. If POD_IP is
+        // missing, bits' `callback_url` is `None` and workers silently fall back
+        // to the load-balanced broker URL — completion callbacks then land on a
+        // random broker, are dropped, and the job is stranded in-progress with
+        // an un-reclaimable durable record. Fail loud rather than silently
+        // misroute (a silent fallback previously masked exactly this bug).
+        let worker_server_key = serde_yaml::Value::String("worker_server".to_string());
+        if inner.contains_key(&worker_server_key) {
+            let pod_ip = std::env::var("POD_IP").unwrap_or_default();
+            let pod_ip = pod_ip.trim();
+            if pod_ip.is_empty() {
+                return Err(<serde_yaml::Error as serde::ser::Error>::custom(
+                    "bits.worker_server is configured but POD_IP is empty or unset: cannot \
+                     advertise a direct worker-callback address. Refusing to start to avoid \
+                     load-balanced callback misrouting that strands jobs. Ensure the frontend \
+                     pod sets POD_IP from status.podIP (downward API).",
+                ));
+            }
+            let worker_server = inner
                 .get_mut(&worker_server_key)
                 .and_then(serde_yaml::Value::as_mapping_mut)
-            {
-                let port = worker_server
-                    .get(serde_yaml::Value::String("port".to_string()))
-                    .and_then(serde_yaml::Value::as_u64)
-                    .and_then(|port| u16::try_from(port).ok())
-                    .unwrap_or(9001);
-                let pod_ip = pod_ip.trim();
-                let advertised_addr = if pod_ip.contains(':') && !pod_ip.starts_with('[') {
-                    format!("[{pod_ip}]:{port}")
-                } else {
-                    format!("{pod_ip}:{port}")
-                };
-                worker_server.insert(
-                    serde_yaml::Value::String("advertised_addr".to_string()),
-                    serde_yaml::Value::String(advertised_addr),
-                );
-            }
+                .ok_or_else(|| {
+                    <serde_yaml::Error as serde::ser::Error>::custom(
+                        "bits.worker_server must be a mapping",
+                    )
+                })?;
+            let port = worker_server
+                .get(serde_yaml::Value::String("port".to_string()))
+                .and_then(serde_yaml::Value::as_u64)
+                .and_then(|port| u16::try_from(port).ok())
+                .unwrap_or(9001);
+            let advertised_addr = if pod_ip.contains(':') && !pod_ip.starts_with('[') {
+                format!("[{pod_ip}]:{port}")
+            } else {
+                format!("{pod_ip}:{port}")
+            };
+            worker_server.insert(
+                serde_yaml::Value::String("advertised_addr".to_string()),
+                serde_yaml::Value::String(advertised_addr),
+            );
         }
 
         serde_yaml::to_string(&bits)
@@ -356,6 +375,29 @@ bits: {}
                 .get("advertised_addr")
                 .and_then(|v| v.as_str()),
             Some("10.1.2.3:9001")
+        );
+    }
+
+    #[test]
+    fn bits_yaml_errors_when_worker_server_present_but_pod_ip_missing() {
+        let _guard = env_lock();
+        remove_pod_ip();
+
+        let yaml = config_with_polytope(
+            r#"bits:
+  bits:
+    worker_server:
+      host: "0.0.0.0"
+      port: 9001
+"#,
+        );
+        let cfg: ServerConfig = serde_yaml::from_str(&yaml).unwrap();
+        let err = cfg
+            .bits_yaml()
+            .expect_err("worker_server without POD_IP must hard-fail");
+        assert!(
+            err.to_string().contains("POD_IP"),
+            "error should mention POD_IP: {err}"
         );
     }
 

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -192,6 +192,32 @@ impl ServerConfig {
             serde_yaml::Value::String(self.polytope.env.clone()),
         );
 
+        if let Ok(pod_ip) = std::env::var("POD_IP")
+            && !pod_ip.trim().is_empty()
+        {
+            let worker_server_key = serde_yaml::Value::String("worker_server".to_string());
+            if let Some(worker_server) = inner
+                .get_mut(&worker_server_key)
+                .and_then(serde_yaml::Value::as_mapping_mut)
+            {
+                let port = worker_server
+                    .get(serde_yaml::Value::String("port".to_string()))
+                    .and_then(serde_yaml::Value::as_u64)
+                    .and_then(|port| u16::try_from(port).ok())
+                    .unwrap_or(9001);
+                let pod_ip = pod_ip.trim();
+                let advertised_addr = if pod_ip.contains(':') && !pod_ip.starts_with('[') {
+                    format!("[{pod_ip}]:{port}")
+                } else {
+                    format!("{pod_ip}:{port}")
+                };
+                worker_server.insert(
+                    serde_yaml::Value::String("advertised_addr".to_string()),
+                    serde_yaml::Value::String(advertised_addr),
+                );
+            }
+        }
+
         serde_yaml::to_string(&bits)
     }
 
@@ -209,6 +235,21 @@ impl ServerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    fn set_pod_ip(value: &str) {
+        unsafe { std::env::set_var("POD_IP", value) };
+    }
+
+    fn remove_pod_ip() {
+        unsafe { std::env::remove_var("POD_IP") };
+    }
 
     fn config_with_polytope(body: &str) -> String {
         format!(
@@ -286,6 +327,55 @@ bits: {}
             .expect("injected YAML should contain inner bits BitsConfig block");
         assert_eq!(inner.get("site").and_then(|v| v.as_str()), Some("bol"));
         assert_eq!(inner.get("env").and_then(|v| v.as_str()), Some("dev"));
+    }
+
+    #[test]
+    fn bits_yaml_injects_worker_server_advertised_addr_from_pod_ip() {
+        let _guard = env_lock();
+        set_pod_ip("10.1.2.3");
+
+        let yaml = config_with_polytope(
+            r#"bits:
+  bits:
+    worker_server:
+      host: "0.0.0.0"
+      port: 9001
+"#,
+        );
+        let cfg: ServerConfig = serde_yaml::from_str(&yaml).unwrap();
+        let bits_yaml = cfg.bits_yaml().unwrap();
+        remove_pod_ip();
+
+        let bits_cfg: serde_yaml::Value = serde_yaml::from_str(&bits_yaml).unwrap();
+        let worker_server = bits_cfg
+            .get("bits")
+            .and_then(|bits| bits.get("worker_server"))
+            .expect("inner worker_server should exist");
+        assert_eq!(
+            worker_server
+                .get("advertised_addr")
+                .and_then(|v| v.as_str()),
+            Some("10.1.2.3:9001")
+        );
+    }
+
+    #[test]
+    fn bits_yaml_does_not_create_worker_server_for_pod_ip() {
+        let _guard = env_lock();
+        set_pod_ip("10.1.2.3");
+
+        let yaml = config_with_polytope("bits: {}\n");
+        let cfg: ServerConfig = serde_yaml::from_str(&yaml).unwrap();
+        let bits_yaml = cfg.bits_yaml().unwrap();
+        remove_pod_ip();
+
+        let bits_cfg: serde_yaml::Value = serde_yaml::from_str(&bits_yaml).unwrap();
+        assert!(
+            bits_cfg
+                .get("bits")
+                .and_then(|bits| bits.get("worker_server"))
+                .is_none()
+        );
     }
 
     #[test]

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -152,6 +152,12 @@ pub fn build_app(
     Ok((app, state))
 }
 
+pub fn build_internal_poll_app(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/internal/poll/{id}", get(api::v2::poll))
+        .with_state(state)
+}
+
 /// BitsSubmitter wraps Arc<AppState> to implement the polytope_edr::RequestSubmitter trait.
 struct BitsSubmitter {
     state: Arc<AppState>,
@@ -208,6 +214,46 @@ impl polytope_edr::RequestSubmitter for BitsSubmitter {
 mod tests {
     use super::*;
 
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    fn internal_poll_test_config(auth: bool) -> config::ServerConfig {
+        let authentication = if auth {
+            r#"
+authentication:
+  url: "http://127.0.0.1:1"
+  secret: "testsecret"
+"#
+        } else {
+            ""
+        };
+        let yaml = format!(
+            r#"
+polytope:
+  site: bol
+  env: dev
+bits: {{}}
+{authentication}"#
+        );
+        serde_yaml::from_str(&yaml).expect("test config should parse")
+    }
+
+    async fn response_status(app: Router, method: axum::http::Method, path: &str) -> StatusCode {
+        app.oneshot(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+    }
+
     #[tokio::test]
     async fn request_id_config_server_emits_new_format_request_id() {
         let yaml = r#"
@@ -229,6 +275,76 @@ bits: {}
 
         assert_eq!(decoded.site, "bol");
         assert_eq!(decoded.env, "dev");
+    }
+
+    #[tokio::test]
+    async fn internal_poll_router_exposes_only_internal_poll_get() {
+        let (_, state) = build_app(internal_poll_test_config(false)).unwrap();
+        let app = build_internal_poll_app(state);
+
+        let poll_status = response_status(
+            app.clone(),
+            axum::http::Method::GET,
+            "/internal/poll/unknown-request-id",
+        )
+        .await;
+        assert_eq!(poll_status, StatusCode::NOT_FOUND);
+
+        for path in [
+            "/api/v1/test",
+            "/api/v2/health",
+            "/api/v2/collections",
+            "/api/v2/requests/unknown-request-id",
+            "/api/v2/ecmwf/requests",
+            "/openmeteo/v1/forecast",
+        ] {
+            let status = response_status(app.clone(), axum::http::Method::GET, path).await;
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "{path} should not be mounted"
+            );
+        }
+
+        let submit_status = response_status(
+            app.clone(),
+            axum::http::Method::POST,
+            "/internal/poll/unknown-request-id",
+        )
+        .await;
+        assert_eq!(submit_status, StatusCode::METHOD_NOT_ALLOWED);
+
+        let cancel_status = response_status(
+            app,
+            axum::http::Method::DELETE,
+            "/internal/poll/unknown-request-id",
+        )
+        .await;
+        assert_eq!(cancel_status, StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn internal_poll_is_auth_exempt_while_public_poll_remains_protected() {
+        let (public_app, state) = build_app(internal_poll_test_config(true)).unwrap();
+        let internal_app = build_internal_poll_app(state);
+
+        let public_status = response_status(
+            public_app,
+            axum::http::Method::GET,
+            "/api/v2/requests/unknown-request-id",
+        )
+        .await;
+        assert_eq!(public_status, StatusCode::UNAUTHORIZED);
+
+        let internal_status = response_status(
+            internal_app,
+            axum::http::Method::GET,
+            "/internal/poll/unknown-request-id",
+        )
+        .await;
+        assert_eq!(internal_status, StatusCode::NOT_FOUND);
+        assert_ne!(internal_status, StatusCode::UNAUTHORIZED);
+        assert_ne!(internal_status, StatusCode::FORBIDDEN);
     }
 
     #[test]

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
     tracing::info!("event.name" = "startup.config.loaded", outcome = "success", config_path = %cli.config, "config loaded");
 
     let bind_addr = cfg.bind_addr();
+    let internal_poll_bind_addr = cfg.internal_poll_bind_addr();
 
     let (app, state) = polytope_server::build_app(cfg).unwrap_or_else(|e| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", error = %e, "failed to build app");
@@ -35,6 +36,24 @@ async fn main() {
             std::process::exit(1);
         });
     tracing::info!("event.name" = "startup.server.listening", outcome = "success", addr = %listener.local_addr().unwrap(), "server listening");
+
+    if let Some(internal_poll_bind_addr) = internal_poll_bind_addr {
+        let internal_poll_listener = tokio::net::TcpListener::bind(&internal_poll_bind_addr)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("event.name" = "startup.config.failed", outcome = "error", bind_addr = %internal_poll_bind_addr, error = %e, "failed to bind internal poll listener");
+                std::process::exit(1);
+            });
+        tracing::info!("event.name" = "startup.internal_poll.listening", outcome = "success", addr = %internal_poll_listener.local_addr().unwrap(), "internal poll listener listening");
+        let internal_poll_app = polytope_server::build_internal_poll_app(state.clone());
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(internal_poll_listener, internal_poll_app).await {
+                tracing::error!("event.name" = "startup.internal_poll.failed", outcome = "error", error = %error, "internal poll listener failed");
+                std::process::exit(1);
+            }
+        });
+    }
+
     let result = axum::serve(listener, app).await;
     tracing::info!(
         "event.name" = "startup.shutdown.complete",

--- a/loadgen/Cargo.toml
+++ b/loadgen/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "loadgen"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+futures-util = "0.3"
+reqwest = { version = "0.12.20", default-features = false, features = ["json", "stream", "rustls-tls", "http2"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }

--- a/loadgen/Dockerfile
+++ b/loadgen/Dockerfile
@@ -1,0 +1,58 @@
+###############################
+# Shared base: Rust + cargo-chef + system deps
+###############################
+FROM docker.io/library/rust:1.93-slim-bookworm AS chef-base
+RUN cargo install cargo-chef --locked
+RUN apt-get update && apt-get install -y git pkg-config build-essential libssl-dev && rm -rf /var/lib/apt/lists/*
+
+###############################
+# Stage 1: Prepare Cargo Chef Recipe
+###############################
+FROM chef-base AS chef
+ARG GIT_AUTH_TOKEN=""
+WORKDIR /ecmwf/polytope-server
+COPY Cargo.lock Cargo.lock
+COPY loadgen/ loadgen/
+RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml
+RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
+RUN cd loadgen && cargo chef prepare --recipe-path recipe.json
+
+###############################
+# Stage 2: Cache Dependencies
+###############################
+FROM chef-base AS cacher
+ARG GIT_AUTH_TOKEN=""
+WORKDIR /ecmwf/polytope-server
+COPY Cargo.lock Cargo.lock
+COPY --from=chef /ecmwf/polytope-server/loadgen/recipe.json loadgen/recipe.json
+COPY --from=chef /ecmwf/polytope-server/.cargo/config.toml .cargo/config.toml
+RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
+RUN cd loadgen && cargo chef cook --release --recipe-path recipe.json
+
+###############################
+# Stage 3: Build the Project
+###############################
+FROM chef-base AS builder
+ARG GIT_AUTH_TOKEN=""
+WORKDIR /ecmwf/polytope-server
+COPY Cargo.lock Cargo.lock
+ARG PACKAGE_NAME=loadgen
+ARG BIN_NAME=loadgen
+COPY loadgen/ loadgen/
+RUN mkdir -p .cargo && echo "[net]" > .cargo/config.toml && echo "git-fetch-with-cli = true" >> .cargo/config.toml
+COPY --from=cacher /ecmwf/polytope-server/loadgen/target loadgen/target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+RUN if [ -n "$GIT_AUTH_TOKEN" ]; then git config --global url."https://${GIT_AUTH_TOKEN}@github.com/".insteadOf "https://github.com/"; fi
+RUN cd loadgen && cargo build --release -p ${PACKAGE_NAME}
+
+###############################
+# Stage 4: Production Release Image
+###############################
+FROM docker.io/library/debian:bookworm-slim AS release
+ARG VERSION
+ARG BIN_NAME=loadgen
+LABEL version=$VERSION
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /ecmwf/polytope-server/loadgen/target/release/${BIN_NAME} /app/loadgen
+ENTRYPOINT ["/app/loadgen"]

--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -1,0 +1,38 @@
+# loadgen
+
+Single-pod async load generator for Polytope BOBS download flow.
+
+## Environment variables
+
+Required:
+
+- `LOADGEN_FRONTEND_URL`: frontend base URL with no trailing slash.
+- `LOADGEN_COLLECTION`: collection for `POST /api/v1/requests/<collection>`.
+- `LOADGEN_AUTH`: full `Authorization` header value.
+- `LOADGEN_PAYLOAD_JSON`: JSON value used as the request body's `request` field; the binary wraps it as `{"verb":"retrieve","request":...}`.
+- `LOADGEN_BOBS_SVC_TEMPLATE`: internal BOBS service URL template, e.g. `http://rel-bobs-{ordinal}:3000`.
+
+Optional:
+
+- `LOADGEN_MOCK_REALM`: enables per-request mock identity when non-empty.
+- `LOADGEN_MOCK_ROLE`: default `default`.
+- `LOADGEN_MOCK_USER_PREFIX`: default `mock-`.
+- `LOADGEN_WARMUP_ITERS`: default `5`.
+- `LOADGEN_CONCURRENCY`: default `64`.
+- `LOADGEN_TOTAL_ITERS`: default `512`.
+- `LOADGEN_RAMP_SECONDS`: default `30`.
+- `LOADGEN_POLL_INTERVAL_MS`: default `250`.
+- `LOADGEN_POLL_TIMEOUT_S`: default `600`.
+- `LOADGEN_MAX_ERROR_RATE`: default `0.01`.
+
+## Docker build
+
+```sh
+docker build -f loadgen/Dockerfile \
+  --build-arg PACKAGE_NAME=loadgen \
+  --build-arg BIN_NAME=loadgen \
+  --build-arg GIT_AUTH_TOKEN="$GIT_AUTH_TOKEN" \
+  -t polytope-loadgen .
+```
+
+The binary emits one `LOADGEN_SUMMARY:{...}` JSON line for log scraping.

--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -19,8 +19,10 @@ Optional:
 - `LOADGEN_MOCK_USER_PREFIX`: default `mock-`.
 - `LOADGEN_WARMUP_ITERS`: default `5`.
 - `LOADGEN_CONCURRENCY`: default `64`.
-- `LOADGEN_TOTAL_ITERS`: default `512`.
-- `LOADGEN_RAMP_SECONDS`: default `30`.
+- `LOADGEN_TOTAL_ITERS`: default `512`; used when `LOADGEN_DURATION_S` is unset.
+- `LOADGEN_DURATION_S`: enables wall-clock duration mode. New requests stop at the deadline and in-flight requests drain.
+- `LOADGEN_RPS`: optional with `LOADGEN_DURATION_S`; when set, uses open-model starts capped by `LOADGEN_CONCURRENCY` and counts saturated starts as `missed_starts`. When unset, duration mode keeps concurrency filled in a closed loop until the deadline.
+- `LOADGEN_RAMP_SECONDS`: default `30`; ramps iteration/closed-loop concurrency or open-model offered rate.
 - `LOADGEN_POLL_INTERVAL_MS`: default `250`.
 - `LOADGEN_POLL_TIMEOUT_S`: default `600`.
 - `LOADGEN_MAX_ERROR_RATE`: default `0.01`.
@@ -35,4 +37,6 @@ docker build -f loadgen/Dockerfile \
   -t polytope-loadgen .
 ```
 
-The binary emits one `LOADGEN_SUMMARY:{...}` JSON line for log scraping.
+The binary emits one `LOADGEN_SUMMARY:{...}` JSON line for log scraping. With `LOADGEN_PROGRESS_INTERVAL_MS` unset it also emits redaction-safe `LOADGEN_PROGRESS:{...}` snapshots every second; set it to `0` to disable progress.
+
+Summary output includes `run_limit`, target/submission/drain durations, `scheduled`, `missed_starts`, and one-minute `time_buckets` with downloaded/error counts, bytes, throughput, error rate, and ready-latency p95. Summary/progress/config serialization deliberately excludes `LOADGEN_AUTH`, `Authorization`, `POLYTOPE_EMAIL`, and `POLYTOPE_KEY` values.

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -203,6 +203,16 @@ pub struct Summary {
     pub bytes_total: u64,
     pub per_stream_mibps: StreamPercentiles,
     pub aggregate_mibps: f64,
+    /// Peak sustained read throughput over any [`PEAK_WINDOW_S`]-wide window.
+    ///
+    /// Unlike `aggregate_mibps` (total bytes / first-read-to-last-read span),
+    /// this is not diluted by ramp-up or a heavy-tailed single-stream drain: a
+    /// mixed-size workload whose largest object reads back alone for minutes
+    /// stretches the `aggregate_mibps` denominator, whereas this captures the
+    /// dense concurrent-read plateau. See [`compute_peak_windowed_mibps`].
+    pub peak_windowed_mibps: f64,
+    /// Window width (seconds) used for `peak_windowed_mibps`.
+    pub peak_window_s: f64,
     pub throughput_rps: f64,
     pub success_rate: f64,
     pub error_rate: f64,
@@ -301,6 +311,7 @@ pub fn summarize(
     let mut bytes_total = 0u64;
     let mut first_read_start: Option<Instant> = None;
     let mut last_read_end: Option<Instant> = None;
+    let mut read_intervals: Vec<(Instant, Instant, u64)> = Vec::new();
 
     for result in results {
         if result.submit_ms.is_some() {
@@ -336,6 +347,9 @@ pub fn summarize(
         if let Some(end) = result.read_end {
             last_read_end = Some(last_read_end.map_or(end, |current| current.max(end)));
         }
+        if let (Some(start), Some(end)) = (result.read_start, result.read_end) {
+            read_intervals.push((start, end, result.bytes));
+        }
     }
 
     let total = results.len();
@@ -353,6 +367,22 @@ pub fn summarize(
         (bytes_total as f64 / 1_048_576.0) / read_span_s
     } else {
         0.0
+    };
+    let peak_windowed_mibps = match first_read_start {
+        Some(origin) => {
+            let relative: Vec<(f64, f64, u64)> = read_intervals
+                .iter()
+                .map(|&(start, end, bytes)| {
+                    (
+                        (start - origin).as_secs_f64(),
+                        (end - origin).as_secs_f64(),
+                        bytes,
+                    )
+                })
+                .collect();
+            compute_peak_windowed_mibps(&relative, PEAK_WINDOW_S)
+        }
+        None => 0.0,
     };
     let throughput_rps = if duration_s > 0.0 {
         counts.downloaded as f64 / duration_s
@@ -374,11 +404,114 @@ pub fn summarize(
         bytes_total,
         per_stream_mibps: stream_percentiles(&per_stream_mibps),
         aggregate_mibps,
+        peak_windowed_mibps,
+        peak_window_s: PEAK_WINDOW_S,
         throughput_rps,
         success_rate,
         error_rate,
         duration_s,
     }
+}
+
+/// Window width (seconds) for the peak sustained-throughput metric. A 10s
+/// window smooths per-request jitter while still isolating the dense
+/// concurrent-read plateau from ramp-up and the heavy-tailed drain.
+const PEAK_WINDOW_S: f64 = 10.0;
+
+/// Peak sustained read throughput (MiB/s) over any `window_s`-wide window.
+///
+/// Each download is modeled as delivering its bytes at a constant rate across
+/// its `[start, end]` interval; the instantaneous aggregate rate is the sum
+/// over concurrently-active downloads. This returns the maximum average
+/// throughput over any window of width `window_s`.
+///
+/// `intervals` are `(start_s, end_s, bytes)` relative to a common origin. The
+/// constant-rate-per-read assumption is an approximation (no per-chunk
+/// timestamps), but the windowed maximum reliably captures the plateau where
+/// reads overlap densely, which `aggregate_mibps` understates whenever object
+/// sizes (and therefore read durations) are skewed.
+fn compute_peak_windowed_mibps(intervals: &[(f64, f64, u64)], window_s: f64) -> f64 {
+    if intervals.is_empty() || window_s <= 0.0 {
+        return 0.0;
+    }
+
+    // Rate-change events: +rate at start, -rate at end. Zero/negative-duration
+    // reads are spread over a tiny epsilon so the modeled rate stays finite.
+    let mut events: Vec<(f64, f64)> = Vec::with_capacity(intervals.len() * 2);
+    let mut min_t = f64::INFINITY;
+    let mut max_t = f64::NEG_INFINITY;
+    for &(start, end, bytes) in intervals {
+        let end = if end > start { end } else { start + 1e-6 };
+        let rate = bytes as f64 / (end - start);
+        events.push((start, rate));
+        events.push((end, -rate));
+        min_t = min_t.min(start);
+        max_t = max_t.max(end);
+    }
+    events.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    // Collapse to unique breakpoint times with the active rate on each segment
+    // [times[k], times[k+1]) and the cumulative bytes delivered at times[k].
+    let mut times: Vec<f64> = Vec::new();
+    let mut seg_rate: Vec<f64> = Vec::new();
+    let mut cur_rate = 0.0;
+    let mut i = 0;
+    while i < events.len() {
+        let t = events[i].0;
+        while i < events.len() && events[i].0 == t {
+            cur_rate += events[i].1;
+            i += 1;
+        }
+        times.push(t);
+        seg_rate.push(cur_rate.max(0.0));
+    }
+    let mut cum: Vec<f64> = Vec::with_capacity(times.len());
+    cum.push(0.0);
+    for k in 0..times.len().saturating_sub(1) {
+        cum.push(cum[k] + seg_rate[k] * (times[k + 1] - times[k]));
+    }
+
+    // C(t): cumulative bytes delivered by time t (piecewise linear).
+    let cumulative = |t: f64| -> f64 {
+        if t <= times[0] {
+            return 0.0;
+        }
+        if t >= *times.last().unwrap() {
+            return *cum.last().unwrap();
+        }
+        let k = match times.binary_search_by(|x| x.total_cmp(&t)) {
+            Ok(k) => k,
+            Err(k) => k - 1,
+        };
+        cum[k] + seg_rate[k] * (t - times[k])
+    };
+
+    let span = max_t - min_t;
+    if span <= window_s {
+        // Whole run fits in one window: the windowed peak is just the overall
+        // read-span average (no tail to exclude).
+        let bytes: f64 = intervals.iter().map(|&(_, _, b)| b as f64).sum();
+        let denom = if span > 0.0 { span } else { window_s };
+        return (bytes / 1_048_576.0) / denom;
+    }
+
+    // (C(t+W) - C(t)) is piecewise linear in t with breakpoints where t or
+    // t+W crosses a segment boundary, so its maximum is at one of those
+    // candidate positions.
+    let lo = min_t;
+    let hi = max_t - window_s;
+    let mut best = 0.0;
+    for &bp in &times {
+        for cand in [bp, bp - window_s] {
+            let t = cand.clamp(lo, hi);
+            let delivered = cumulative(t + window_s) - cumulative(t);
+            let mibps = (delivered / 1_048_576.0) / window_s;
+            if mibps > best {
+                best = mibps;
+            }
+        }
+    }
+    best
 }
 
 fn percentiles(values: &[f64]) -> Percentiles {
@@ -522,5 +655,34 @@ mod tests {
         assert_eq!(summary.throughput_rps, 2.0 / 6.0);
         assert!((summary.error_rate - (1.0 / 3.0)).abs() < f64::EPSILON);
         assert_eq!(summary.per_stream_mibps.mean, Some(1.0));
+        // 3 MiB over a 3s read span (< 10s window) => falls back to span avg.
+        assert_eq!(summary.peak_window_s, 10.0);
+        assert!((summary.peak_windowed_mibps - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn peak_windowed_throughput_excludes_sparse_tail() {
+        let mib = 1_048_576u64;
+        // A fast 100 MiB read in [0,1]s alongside a slow 100 MiB read spread
+        // over [0,100]s. Naive span-average = 200 MiB / 100 s = 2 MiB/s, badly
+        // diluted by the tail. The busiest 10s window [0,10] delivers all
+        // 100 MiB of the fast read plus 10 MiB of the slow one = 110 MiB/10s.
+        let intervals = vec![(0.0, 1.0, 100 * mib), (0.0, 100.0, 100 * mib)];
+        let peak = compute_peak_windowed_mibps(&intervals, 10.0);
+        assert!((peak - 11.0).abs() < 0.01, "peak={peak}");
+    }
+
+    #[test]
+    fn peak_windowed_throughput_short_run_falls_back_to_span_average() {
+        let mib = 1_048_576u64;
+        // 40 MiB over a 4s span, shorter than the 10s window.
+        let intervals = vec![(0.0, 4.0, 40 * mib)];
+        let peak = compute_peak_windowed_mibps(&intervals, 10.0);
+        assert!((peak - 10.0).abs() < 0.01, "peak={peak}");
+    }
+
+    #[test]
+    fn peak_windowed_throughput_empty_is_zero() {
+        assert_eq!(compute_peak_windowed_mibps(&[], 10.0), 0.0);
     }
 }

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -5,6 +5,38 @@ use std::env;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunLimit {
+    Iterations,
+    Duration {
+        duration: Duration,
+        rps: Option<f64>,
+    },
+}
+
+impl RunLimit {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Iterations => "iterations",
+            Self::Duration { .. } => "duration",
+        }
+    }
+
+    pub fn target_duration_s(&self) -> Option<f64> {
+        match self {
+            Self::Iterations => None,
+            Self::Duration { duration, .. } => Some(duration.as_secs_f64()),
+        }
+    }
+
+    pub fn target_rps(&self) -> Option<f64> {
+        match self {
+            Self::Iterations => None,
+            Self::Duration { rps, .. } => *rps,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub frontend_url: String,
@@ -17,6 +49,7 @@ pub struct Config {
     pub warmup_iters: usize,
     pub concurrency: usize,
     pub total_iters: usize,
+    pub run_limit: RunLimit,
     pub ramp_seconds: u64,
     pub poll_interval: Duration,
     pub poll_timeout: Duration,
@@ -26,28 +59,59 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Result<Self, String> {
-        let frontend_url = required_env("LOADGEN_FRONTEND_URL")?;
-        let collection = required_env("LOADGEN_COLLECTION")?;
-        let auth = required_env("LOADGEN_AUTH")?;
-        let payload_json = serde_json::from_str(&required_env("LOADGEN_PAYLOAD_JSON")?)
+        Self::from_lookup(|name| env::var(name).ok())
+    }
+
+    pub fn from_lookup<F>(lookup: F) -> Result<Self, String>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let frontend_url = required_lookup(&lookup, "LOADGEN_FRONTEND_URL")?;
+        let collection = required_lookup(&lookup, "LOADGEN_COLLECTION")?;
+        let auth = required_lookup(&lookup, "LOADGEN_AUTH")?;
+        let payload_json = serde_json::from_str(&required_lookup(&lookup, "LOADGEN_PAYLOAD_JSON")?)
             .map_err(|err| format!("LOADGEN_PAYLOAD_JSON is not valid JSON: {err}"))?;
-        let bobs_svc_template = required_env("LOADGEN_BOBS_SVC_TEMPLATE")?;
-        let mock_realm = optional_non_empty("LOADGEN_MOCK_REALM");
-        let mock_role = env_or("LOADGEN_MOCK_ROLE", "default");
-        let mock_user_prefix = env_or("LOADGEN_MOCK_USER_PREFIX", "mock-");
-        let warmup_iters = parse_env("LOADGEN_WARMUP_ITERS", 5)?;
-        let concurrency = parse_env("LOADGEN_CONCURRENCY", 64)?;
-        let total_iters = parse_env("LOADGEN_TOTAL_ITERS", 512)?;
-        let ramp_seconds = parse_env("LOADGEN_RAMP_SECONDS", 30)?;
-        let poll_interval = Duration::from_millis(parse_env("LOADGEN_POLL_INTERVAL_MS", 250)?);
-        let poll_timeout = Duration::from_secs(parse_env("LOADGEN_POLL_TIMEOUT_S", 600)?);
-        let max_error_rate = parse_env("LOADGEN_MAX_ERROR_RATE", 0.01)?;
+        let bobs_svc_template = required_lookup(&lookup, "LOADGEN_BOBS_SVC_TEMPLATE")?;
+        let mock_realm = optional_non_empty_lookup(&lookup, "LOADGEN_MOCK_REALM");
+        let mock_role = lookup_or(&lookup, "LOADGEN_MOCK_ROLE", "default");
+        let mock_user_prefix = lookup_or(&lookup, "LOADGEN_MOCK_USER_PREFIX", "mock-");
+        let warmup_iters = parse_lookup(&lookup, "LOADGEN_WARMUP_ITERS", 5)?;
+        let concurrency = parse_lookup(&lookup, "LOADGEN_CONCURRENCY", 64)?;
+        let total_iters = parse_lookup(&lookup, "LOADGEN_TOTAL_ITERS", 512)?;
+        let ramp_seconds = parse_lookup(&lookup, "LOADGEN_RAMP_SECONDS", 30)?;
+        let poll_interval =
+            Duration::from_millis(parse_lookup(&lookup, "LOADGEN_POLL_INTERVAL_MS", 250)?);
+        let poll_timeout =
+            Duration::from_secs(parse_lookup(&lookup, "LOADGEN_POLL_TIMEOUT_S", 600)?);
+        let max_error_rate = parse_lookup(&lookup, "LOADGEN_MAX_ERROR_RATE", 0.01)?;
+        let duration_s = parse_optional_f64(&lookup, "LOADGEN_DURATION_S")?;
+        let rps = parse_optional_f64(&lookup, "LOADGEN_RPS")?;
         if frontend_url.ends_with('/') {
             return Err("LOADGEN_FRONTEND_URL must not have a trailing slash".to_string());
         }
         if concurrency == 0 {
             return Err("LOADGEN_CONCURRENCY must be at least 1".to_string());
         }
+        let run_limit = match (duration_s, rps) {
+            (Some(duration_s), rps) => {
+                if duration_s <= 0.0 || !duration_s.is_finite() {
+                    return Err("LOADGEN_DURATION_S must be a positive finite number".to_string());
+                }
+                if let Some(rps) = rps {
+                    if rps <= 0.0 || !rps.is_finite() {
+                        return Err("LOADGEN_RPS must be a positive finite number".to_string());
+                    }
+                }
+                RunLimit::Duration {
+                    duration: Duration::from_secs_f64(duration_s),
+                    rps,
+                }
+            }
+            (None, Some(_)) => {
+                return Err("LOADGEN_RPS requires LOADGEN_DURATION_S".to_string());
+            }
+            (None, None) => RunLimit::Iterations,
+        };
         Ok(Self {
             frontend_url,
             collection,
@@ -59,6 +123,7 @@ impl Config {
             warmup_iters,
             concurrency,
             total_iters,
+            run_limit,
             ramp_seconds,
             poll_interval,
             poll_timeout,
@@ -81,6 +146,9 @@ impl Config {
             warmup_iters: self.warmup_iters,
             concurrency: self.concurrency,
             total_iters: self.total_iters,
+            run_limit: self.run_limit.name().to_string(),
+            target_duration_s: self.run_limit.target_duration_s(),
+            target_rps: self.run_limit.target_rps(),
             ramp_seconds: self.ramp_seconds,
             poll_interval_ms: self.poll_interval.as_millis() as u64,
             poll_timeout_s: self.poll_timeout.as_secs(),
@@ -90,9 +158,12 @@ impl Config {
     }
 }
 
-fn required_env(name: &str) -> Result<String, String> {
-    env::var(name)
-        .map_err(|_| format!("missing required environment variable {name}"))
+fn required_lookup<F>(lookup: &F, name: &str) -> Result<String, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    lookup(name)
+        .ok_or_else(|| format!("missing required environment variable {name}"))
         .and_then(|value| {
             if value.trim().is_empty() {
                 Err(format!("required environment variable {name} is empty"))
@@ -102,27 +173,46 @@ fn required_env(name: &str) -> Result<String, String> {
         })
 }
 
-fn env_or(name: &str, default: &str) -> String {
-    env::var(name)
-        .ok()
+fn lookup_or<F>(lookup: &F, name: &str, default: &str) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    lookup(name)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| default.to_string())
 }
 
-fn optional_non_empty(name: &str) -> Option<String> {
-    env::var(name).ok().filter(|value| !value.is_empty())
+fn optional_non_empty_lookup<F>(lookup: &F, name: &str) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    lookup(name).filter(|value| !value.is_empty())
 }
 
-fn parse_env<T>(name: &str, default: T) -> Result<T, String>
+fn parse_lookup<F, T>(lookup: &F, name: &str, default: T) -> Result<T, String>
 where
+    F: Fn(&str) -> Option<String>,
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
 {
-    match env::var(name) {
-        Ok(value) if !value.trim().is_empty() => value
+    match lookup(name) {
+        Some(value) if !value.trim().is_empty() => value
             .parse()
             .map_err(|err| format!("{name} is invalid: {err}")),
         _ => Ok(default),
+    }
+}
+
+fn parse_optional_f64<F>(lookup: &F, name: &str) -> Result<Option<f64>, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    match lookup(name) {
+        Some(value) if !value.trim().is_empty() => value
+            .parse()
+            .map(Some)
+            .map_err(|err| format!("{name} is invalid: {err}")),
+        _ => Ok(None),
     }
 }
 
@@ -136,6 +226,9 @@ pub struct SummaryConfig {
     pub warmup_iters: usize,
     pub concurrency: usize,
     pub total_iters: usize,
+    pub run_limit: String,
+    pub target_duration_s: Option<f64>,
+    pub target_rps: Option<f64>,
     pub ramp_seconds: u64,
     pub poll_interval_ms: u64,
     pub poll_timeout_s: u64,
@@ -163,6 +256,7 @@ pub struct IterationResult {
     pub status: Option<u16>,
     pub read_start: Option<Instant>,
     pub read_end: Option<Instant>,
+    pub completed_at: Instant,
 }
 
 #[derive(Debug, Default, Serialize, PartialEq)]
@@ -194,13 +288,59 @@ pub struct StreamPercentiles {
     pub mean: Option<f64>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TimeBucketMetrics {
+    pub bucket_start_s: f64,
+    pub bucket_end_s: f64,
+    pub downloaded: usize,
+    pub error: usize,
+    pub bytes: u64,
+    pub throughput_rps: f64,
+    pub error_rate: f64,
+    pub ready_ms_p95: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SummaryMetadata {
+    pub run_limit: String,
+    pub target_duration_s: Option<f64>,
+    pub submission_duration_s: f64,
+    pub drain_duration_s: f64,
+    pub scheduled: usize,
+    pub missed_starts: usize,
+    pub measured_start: Option<Instant>,
+    pub bucket_width_s: f64,
+}
+
+impl SummaryMetadata {
+    pub fn iteration(duration_s: f64, scheduled: usize) -> Self {
+        Self {
+            run_limit: "iterations".to_string(),
+            target_duration_s: None,
+            submission_duration_s: duration_s,
+            drain_duration_s: 0.0,
+            scheduled,
+            missed_starts: 0,
+            measured_start: None,
+            bucket_width_s: DEFAULT_BUCKET_WIDTH_S,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Summary {
     pub phase: String,
     pub config: SummaryConfig,
+    pub run_limit: String,
+    pub target_duration_s: Option<f64>,
+    pub submission_duration_s: f64,
+    pub drain_duration_s: f64,
+    pub scheduled: usize,
+    pub missed_starts: usize,
     pub counts: Counts,
     pub errors_by_status: BTreeMap<String, usize>,
     pub percentiles: BTreeMap<String, Percentiles>,
+    pub time_buckets: Vec<TimeBucketMetrics>,
     pub bytes_total: u64,
     pub per_stream_mibps: StreamPercentiles,
     pub aggregate_mibps: f64,
@@ -300,6 +440,8 @@ fn percent_decode(input: &str) -> Result<String, String> {
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 pub struct ProgressCounts {
     pub started: usize,
+    pub scheduled: usize,
+    pub missed_starts: usize,
     pub submitted: usize,
     pub ready: usize,
     pub downloaded: usize,
@@ -373,11 +515,17 @@ impl ProgressTracker {
     }
 
     pub fn record_started(&self) {
+        let mut state = self.state.lock().expect("progress mutex poisoned");
+        state.counts.started += 1;
+        state.counts.scheduled += 1;
+    }
+
+    pub fn record_missed_start(&self) {
         self.state
             .lock()
             .expect("progress mutex poisoned")
             .counts
-            .started += 1;
+            .missed_starts += 1;
     }
 
     pub fn record_submitted(&self) {
@@ -480,6 +628,22 @@ pub fn summarize(
     results: &[IterationResult],
     duration_s: f64,
 ) -> Summary {
+    summarize_with_metadata(
+        phase,
+        config,
+        results,
+        duration_s,
+        SummaryMetadata::iteration(duration_s, results.len()),
+    )
+}
+
+pub fn summarize_with_metadata(
+    phase: &str,
+    config: SummaryConfig,
+    results: &[IterationResult],
+    duration_s: f64,
+    metadata: SummaryMetadata,
+) -> Summary {
     let mut counts = Counts::default();
     let mut errors_by_status = BTreeMap::new();
     let mut submit_ms = Vec::new();
@@ -573,12 +737,21 @@ pub fn summarize(
     metric_percentiles.insert("ready_ms".to_string(), percentiles(&ready_ms));
     metric_percentiles.insert("read_ms".to_string(), percentiles(&read_ms));
 
+    let time_buckets = time_buckets(results, metadata.measured_start, metadata.bucket_width_s);
+
     Summary {
         phase: phase.to_string(),
         config,
+        run_limit: metadata.run_limit,
+        target_duration_s: metadata.target_duration_s,
+        submission_duration_s: metadata.submission_duration_s,
+        drain_duration_s: metadata.drain_duration_s,
+        scheduled: metadata.scheduled,
+        missed_starts: metadata.missed_starts,
         counts,
         errors_by_status,
         percentiles: metric_percentiles,
+        time_buckets,
         bytes_total,
         per_stream_mibps: stream_percentiles(&per_stream_mibps),
         aggregate_mibps,
@@ -591,10 +764,78 @@ pub fn summarize(
     }
 }
 
+const DEFAULT_BUCKET_WIDTH_S: f64 = 60.0;
+
 /// Window width (seconds) for the peak sustained-throughput metric. A 10s
 /// window smooths per-request jitter while still isolating the dense
 /// concurrent-read plateau from ramp-up and the heavy-tailed drain.
 const PEAK_WINDOW_S: f64 = 10.0;
+
+#[derive(Default)]
+struct BucketAccumulator {
+    downloaded: usize,
+    error: usize,
+    bytes: u64,
+    ready_ms: Vec<f64>,
+}
+
+fn time_buckets(
+    results: &[IterationResult],
+    measured_start: Option<Instant>,
+    bucket_width_s: f64,
+) -> Vec<TimeBucketMetrics> {
+    if results.is_empty() || bucket_width_s <= 0.0 || !bucket_width_s.is_finite() {
+        return Vec::new();
+    }
+    let origin = measured_start.unwrap_or_else(|| {
+        results
+            .iter()
+            .map(|result| result.completed_at)
+            .min()
+            .unwrap_or_else(Instant::now)
+    });
+    let mut buckets: BTreeMap<usize, BucketAccumulator> = BTreeMap::new();
+    for result in results {
+        let elapsed_s = result
+            .completed_at
+            .checked_duration_since(origin)
+            .unwrap_or_default()
+            .as_secs_f64();
+        let bucket_index = (elapsed_s / bucket_width_s).floor() as usize;
+        let bucket = buckets.entry(bucket_index).or_default();
+        if result.outcome == Outcome::Downloaded {
+            bucket.downloaded += 1;
+            bucket.bytes += result.bytes;
+        } else {
+            bucket.error += 1;
+        }
+        if let Some(ready_ms) = result.ready_ms {
+            bucket.ready_ms.push(ready_ms);
+        }
+    }
+    buckets
+        .into_iter()
+        .map(|(idx, bucket)| {
+            let bucket_start_s = idx as f64 * bucket_width_s;
+            let bucket_end_s = bucket_start_s + bucket_width_s;
+            let total = bucket.downloaded + bucket.error;
+            TimeBucketMetrics {
+                bucket_start_s,
+                bucket_end_s,
+                downloaded: bucket.downloaded,
+                error: bucket.error,
+                bytes: bucket.bytes,
+                throughput_rps: bucket.downloaded as f64 / bucket_width_s,
+                error_rate: if total == 0 {
+                    0.0
+                } else {
+                    bucket.error as f64 / total as f64
+                },
+                ready_ms_p95: percentile(&bucket.ready_ms, 95.0),
+            }
+        })
+        .collect()
+}
 
 /// Peak sustained read throughput (MiB/s) over any `window_s`-wide window.
 ///
@@ -745,6 +986,75 @@ pub fn redact_auth_for_logs(_: &Config) -> Map<String, Value> {
 mod tests {
     use super::*;
 
+    fn base_env() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (
+                "LOADGEN_FRONTEND_URL".to_string(),
+                "http://frontend:3000".to_string(),
+            ),
+            ("LOADGEN_COLLECTION".to_string(), "c".to_string()),
+            (
+                "LOADGEN_AUTH".to_string(),
+                "EmailKey redaction-auth-secret".to_string(),
+            ),
+            (
+                "LOADGEN_PAYLOAD_JSON".to_string(),
+                json!({"a": 1}).to_string(),
+            ),
+            (
+                "LOADGEN_BOBS_SVC_TEMPLATE".to_string(),
+                "http://bobs-{ordinal}:3000".to_string(),
+            ),
+        ])
+    }
+
+    fn config_from_map(values: &BTreeMap<String, String>) -> Result<Config, String> {
+        Config::from_lookup(|name| values.get(name).cloned())
+    }
+
+    #[test]
+    fn config_defaults_to_iteration_mode_and_parses_duration_modes() {
+        let mut env = base_env();
+        let config = config_from_map(&env).unwrap();
+        assert_eq!(config.run_limit, RunLimit::Iterations);
+        assert_eq!(config.summary_config().run_limit, "iterations");
+        assert_eq!(config.summary_config().target_duration_s, None);
+        assert_eq!(config.summary_config().target_rps, None);
+        assert_eq!(config.total_iters, 512);
+
+        env.insert("LOADGEN_DURATION_S".to_string(), "900".to_string());
+        let config = config_from_map(&env).unwrap();
+        assert_eq!(config.run_limit.name(), "duration");
+        assert_eq!(config.run_limit.target_duration_s(), Some(900.0));
+        assert_eq!(config.run_limit.target_rps(), None);
+
+        env.insert("LOADGEN_RPS".to_string(), "0.5".to_string());
+        let config = config_from_map(&env).unwrap();
+        assert_eq!(config.run_limit.name(), "duration");
+        assert_eq!(config.run_limit.target_duration_s(), Some(900.0));
+        assert_eq!(config.run_limit.target_rps(), Some(0.5));
+    }
+
+    #[test]
+    fn config_rejects_invalid_duration_rps_and_concurrency_combinations() {
+        let mut env = base_env();
+        env.insert("LOADGEN_CONCURRENCY".to_string(), "0".to_string());
+        assert!(config_from_map(&env).unwrap_err().contains("CONCURRENCY"));
+
+        let mut env = base_env();
+        env.insert("LOADGEN_DURATION_S".to_string(), "0".to_string());
+        assert!(config_from_map(&env).unwrap_err().contains("DURATION"));
+
+        let mut env = base_env();
+        env.insert("LOADGEN_DURATION_S".to_string(), "60".to_string());
+        env.insert("LOADGEN_RPS".to_string(), "0".to_string());
+        assert!(config_from_map(&env).unwrap_err().contains("RPS"));
+
+        let mut env = base_env();
+        env.insert("LOADGEN_RPS".to_string(), "1".to_string());
+        assert!(config_from_map(&env).unwrap_err().contains("requires"));
+    }
+
     #[test]
     fn bobs_location_translation_matches_python_runner() {
         let template = "http://rel-bobs-{ordinal}:3000";
@@ -783,6 +1093,9 @@ mod tests {
             warmup_iters: 5,
             concurrency: 2,
             total_iters: 4,
+            run_limit: "iterations".to_string(),
+            target_duration_s: None,
+            target_rps: None,
             ramp_seconds: 1,
             poll_interval_ms: 250,
             poll_timeout_s: 600,
@@ -799,6 +1112,7 @@ mod tests {
                 status: None,
                 read_start: Some(now),
                 read_end: Some(now + Duration::from_secs(1)),
+                completed_at: now + Duration::from_secs(1),
             },
             IterationResult {
                 outcome: Outcome::Downloaded,
@@ -809,6 +1123,7 @@ mod tests {
                 status: None,
                 read_start: Some(now + Duration::from_secs(1)),
                 read_end: Some(now + Duration::from_secs(3)),
+                completed_at: now + Duration::from_secs(3),
             },
             IterationResult {
                 outcome: Outcome::SubmitFailed,
@@ -819,6 +1134,7 @@ mod tests {
                 status: Some(500),
                 read_start: None,
                 read_end: None,
+                completed_at: now + Duration::from_secs(4),
             },
         ];
         let summary = summarize("measured", cfg, &results, 6.0);
@@ -836,6 +1152,151 @@ mod tests {
         // 3 MiB over a 3s read span (< 10s window) => falls back to span avg.
         assert_eq!(summary.peak_window_s, 10.0);
         assert!((summary.peak_windowed_mibps - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn summary_time_buckets_group_completions_and_ready_p95() {
+        let now = Instant::now();
+        let cfg = SummaryConfig {
+            frontend_url: "http://frontend:3000".to_string(),
+            collection: "c".to_string(),
+            mock_realm: None,
+            mock_role: "default".to_string(),
+            mock_user_prefix: "mock-".to_string(),
+            warmup_iters: 0,
+            concurrency: 2,
+            total_iters: 0,
+            run_limit: "duration".to_string(),
+            target_duration_s: Some(2.0),
+            target_rps: Some(2.0),
+            ramp_seconds: 0,
+            poll_interval_ms: 250,
+            poll_timeout_s: 600,
+            bobs_svc_template: "http://bobs-{ordinal}:3000".to_string(),
+            max_error_rate: 0.01,
+        };
+        let results = vec![
+            IterationResult {
+                outcome: Outcome::Downloaded,
+                submit_ms: Some(1.0),
+                ready_ms: Some(100.0),
+                read_ms: Some(10.0),
+                bytes: 10,
+                status: None,
+                read_start: Some(now),
+                read_end: Some(now + Duration::from_millis(100)),
+                completed_at: now + Duration::from_millis(200),
+            },
+            IterationResult {
+                outcome: Outcome::Downloaded,
+                submit_ms: Some(1.0),
+                ready_ms: Some(300.0),
+                read_ms: Some(10.0),
+                bytes: 20,
+                status: None,
+                read_start: Some(now),
+                read_end: Some(now + Duration::from_millis(100)),
+                completed_at: now + Duration::from_millis(800),
+            },
+            IterationResult {
+                outcome: Outcome::PollFailed,
+                submit_ms: Some(1.0),
+                ready_ms: None,
+                read_ms: None,
+                bytes: 0,
+                status: Some(500),
+                read_start: None,
+                read_end: None,
+                completed_at: now + Duration::from_millis(1200),
+            },
+        ];
+        let summary = summarize_with_metadata(
+            "measured",
+            cfg,
+            &results,
+            2.0,
+            SummaryMetadata {
+                run_limit: "duration".to_string(),
+                target_duration_s: Some(2.0),
+                submission_duration_s: 2.0,
+                drain_duration_s: 0.5,
+                scheduled: 3,
+                missed_starts: 4,
+                measured_start: Some(now),
+                bucket_width_s: 1.0,
+            },
+        );
+        assert_eq!(summary.run_limit, "duration");
+        assert_eq!(summary.scheduled, 3);
+        assert_eq!(summary.missed_starts, 4);
+        assert_eq!(summary.time_buckets.len(), 2);
+        assert_eq!(summary.time_buckets[0].downloaded, 2);
+        assert_eq!(summary.time_buckets[0].bytes, 30);
+        assert_eq!(summary.time_buckets[0].throughput_rps, 2.0);
+        assert_eq!(summary.time_buckets[0].ready_ms_p95, Some(300.0));
+        assert_eq!(summary.time_buckets[1].error, 1);
+        assert_eq!(summary.time_buckets[1].error_rate, 1.0);
+    }
+
+    #[test]
+    fn summary_progress_and_config_serialization_exclude_auth_and_env_secret_values() {
+        let mut env = base_env();
+        env.insert(
+            "LOADGEN_AUTH".to_string(),
+            "EmailKey super-auth-token".to_string(),
+        );
+        env.insert(
+            "POLYTOPE_EMAIL".to_string(),
+            "private-user@example.test".to_string(),
+        );
+        env.insert(
+            "POLYTOPE_KEY".to_string(),
+            "private-polytope-key".to_string(),
+        );
+        env.insert("LOADGEN_DURATION_S".to_string(), "60".to_string());
+        env.insert("LOADGEN_RPS".to_string(), "1".to_string());
+        let config = config_from_map(&env).unwrap();
+        let start = Instant::now();
+        let summary = summarize_with_metadata(
+            "measured",
+            config.summary_config(),
+            &[],
+            0.0,
+            SummaryMetadata {
+                run_limit: config.run_limit.name().to_string(),
+                target_duration_s: config.run_limit.target_duration_s(),
+                submission_duration_s: 0.0,
+                drain_duration_s: 0.0,
+                scheduled: 0,
+                missed_starts: 0,
+                measured_start: Some(start),
+                bucket_width_s: 60.0,
+            },
+        );
+        let tracker = ProgressTracker::new(start);
+        tracker.record_started();
+        tracker.record_missed_start();
+        tracker.record_finished(Outcome::DownloadFailed, 0);
+        let text = format!(
+            "{}\n{}\n{}",
+            serde_json::to_string(&summary).unwrap(),
+            serde_json::to_string(&tracker.snapshot(start + Duration::from_secs(1))).unwrap(),
+            serde_json::to_string(&config.summary_config()).unwrap(),
+        );
+        for forbidden in [
+            "EmailKey super-auth-token",
+            "private-user@example.test",
+            "private-polytope-key",
+            "LOADGEN_AUTH",
+            "Authorization",
+            "POLYTOPE_EMAIL",
+            "POLYTOPE_KEY",
+        ] {
+            assert!(
+                !text.contains(forbidden),
+                "found forbidden value {forbidden}: {text}"
+            );
+        }
     }
 
     #[test]
@@ -967,6 +1428,9 @@ mod tests {
             warmup_iters: 5,
             concurrency: 1,
             total_iters: 0,
+            run_limit: "iterations".to_string(),
+            target_duration_s: None,
+            target_rps: None,
             ramp_seconds: 0,
             poll_interval_ms: 250,
             poll_timeout_s: 600,

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
 use std::env;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone)]
@@ -294,6 +295,183 @@ fn percent_decode(input: &str) -> Result<String, String> {
         }
     }
     String::from_utf8(out).map_err(|_| "invalid UTF-8 in BOBS location URL".to_string())
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct ProgressCounts {
+    pub started: usize,
+    pub submitted: usize,
+    pub ready: usize,
+    pub downloaded: usize,
+    pub error: usize,
+    pub submit_failed: usize,
+    pub poll_failed: usize,
+    pub timed_out: usize,
+    pub download_failed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ProgressRates {
+    pub window_rps: f64,
+    pub window_mibps: f64,
+}
+
+/// JSON payload emitted as `LOADGEN_PROGRESS:{json}` during measured runs.
+///
+/// The progress stream is intentionally redaction-safe: it contains only
+/// counters, byte totals, rates, elapsed time, and raw ready-latency samples.
+/// It never includes request configuration, URLs, headers, authorization values,
+/// payloads, mock identities, or precomputed ready-latency percentiles.
+///
+/// `window_s` is the time-based rolling-rate window width in seconds that live
+/// consumers should use when aggregating progress. It defaults to `60`.
+/// `ready_ms_since_last` contains raw ready-latency samples observed since the
+/// previous emitted progress snapshot; consumers compute rolling percentiles
+/// from these raw samples across pods.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ProgressSnapshot {
+    pub schema_version: u32,
+    pub seq: u64,
+    pub elapsed_s: f64,
+    pub window_s: u64,
+    pub counts: ProgressCounts,
+    pub bytes_total: u64,
+    pub rates: ProgressRates,
+    pub ready_ms_since_last: Vec<f64>,
+}
+
+#[derive(Debug)]
+pub struct ProgressTracker {
+    start: Instant,
+    window_s: u64,
+    state: Mutex<ProgressState>,
+}
+
+#[derive(Debug, Default)]
+struct ProgressState {
+    seq: u64,
+    counts: ProgressCounts,
+    bytes_total: u64,
+    ready_ms: Vec<f64>,
+    last_snapshot_at: Option<Instant>,
+    last_snapshot_downloaded: usize,
+    last_snapshot_bytes: u64,
+    last_snapshot_ready_index: usize,
+}
+
+impl ProgressTracker {
+    pub fn new(start: Instant) -> Self {
+        Self::with_window(start, 60)
+    }
+
+    pub fn with_window(start: Instant, window_s: u64) -> Self {
+        Self {
+            start,
+            window_s,
+            state: Mutex::new(ProgressState::default()),
+        }
+    }
+
+    pub fn record_started(&self) {
+        self.state
+            .lock()
+            .expect("progress mutex poisoned")
+            .counts
+            .started += 1;
+    }
+
+    pub fn record_submitted(&self) {
+        self.state
+            .lock()
+            .expect("progress mutex poisoned")
+            .counts
+            .submitted += 1;
+    }
+
+    pub fn record_ready(&self, ready_ms: f64) {
+        let mut state = self.state.lock().expect("progress mutex poisoned");
+        state.counts.ready += 1;
+        state.ready_ms.push(ready_ms);
+    }
+
+    pub fn record_finished(&self, outcome: Outcome, bytes: u64) {
+        let mut state = self.state.lock().expect("progress mutex poisoned");
+        state.bytes_total += bytes;
+        match outcome {
+            Outcome::Downloaded => state.counts.downloaded += 1,
+            Outcome::SubmitFailed => {
+                state.counts.error += 1;
+                state.counts.submit_failed += 1;
+            }
+            Outcome::PollFailed => {
+                state.counts.error += 1;
+                state.counts.poll_failed += 1;
+            }
+            Outcome::TimedOut => {
+                state.counts.error += 1;
+                state.counts.timed_out += 1;
+            }
+            Outcome::DownloadFailed => {
+                state.counts.error += 1;
+                state.counts.download_failed += 1;
+            }
+        }
+    }
+
+    pub fn snapshot(&self, now: Instant) -> ProgressSnapshot {
+        let mut state = self.state.lock().expect("progress mutex poisoned");
+        let previous = state.last_snapshot_at.unwrap_or(self.start);
+        let interval_s = (now - previous).as_secs_f64();
+        let downloaded_delta = state.counts.downloaded - state.last_snapshot_downloaded;
+        let bytes_delta = state.bytes_total - state.last_snapshot_bytes;
+        let ready_ms_since_last = state.ready_ms[state.last_snapshot_ready_index..].to_vec();
+        state.seq += 1;
+        state.last_snapshot_at = Some(now);
+        state.last_snapshot_downloaded = state.counts.downloaded;
+        state.last_snapshot_bytes = state.bytes_total;
+        state.last_snapshot_ready_index = state.ready_ms.len();
+        ProgressSnapshot {
+            schema_version: 1,
+            seq: state.seq,
+            elapsed_s: (now - self.start).as_secs_f64(),
+            window_s: self.window_s,
+            counts: state.counts.clone(),
+            bytes_total: state.bytes_total,
+            rates: ProgressRates {
+                window_rps: if interval_s > 0.0 {
+                    downloaded_delta as f64 / interval_s
+                } else {
+                    0.0
+                },
+                window_mibps: if interval_s > 0.0 {
+                    (bytes_delta as f64 / 1_048_576.0) / interval_s
+                } else {
+                    0.0
+                },
+            },
+            ready_ms_since_last,
+        }
+    }
+}
+
+pub fn loadgen_progress_interval_from_env() -> Result<Option<Duration>, String> {
+    loadgen_progress_interval_from_value(env::var("LOADGEN_PROGRESS_INTERVAL_MS").ok().as_deref())
+}
+
+pub fn loadgen_progress_interval_from_value(
+    value: Option<&str>,
+) -> Result<Option<Duration>, String> {
+    let millis: u64 = match value.filter(|value| !value.trim().is_empty()) {
+        Some(value) => value
+            .parse()
+            .map_err(|err| format!("LOADGEN_PROGRESS_INTERVAL_MS is invalid: {err}"))?,
+        None => 1000,
+    };
+    if millis == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(Duration::from_millis(millis)))
+    }
 }
 
 pub fn summarize(
@@ -679,6 +857,128 @@ mod tests {
         let intervals = vec![(0.0, 4.0, 40 * mib)];
         let peak = compute_peak_windowed_mibps(&intervals, 10.0);
         assert!((peak - 10.0).abs() < 0.01, "peak={peak}");
+    }
+
+    #[test]
+    fn progress_snapshot_uses_interval_download_and_byte_deltas() {
+        let start = Instant::now();
+        let tracker = ProgressTracker::new(start);
+        tracker.record_started();
+        tracker.record_started();
+        tracker.record_submitted();
+        tracker.record_ready(120.0);
+        tracker.record_finished(Outcome::Downloaded, 2 * 1_048_576);
+
+        let first = tracker.snapshot(start + Duration::from_secs(2));
+        assert_eq!(first.seq, 1);
+        assert_eq!(first.counts.started, 2);
+        assert_eq!(first.counts.submitted, 1);
+        assert_eq!(first.counts.ready, 1);
+        assert_eq!(first.counts.downloaded, 1);
+        assert_eq!(first.bytes_total, 2 * 1_048_576);
+        assert_eq!(first.rates.window_rps, 0.5);
+        assert_eq!(first.rates.window_mibps, 1.0);
+        assert_eq!(first.ready_ms_since_last, vec![120.0]);
+
+        tracker.record_ready(240.0);
+        tracker.record_finished(Outcome::Downloaded, 4 * 1_048_576);
+        let second = tracker.snapshot(start + Duration::from_secs(4));
+        assert_eq!(second.seq, 2);
+        assert_eq!(second.counts.downloaded, 2);
+        assert_eq!(second.bytes_total, 6 * 1_048_576);
+        assert_eq!(second.rates.window_rps, 0.5);
+        assert_eq!(second.rates.window_mibps, 2.0);
+        assert_eq!(second.ready_ms_since_last, vec![240.0]);
+
+        let third = tracker.snapshot(start + Duration::from_secs(5));
+        assert_eq!(third.rates.window_rps, 0.0);
+        assert_eq!(third.rates.window_mibps, 0.0);
+        assert!(third.ready_ms_since_last.is_empty());
+    }
+
+    #[test]
+    fn progress_snapshot_defaults_window_to_sixty_seconds_and_emits_raw_ready_samples() {
+        let start = Instant::now();
+        let tracker = ProgressTracker::new(start);
+        tracker.record_ready(10.0);
+        tracker.record_ready(30.0);
+        let snapshot = tracker.snapshot(start + Duration::from_secs(1));
+        assert_eq!(snapshot.window_s, 60);
+        assert_eq!(snapshot.ready_ms_since_last, vec![10.0, 30.0]);
+    }
+
+    #[test]
+    fn progress_snapshot_serialization_is_redaction_safe() {
+        let start = Instant::now();
+        let tracker = ProgressTracker::new(start);
+        tracker.record_started();
+        tracker.record_submitted();
+        tracker.record_ready(42.0);
+        tracker.record_finished(Outcome::PollFailed, 0);
+        let value = serde_json::to_value(tracker.snapshot(start + Duration::from_secs(1))).unwrap();
+        let text = value.to_string();
+
+        assert_eq!(value["schema_version"], 1);
+        assert!(value.get("counts").is_some());
+        assert!(value.get("rates").is_some());
+        assert_eq!(value["counts"]["error"], 1);
+        assert_eq!(value["counts"]["poll_failed"], 1);
+        assert_eq!(value["ready_ms_since_last"], json!([42.0]));
+        for forbidden in [
+            "auth",
+            "authorization",
+            "header",
+            "config",
+            "frontend_url",
+            "collection",
+            "payload",
+            "EmailKey",
+            "rolling_ready_ms",
+            "p95",
+        ] {
+            assert!(
+                !text.to_lowercase().contains(&forbidden.to_lowercase()),
+                "progress snapshot contains forbidden field/value {forbidden}: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn progress_interval_zero_disables_progress_without_changing_summary_shape() {
+        assert_eq!(
+            loadgen_progress_interval_from_value(Some("0")).unwrap(),
+            None
+        );
+        assert_eq!(
+            loadgen_progress_interval_from_value(None).unwrap(),
+            Some(Duration::from_millis(1000))
+        );
+        assert_eq!(
+            loadgen_progress_interval_from_value(Some("250")).unwrap(),
+            Some(Duration::from_millis(250))
+        );
+
+        let cfg = SummaryConfig {
+            frontend_url: "http://frontend:3000".to_string(),
+            collection: "c".to_string(),
+            mock_realm: None,
+            mock_role: "default".to_string(),
+            mock_user_prefix: "mock-".to_string(),
+            warmup_iters: 5,
+            concurrency: 1,
+            total_iters: 0,
+            ramp_seconds: 0,
+            poll_interval_ms: 250,
+            poll_timeout_s: 600,
+            bobs_svc_template: "http://bobs-{ordinal}:3000".to_string(),
+            max_error_rate: 0.01,
+        };
+        let summary = serde_json::to_value(summarize("measured", cfg, &[], 0.0)).unwrap();
+        assert_eq!(summary["phase"], "measured");
+        assert!(summary.get("config").is_some());
+        assert!(summary.get("counts").is_some());
+        assert!(summary.get("rates").is_none());
+        assert!(summary.get("ready_ms_since_last").is_none());
     }
 
     #[test]

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -1,0 +1,526 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
+use std::env;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub frontend_url: String,
+    pub collection: String,
+    pub auth: String,
+    pub payload_json: Value,
+    pub mock_realm: Option<String>,
+    pub mock_role: String,
+    pub mock_user_prefix: String,
+    pub warmup_iters: usize,
+    pub concurrency: usize,
+    pub total_iters: usize,
+    pub ramp_seconds: u64,
+    pub poll_interval: Duration,
+    pub poll_timeout: Duration,
+    pub bobs_svc_template: String,
+    pub max_error_rate: f64,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, String> {
+        let frontend_url = required_env("LOADGEN_FRONTEND_URL")?;
+        let collection = required_env("LOADGEN_COLLECTION")?;
+        let auth = required_env("LOADGEN_AUTH")?;
+        let payload_json = serde_json::from_str(&required_env("LOADGEN_PAYLOAD_JSON")?)
+            .map_err(|err| format!("LOADGEN_PAYLOAD_JSON is not valid JSON: {err}"))?;
+        let bobs_svc_template = required_env("LOADGEN_BOBS_SVC_TEMPLATE")?;
+        let mock_realm = optional_non_empty("LOADGEN_MOCK_REALM");
+        let mock_role = env_or("LOADGEN_MOCK_ROLE", "default");
+        let mock_user_prefix = env_or("LOADGEN_MOCK_USER_PREFIX", "mock-");
+        let warmup_iters = parse_env("LOADGEN_WARMUP_ITERS", 5)?;
+        let concurrency = parse_env("LOADGEN_CONCURRENCY", 64)?;
+        let total_iters = parse_env("LOADGEN_TOTAL_ITERS", 512)?;
+        let ramp_seconds = parse_env("LOADGEN_RAMP_SECONDS", 30)?;
+        let poll_interval = Duration::from_millis(parse_env("LOADGEN_POLL_INTERVAL_MS", 250)?);
+        let poll_timeout = Duration::from_secs(parse_env("LOADGEN_POLL_TIMEOUT_S", 600)?);
+        let max_error_rate = parse_env("LOADGEN_MAX_ERROR_RATE", 0.01)?;
+        if frontend_url.ends_with('/') {
+            return Err("LOADGEN_FRONTEND_URL must not have a trailing slash".to_string());
+        }
+        if concurrency == 0 {
+            return Err("LOADGEN_CONCURRENCY must be at least 1".to_string());
+        }
+        Ok(Self {
+            frontend_url,
+            collection,
+            auth,
+            payload_json,
+            mock_realm,
+            mock_role,
+            mock_user_prefix,
+            warmup_iters,
+            concurrency,
+            total_iters,
+            ramp_seconds,
+            poll_interval,
+            poll_timeout,
+            bobs_svc_template,
+            max_error_rate,
+        })
+    }
+
+    pub fn request_body(&self) -> Value {
+        json!({"verb": "retrieve", "request": self.payload_json})
+    }
+
+    pub fn summary_config(&self) -> SummaryConfig {
+        SummaryConfig {
+            frontend_url: self.frontend_url.clone(),
+            collection: self.collection.clone(),
+            mock_realm: self.mock_realm.clone(),
+            mock_role: self.mock_role.clone(),
+            mock_user_prefix: self.mock_user_prefix.clone(),
+            warmup_iters: self.warmup_iters,
+            concurrency: self.concurrency,
+            total_iters: self.total_iters,
+            ramp_seconds: self.ramp_seconds,
+            poll_interval_ms: self.poll_interval.as_millis() as u64,
+            poll_timeout_s: self.poll_timeout.as_secs(),
+            bobs_svc_template: self.bobs_svc_template.clone(),
+            max_error_rate: self.max_error_rate,
+        }
+    }
+}
+
+fn required_env(name: &str) -> Result<String, String> {
+    env::var(name)
+        .map_err(|_| format!("missing required environment variable {name}"))
+        .and_then(|value| {
+            if value.trim().is_empty() {
+                Err(format!("required environment variable {name} is empty"))
+            } else {
+                Ok(value)
+            }
+        })
+}
+
+fn env_or(name: &str, default: &str) -> String {
+    env::var(name)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn optional_non_empty(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn parse_env<T>(name: &str, default: T) -> Result<T, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => value
+            .parse()
+            .map_err(|err| format!("{name} is invalid: {err}")),
+        _ => Ok(default),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SummaryConfig {
+    pub frontend_url: String,
+    pub collection: String,
+    pub mock_realm: Option<String>,
+    pub mock_role: String,
+    pub mock_user_prefix: String,
+    pub warmup_iters: usize,
+    pub concurrency: usize,
+    pub total_iters: usize,
+    pub ramp_seconds: u64,
+    pub poll_interval_ms: u64,
+    pub poll_timeout_s: u64,
+    pub bobs_svc_template: String,
+    pub max_error_rate: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Downloaded,
+    SubmitFailed,
+    PollFailed,
+    TimedOut,
+    DownloadFailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct IterationResult {
+    pub outcome: Outcome,
+    pub submit_ms: Option<f64>,
+    pub ready_ms: Option<f64>,
+    pub read_ms: Option<f64>,
+    pub bytes: u64,
+    pub status: Option<u16>,
+    pub read_start: Option<Instant>,
+    pub read_end: Option<Instant>,
+}
+
+#[derive(Debug, Default, Serialize, PartialEq)]
+pub struct Counts {
+    pub submitted: usize,
+    pub ready: usize,
+    pub downloaded: usize,
+    pub submit_failed: usize,
+    pub poll_failed: usize,
+    pub timed_out: usize,
+    pub download_failed: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct Percentiles {
+    pub p50: Option<f64>,
+    pub p90: Option<f64>,
+    pub p95: Option<f64>,
+    pub p99: Option<f64>,
+    pub max: Option<f64>,
+    pub mean: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct StreamPercentiles {
+    pub p50: Option<f64>,
+    pub p95: Option<f64>,
+    pub max: Option<f64>,
+    pub mean: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Summary {
+    pub phase: String,
+    pub config: SummaryConfig,
+    pub counts: Counts,
+    pub errors_by_status: BTreeMap<String, usize>,
+    pub percentiles: BTreeMap<String, Percentiles>,
+    pub bytes_total: u64,
+    pub per_stream_mibps: StreamPercentiles,
+    pub aggregate_mibps: f64,
+    pub throughput_rps: f64,
+    pub success_rate: f64,
+    pub error_rate: f64,
+    pub duration_s: f64,
+}
+
+pub fn to_bobs_internal(
+    location_url: &str,
+    bobs_svc_template: &str,
+) -> Result<(String, String), String> {
+    let parsed = reqwest::Url::parse(location_url)
+        .map_err(|_| format!("Cannot parse BOBS location URL: {location_url:?}"))?;
+    let parts: Vec<String> = parsed
+        .path_segments()
+        .ok_or_else(|| format!("Cannot parse BOBS location URL: {location_url:?}"))?
+        .filter(|part| !part.is_empty())
+        .map(percent_decode)
+        .collect::<Result<_, _>>()?;
+
+    let (route_segment, key, key_must_be_uuid_like) = match parts.as_slice() {
+        [route, key] => (route, key, true),
+        [route, api, v1, key] if api == "api" && v1 == "v1" => (route, key, true),
+        [route, api, v1, read, key] if api == "api" && v1 == "v1" && read == "read" => {
+            (route, key, false)
+        }
+        _ => return Err(format!("Cannot parse BOBS location URL: {location_url:?}")),
+    };
+
+    if !is_route_segment(route_segment) || key.is_empty() || key.contains('/') {
+        return Err(format!("Cannot parse BOBS location URL: {location_url:?}"));
+    }
+    if key_must_be_uuid_like && !is_uuid_like_key(key) {
+        return Err(format!("Cannot parse BOBS location URL: {location_url:?}"));
+    }
+
+    let ordinal = route_segment
+        .rsplit_once('-')
+        .map(|(_, ordinal)| ordinal)
+        .unwrap_or_default();
+    let base = bobs_svc_template.replace("{ordinal}", ordinal);
+    Ok((format!("{base}/api/v1/read/{key}"), ordinal.to_string()))
+}
+
+fn is_route_segment(value: &str) -> bool {
+    let Some((prefix, ordinal)) = value.rsplit_once('-') else {
+        return false;
+    };
+    !prefix.is_empty()
+        && prefix.bytes().all(|byte| byte.is_ascii_lowercase())
+        && !ordinal.is_empty()
+        && ordinal.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn is_uuid_like_key(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+}
+
+fn percent_decode(input: &str) -> Result<String, String> {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if bytes[idx] == b'%' {
+            if idx + 2 >= bytes.len() {
+                return Err("invalid percent encoding in BOBS location URL".to_string());
+            }
+            let hex = std::str::from_utf8(&bytes[idx + 1..idx + 3])
+                .map_err(|_| "invalid percent encoding in BOBS location URL".to_string())?;
+            let value = u8::from_str_radix(hex, 16)
+                .map_err(|_| "invalid percent encoding in BOBS location URL".to_string())?;
+            out.push(value);
+            idx += 3;
+        } else {
+            out.push(bytes[idx]);
+            idx += 1;
+        }
+    }
+    String::from_utf8(out).map_err(|_| "invalid UTF-8 in BOBS location URL".to_string())
+}
+
+pub fn summarize(
+    phase: &str,
+    config: SummaryConfig,
+    results: &[IterationResult],
+    duration_s: f64,
+) -> Summary {
+    let mut counts = Counts::default();
+    let mut errors_by_status = BTreeMap::new();
+    let mut submit_ms = Vec::new();
+    let mut ready_ms = Vec::new();
+    let mut read_ms = Vec::new();
+    let mut per_stream_mibps = Vec::new();
+    let mut bytes_total = 0u64;
+    let mut first_read_start: Option<Instant> = None;
+    let mut last_read_end: Option<Instant> = None;
+
+    for result in results {
+        if result.submit_ms.is_some() {
+            counts.submitted += 1;
+        }
+        if let Some(value) = result.submit_ms {
+            submit_ms.push(value);
+        }
+        if let Some(value) = result.ready_ms {
+            counts.ready += 1;
+            ready_ms.push(value);
+        }
+        if let Some(value) = result.read_ms {
+            read_ms.push(value);
+            if value > 0.0 {
+                per_stream_mibps.push((result.bytes as f64 / 1_048_576.0) / (value / 1_000.0));
+            }
+        }
+        bytes_total += result.bytes;
+        match result.outcome {
+            Outcome::Downloaded => counts.downloaded += 1,
+            Outcome::SubmitFailed => counts.submit_failed += 1,
+            Outcome::PollFailed => counts.poll_failed += 1,
+            Outcome::TimedOut => counts.timed_out += 1,
+            Outcome::DownloadFailed => counts.download_failed += 1,
+        }
+        if let Some(status) = result.status {
+            *errors_by_status.entry(status.to_string()).or_insert(0) += 1;
+        }
+        if let Some(start) = result.read_start {
+            first_read_start = Some(first_read_start.map_or(start, |current| current.min(start)));
+        }
+        if let Some(end) = result.read_end {
+            last_read_end = Some(last_read_end.map_or(end, |current| current.max(end)));
+        }
+    }
+
+    let total = results.len();
+    let success_rate = if total == 0 {
+        1.0
+    } else {
+        counts.downloaded as f64 / total as f64
+    };
+    let error_rate = 1.0 - success_rate;
+    let read_span_s = match (first_read_start, last_read_end) {
+        (Some(start), Some(end)) => (end - start).as_secs_f64(),
+        _ => 0.0,
+    };
+    let aggregate_mibps = if read_span_s > 0.0 {
+        (bytes_total as f64 / 1_048_576.0) / read_span_s
+    } else {
+        0.0
+    };
+    let throughput_rps = if duration_s > 0.0 {
+        counts.downloaded as f64 / duration_s
+    } else {
+        0.0
+    };
+
+    let mut metric_percentiles = BTreeMap::new();
+    metric_percentiles.insert("submit_ms".to_string(), percentiles(&submit_ms));
+    metric_percentiles.insert("ready_ms".to_string(), percentiles(&ready_ms));
+    metric_percentiles.insert("read_ms".to_string(), percentiles(&read_ms));
+
+    Summary {
+        phase: phase.to_string(),
+        config,
+        counts,
+        errors_by_status,
+        percentiles: metric_percentiles,
+        bytes_total,
+        per_stream_mibps: stream_percentiles(&per_stream_mibps),
+        aggregate_mibps,
+        throughput_rps,
+        success_rate,
+        error_rate,
+        duration_s,
+    }
+}
+
+fn percentiles(values: &[f64]) -> Percentiles {
+    Percentiles {
+        p50: percentile(values, 50.0),
+        p90: percentile(values, 90.0),
+        p95: percentile(values, 95.0),
+        p99: percentile(values, 99.0),
+        max: values.iter().copied().reduce(f64::max),
+        mean: mean(values),
+    }
+}
+
+fn stream_percentiles(values: &[f64]) -> StreamPercentiles {
+    StreamPercentiles {
+        p50: percentile(values, 50.0),
+        p95: percentile(values, 95.0),
+        max: values.iter().copied().reduce(f64::max),
+        mean: mean(values),
+    }
+}
+
+fn percentile(values: &[f64], percentile: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut ordered = values.to_vec();
+    ordered.sort_by(f64::total_cmp);
+    let index = ((percentile / 100.0) * (ordered.len() as f64 - 1.0)).round() as usize;
+    ordered.get(index).copied()
+}
+
+fn mean(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(values.iter().sum::<f64>() / values.len() as f64)
+    }
+}
+
+pub fn warmup_failed_summary(config: SummaryConfig) -> Value {
+    json!({
+        "phase": "warmup_failed",
+        "config": config,
+    })
+}
+
+pub fn redact_auth_for_logs(_: &Config) -> Map<String, Value> {
+    Map::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bobs_location_translation_matches_python_runner() {
+        let template = "http://rel-bobs-{ordinal}:3000";
+        assert_eq!(
+            to_bobs_internal("https://host/download-3/0123-abcd", template).unwrap(),
+            (
+                "http://rel-bobs-3:3000/api/v1/read/0123-abcd".to_string(),
+                "3".to_string()
+            )
+        );
+        assert_eq!(
+            to_bobs_internal("https://host/download-12/api/v1/abcdef", template)
+                .unwrap()
+                .0,
+            "http://rel-bobs-12:3000/api/v1/read/abcdef"
+        );
+        assert_eq!(
+            to_bobs_internal("https://host/download-4/api/v1/read/object-key", template)
+                .unwrap()
+                .0,
+            "http://rel-bobs-4:3000/api/v1/read/object-key"
+        );
+        assert!(to_bobs_internal("https://host/download-4/not-api/object-key", template).is_err());
+        assert!(to_bobs_internal("https://host/download-4/not_uuid", template).is_err());
+    }
+
+    #[test]
+    fn summary_aggregation_uses_known_percentiles_and_rates() {
+        let now = Instant::now();
+        let cfg = SummaryConfig {
+            frontend_url: "http://frontend:3000".to_string(),
+            collection: "c".to_string(),
+            mock_realm: None,
+            mock_role: "default".to_string(),
+            mock_user_prefix: "mock-".to_string(),
+            warmup_iters: 5,
+            concurrency: 2,
+            total_iters: 4,
+            ramp_seconds: 1,
+            poll_interval_ms: 250,
+            poll_timeout_s: 600,
+            bobs_svc_template: "http://bobs-{ordinal}:3000".to_string(),
+            max_error_rate: 0.01,
+        };
+        let results = vec![
+            IterationResult {
+                outcome: Outcome::Downloaded,
+                submit_ms: Some(10.0),
+                ready_ms: Some(100.0),
+                read_ms: Some(1000.0),
+                bytes: 1_048_576,
+                status: None,
+                read_start: Some(now),
+                read_end: Some(now + Duration::from_secs(1)),
+            },
+            IterationResult {
+                outcome: Outcome::Downloaded,
+                submit_ms: Some(20.0),
+                ready_ms: Some(200.0),
+                read_ms: Some(2000.0),
+                bytes: 2_097_152,
+                status: None,
+                read_start: Some(now + Duration::from_secs(1)),
+                read_end: Some(now + Duration::from_secs(3)),
+            },
+            IterationResult {
+                outcome: Outcome::SubmitFailed,
+                submit_ms: Some(30.0),
+                ready_ms: None,
+                read_ms: None,
+                bytes: 0,
+                status: Some(500),
+                read_start: None,
+                read_end: None,
+            },
+        ];
+        let summary = summarize("measured", cfg, &results, 6.0);
+        assert_eq!(summary.counts.downloaded, 2);
+        assert_eq!(summary.counts.submit_failed, 1);
+        assert_eq!(summary.errors_by_status.get("500"), Some(&1));
+        assert_eq!(summary.percentiles["submit_ms"].p50, Some(20.0));
+        assert_eq!(summary.percentiles["submit_ms"].p90, Some(30.0));
+        assert_eq!(summary.percentiles["ready_ms"].mean, Some(150.0));
+        assert_eq!(summary.bytes_total, 3_145_728);
+        assert_eq!(summary.aggregate_mibps, 1.0);
+        assert_eq!(summary.throughput_rps, 2.0 / 6.0);
+        assert!((summary.error_rate - (1.0 / 3.0)).abs() < f64::EPSILON);
+        assert_eq!(summary.per_stream_mibps.mean, Some(1.0));
+    }
+}

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -1,10 +1,12 @@
 use futures_util::StreamExt;
 use loadgen::{
-    Config, IterationResult, Outcome, summarize, to_bobs_internal, warmup_failed_summary,
+    Config, IterationResult, Outcome, ProgressTracker, loadgen_progress_interval_from_env,
+    summarize, to_bobs_internal, warmup_failed_summary,
 };
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, LOCATION};
 use reqwest::{Client, StatusCode};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
@@ -33,7 +35,7 @@ async fn main() {
     };
 
     for idx in 0..config.warmup_iters {
-        match run_iteration(client.clone(), config.clone(), idx).await {
+        match run_iteration(client.clone(), config.clone(), idx, None).await {
             Ok(result) if result.outcome == Outcome::Downloaded => {}
             Ok(result) => {
                 eprintln!(
@@ -54,8 +56,40 @@ async fn main() {
     }
     eprintln!("warm-up passed: {} full cycles", config.warmup_iters);
 
+    let progress_interval = match loadgen_progress_interval_from_env() {
+        Ok(interval) => interval,
+        Err(err) => {
+            eprintln!("loadgen config error: {err}");
+            std::process::exit(2);
+        }
+    };
+
     let measured_start = Instant::now();
-    let results = run_measured(client, config.clone()).await;
+    let progress = progress_interval.map(|_| Arc::new(ProgressTracker::new(measured_start)));
+    let progress_done = Arc::new(AtomicBool::new(false));
+    let progress_task = progress_interval
+        .zip(progress.clone())
+        .map(|(interval, progress)| {
+            let done = progress_done.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(interval).await;
+                    if done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let snapshot = progress.snapshot(Instant::now());
+                    println!(
+                        "LOADGEN_PROGRESS:{snapshot}",
+                        snapshot = serde_json::to_string(&snapshot).expect("progress serializes")
+                    );
+                }
+            })
+        });
+    let results = run_measured(client, config.clone(), progress).await;
+    progress_done.store(true, Ordering::Relaxed);
+    if let Some(task) = progress_task {
+        task.abort();
+    }
     let duration_s = measured_start.elapsed().as_secs_f64();
     let summary = summarize("measured", config.summary_config(), &results, duration_s);
     let error_rate = summary.error_rate;
@@ -68,7 +102,11 @@ async fn main() {
     }
 }
 
-async fn run_measured(client: Arc<Client>, config: Arc<Config>) -> Vec<IterationResult> {
+async fn run_measured(
+    client: Arc<Client>,
+    config: Arc<Config>,
+    progress: Option<Arc<ProgressTracker>>,
+) -> Vec<IterationResult> {
     let semaphore = Arc::new(Semaphore::new(0));
     let permits = semaphore.clone();
     let concurrency = config.concurrency;
@@ -94,8 +132,12 @@ async fn run_measured(client: Arc<Client>, config: Arc<Config>) -> Vec<Iteration
             .expect("semaphore is not closed");
         let client = client.clone();
         let config = config.clone();
+        let progress = progress.clone();
         join_set.spawn(async move {
-            let result = run_iteration(client, config, idx)
+            if let Some(progress) = &progress {
+                progress.record_started();
+            }
+            let result = run_iteration(client, config, idx, progress.clone())
                 .await
                 .unwrap_or(IterationResult {
                     outcome: Outcome::DownloadFailed,
@@ -107,6 +149,9 @@ async fn run_measured(client: Arc<Client>, config: Arc<Config>) -> Vec<Iteration
                     read_start: None,
                     read_end: None,
                 });
+            if let Some(progress) = &progress {
+                progress.record_finished(result.outcome, result.bytes);
+            }
             drop(permit);
             result
         });
@@ -118,6 +163,9 @@ async fn run_measured(client: Arc<Client>, config: Arc<Config>) -> Vec<Iteration
             Ok(result) => results.push(result),
             Err(err) => {
                 eprintln!("iteration task failed: {err}");
+                if let Some(progress) = &progress {
+                    progress.record_finished(Outcome::DownloadFailed, 0);
+                }
                 results.push(IterationResult {
                     outcome: Outcome::DownloadFailed,
                     submit_ms: None,
@@ -138,6 +186,7 @@ async fn run_iteration(
     client: Arc<Client>,
     config: Arc<Config>,
     idx: usize,
+    progress: Option<Arc<ProgressTracker>>,
 ) -> Result<IterationResult, String> {
     let iteration_start = Instant::now();
     let submit_url = format!(
@@ -158,6 +207,9 @@ async fn run_iteration(
         Err(err) => return Err(format!("submit request failed: {err}")),
     };
     let submit_ms = iteration_start.elapsed().as_secs_f64() * 1000.0;
+    if let Some(progress) = &progress {
+        progress.record_submitted();
+    }
     let submit_status = submit_response.status();
     if submit_status != StatusCode::ACCEPTED {
         drain_response(submit_response).await.ok();
@@ -252,6 +304,9 @@ async fn run_iteration(
     };
 
     let ready_ms = iteration_start.elapsed().as_secs_f64() * 1000.0;
+    if let Some(progress) = &progress {
+        progress.record_ready(ready_ms);
+    }
     let (internal_url, _) = match to_bobs_internal(&location, &config.bobs_svc_template) {
         Ok(value) => value,
         Err(err) => return Err(err),

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -1,0 +1,365 @@
+use futures_util::StreamExt;
+use loadgen::{
+    Config, IterationResult, Outcome, summarize, to_bobs_internal, warmup_failed_summary,
+};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, LOCATION};
+use reqwest::{Client, StatusCode};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+#[tokio::main]
+async fn main() {
+    let config = match Config::from_env() {
+        Ok(config) => Arc::new(config),
+        Err(err) => {
+            eprintln!("loadgen config error: {err}");
+            std::process::exit(2);
+        }
+    };
+
+    let client = match Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .pool_idle_timeout(Duration::from_secs(90))
+        .tcp_keepalive(Duration::from_secs(60))
+        .build()
+    {
+        Ok(client) => Arc::new(client),
+        Err(err) => {
+            eprintln!("failed to build HTTP client: {err}");
+            std::process::exit(2);
+        }
+    };
+
+    for idx in 0..config.warmup_iters {
+        match run_iteration(client.clone(), config.clone(), idx).await {
+            Ok(result) if result.outcome == Outcome::Downloaded => {}
+            Ok(result) => {
+                eprintln!(
+                    "warm-up iteration {idx} failed: {:?}, status={:?}",
+                    result.outcome, result.status
+                );
+                let summary = warmup_failed_summary(config.summary_config());
+                println!("LOADGEN_SUMMARY:{summary}");
+                std::process::exit(1);
+            }
+            Err(err) => {
+                eprintln!("warm-up iteration {idx} failed: {err}");
+                let summary = warmup_failed_summary(config.summary_config());
+                println!("LOADGEN_SUMMARY:{summary}");
+                std::process::exit(1);
+            }
+        }
+    }
+    eprintln!("warm-up passed: {} full cycles", config.warmup_iters);
+
+    let measured_start = Instant::now();
+    let results = run_measured(client, config.clone()).await;
+    let duration_s = measured_start.elapsed().as_secs_f64();
+    let summary = summarize("measured", config.summary_config(), &results, duration_s);
+    let error_rate = summary.error_rate;
+    println!(
+        "LOADGEN_SUMMARY:{summary}",
+        summary = serde_json::to_string(&summary).expect("summary serializes")
+    );
+    if error_rate > config.max_error_rate {
+        std::process::exit(1);
+    }
+}
+
+async fn run_measured(client: Arc<Client>, config: Arc<Config>) -> Vec<IterationResult> {
+    let semaphore = Arc::new(Semaphore::new(0));
+    let permits = semaphore.clone();
+    let concurrency = config.concurrency;
+    let ramp_seconds = config.ramp_seconds;
+    tokio::spawn(async move {
+        if ramp_seconds == 0 {
+            permits.add_permits(concurrency);
+            return;
+        }
+        let interval = Duration::from_secs_f64(ramp_seconds as f64 / concurrency as f64);
+        for _ in 0..concurrency {
+            permits.add_permits(1);
+            tokio::time::sleep(interval).await;
+        }
+    });
+
+    let mut join_set = JoinSet::new();
+    for idx in 0..config.total_iters {
+        let permit = semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore is not closed");
+        let client = client.clone();
+        let config = config.clone();
+        join_set.spawn(async move {
+            let result = run_iteration(client, config, idx)
+                .await
+                .unwrap_or(IterationResult {
+                    outcome: Outcome::DownloadFailed,
+                    submit_ms: None,
+                    ready_ms: None,
+                    read_ms: None,
+                    bytes: 0,
+                    status: None,
+                    read_start: None,
+                    read_end: None,
+                });
+            drop(permit);
+            result
+        });
+    }
+
+    let mut results = Vec::with_capacity(config.total_iters);
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
+            Ok(result) => results.push(result),
+            Err(err) => {
+                eprintln!("iteration task failed: {err}");
+                results.push(IterationResult {
+                    outcome: Outcome::DownloadFailed,
+                    submit_ms: None,
+                    ready_ms: None,
+                    read_ms: None,
+                    bytes: 0,
+                    status: None,
+                    read_start: None,
+                    read_end: None,
+                });
+            }
+        }
+    }
+    results
+}
+
+async fn run_iteration(
+    client: Arc<Client>,
+    config: Arc<Config>,
+    idx: usize,
+) -> Result<IterationResult, String> {
+    let iteration_start = Instant::now();
+    let submit_url = format!(
+        "{}/api/v1/requests/{}",
+        config.frontend_url, config.collection
+    );
+    let mut submit_headers = base_headers(&config, true)?;
+    add_mock_headers(&config, idx, &mut submit_headers)?;
+
+    let submit_response = match client
+        .post(submit_url)
+        .headers(submit_headers)
+        .json(&config.request_body())
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => return Err(format!("submit request failed: {err}")),
+    };
+    let submit_ms = iteration_start.elapsed().as_secs_f64() * 1000.0;
+    let submit_status = submit_response.status();
+    if submit_status != StatusCode::ACCEPTED {
+        drain_response(submit_response).await.ok();
+        return Ok(IterationResult {
+            outcome: Outcome::SubmitFailed,
+            submit_ms: Some(submit_ms),
+            ready_ms: None,
+            read_ms: None,
+            bytes: 0,
+            status: Some(submit_status.as_u16()),
+            read_start: None,
+            read_end: None,
+        });
+    }
+    let submit_json: serde_json::Value = submit_response
+        .json()
+        .await
+        .map_err(|err| format!("submit response JSON decode failed: {err}"))?;
+    let Some(request_id) = submit_json
+        .get("id")
+        .or_else(|| submit_json.get("request_id"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(IterationResult {
+            outcome: Outcome::SubmitFailed,
+            submit_ms: Some(submit_ms),
+            ready_ms: None,
+            read_ms: None,
+            bytes: 0,
+            status: Some(submit_status.as_u16()),
+            read_start: None,
+            read_end: None,
+        });
+    };
+
+    let poll_url = format!("{}/api/v1/requests/{request_id}", config.frontend_url);
+    let deadline = Instant::now() + config.poll_timeout;
+    let location = loop {
+        if Instant::now() >= deadline {
+            return Ok(IterationResult {
+                outcome: Outcome::TimedOut,
+                submit_ms: Some(submit_ms),
+                ready_ms: None,
+                read_ms: None,
+                bytes: 0,
+                status: None,
+                read_start: None,
+                read_end: None,
+            });
+        }
+        let mut poll_headers = base_headers(&config, false)?;
+        add_mock_headers(&config, idx, &mut poll_headers)?;
+        let response = match client.get(&poll_url).headers(poll_headers).send().await {
+            Ok(response) => response,
+            Err(_) => {
+                tokio::time::sleep(config.poll_interval).await;
+                continue;
+            }
+        };
+        let status = response.status();
+        let location = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .map(ToString::to_string);
+        drain_response(response).await.ok();
+        if status == StatusCode::SEE_OTHER {
+            if let Some(location) = location {
+                break location;
+            }
+        } else if status == StatusCode::ACCEPTED
+            || status == StatusCode::NO_CONTENT
+            || status.is_redirection()
+            || status.is_success()
+        {
+            tokio::time::sleep(config.poll_interval).await;
+            continue;
+        } else if status.is_client_error() || status.is_server_error() {
+            return Ok(IterationResult {
+                outcome: Outcome::PollFailed,
+                submit_ms: Some(submit_ms),
+                ready_ms: None,
+                read_ms: None,
+                bytes: 0,
+                status: Some(status.as_u16()),
+                read_start: None,
+                read_end: None,
+            });
+        }
+        tokio::time::sleep(config.poll_interval).await;
+    };
+
+    let ready_ms = iteration_start.elapsed().as_secs_f64() * 1000.0;
+    let (internal_url, _) = match to_bobs_internal(&location, &config.bobs_svc_template) {
+        Ok(value) => value,
+        Err(err) => return Err(err),
+    };
+    let read_start = Instant::now();
+    let download_result = download_body(&client, &internal_url).await;
+    let read_end = Instant::now();
+    let read_ms = (read_end - read_start).as_secs_f64() * 1000.0;
+
+    match download_result {
+        Ok(bytes) => Ok(IterationResult {
+            outcome: Outcome::Downloaded,
+            submit_ms: Some(submit_ms),
+            ready_ms: Some(ready_ms),
+            read_ms: Some(read_ms),
+            bytes,
+            status: None,
+            read_start: Some(read_start),
+            read_end: Some(read_end),
+        }),
+        Err(DownloadError { status }) => Ok(IterationResult {
+            outcome: Outcome::DownloadFailed,
+            submit_ms: Some(submit_ms),
+            ready_ms: Some(ready_ms),
+            read_ms: Some(read_ms),
+            bytes: 0,
+            status,
+            read_start: Some(read_start),
+            read_end: Some(read_end),
+        }),
+    }
+}
+
+fn base_headers(config: &Config, include_content_type: bool) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&config.auth)
+            .map_err(|err| format!("LOADGEN_AUTH is not a valid header value: {err}"))?,
+    );
+    if include_content_type {
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+    Ok(headers)
+}
+
+fn add_mock_headers(config: &Config, idx: usize, headers: &mut HeaderMap) -> Result<(), String> {
+    let Some(realm) = &config.mock_realm else {
+        return Ok(());
+    };
+    headers.insert(
+        "polytope-mock-user",
+        HeaderValue::from_str(&format!("{}{idx}", config.mock_user_prefix))
+            .map_err(|err| format!("mock user header is invalid: {err}"))?,
+    );
+    headers.insert(
+        "polytope-mock-roles",
+        HeaderValue::from_str(&format!("{}:{}", realm, config.mock_role))
+            .map_err(|err| format!("mock roles header is invalid: {err}"))?,
+    );
+    Ok(())
+}
+
+struct DownloadError {
+    status: Option<u16>,
+}
+
+async fn download_body(client: &Client, internal_url: &str) -> Result<u64, DownloadError> {
+    let mut last_status = None;
+    for attempt in 1..=5 {
+        let response = client
+            .get(internal_url)
+            .send()
+            .await
+            .map_err(|_| DownloadError { status: None })?;
+        let status = response.status();
+        if status == StatusCode::TEMPORARY_REDIRECT {
+            last_status = Some(status.as_u16());
+            drain_response(response).await.ok();
+            if attempt < 5 {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            return Err(DownloadError {
+                status: last_status,
+            });
+        }
+        if status != StatusCode::OK && status != StatusCode::PARTIAL_CONTENT {
+            let status = status.as_u16();
+            drain_response(response).await.ok();
+            return Err(DownloadError {
+                status: Some(status),
+            });
+        }
+        return drain_response(response).await.map_err(|_| DownloadError {
+            status: last_status,
+        });
+    }
+    Err(DownloadError {
+        status: last_status,
+    })
+}
+
+async fn drain_response(response: reqwest::Response) -> Result<u64, reqwest::Error> {
+    let mut stream = response.bytes_stream();
+    let mut total = 0u64;
+    while let Some(chunk) = stream.next().await {
+        total += chunk?.len() as u64;
+    }
+    Ok(total)
+}

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -1,14 +1,15 @@
 use futures_util::StreamExt;
 use loadgen::{
-    Config, IterationResult, Outcome, ProgressTracker, loadgen_progress_interval_from_env,
-    summarize, to_bobs_internal, warmup_failed_summary,
+    Config, IterationResult, Outcome, ProgressTracker, RunLimit, SummaryMetadata,
+    loadgen_progress_interval_from_env, summarize_with_metadata, to_bobs_internal,
+    warmup_failed_summary,
 };
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, LOCATION};
 use reqwest::{Client, StatusCode};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
 
 #[tokio::main]
@@ -85,13 +86,28 @@ async fn main() {
                 }
             })
         });
-    let results = run_measured(client, config.clone(), progress).await;
+    let measured = run_measured(client, config.clone(), progress).await;
     progress_done.store(true, Ordering::Relaxed);
     if let Some(task) = progress_task {
         task.abort();
     }
     let duration_s = measured_start.elapsed().as_secs_f64();
-    let summary = summarize("measured", config.summary_config(), &results, duration_s);
+    let summary = summarize_with_metadata(
+        "measured",
+        config.summary_config(),
+        &measured.results,
+        duration_s,
+        SummaryMetadata {
+            run_limit: config.run_limit.name().to_string(),
+            target_duration_s: config.run_limit.target_duration_s(),
+            submission_duration_s: measured.submission_duration_s,
+            drain_duration_s: measured.drain_duration_s,
+            scheduled: measured.scheduled,
+            missed_starts: measured.missed_starts,
+            measured_start: Some(measured_start),
+            bucket_width_s: 60.0,
+        },
+    );
     let error_rate = summary.error_rate;
     println!(
         "LOADGEN_SUMMARY:{summary}",
@@ -102,11 +118,33 @@ async fn main() {
     }
 }
 
+struct MeasuredRun {
+    results: Vec<IterationResult>,
+    submission_duration_s: f64,
+    drain_duration_s: f64,
+    scheduled: usize,
+    missed_starts: usize,
+}
+
 async fn run_measured(
     client: Arc<Client>,
     config: Arc<Config>,
     progress: Option<Arc<ProgressTracker>>,
-) -> Vec<IterationResult> {
+) -> MeasuredRun {
+    match config.run_limit.clone() {
+        RunLimit::Iterations => run_measured_iterations(client, config, progress).await,
+        RunLimit::Duration { duration, rps } => match rps {
+            Some(rps) => run_measured_duration_open(client, config, progress, duration, rps).await,
+            None => run_measured_duration_closed_loop(client, config, progress, duration).await,
+        },
+    }
+}
+
+async fn run_measured_iterations(
+    client: Arc<Client>,
+    config: Arc<Config>,
+    progress: Option<Arc<ProgressTracker>>,
+) -> MeasuredRun {
     let semaphore = Arc::new(Semaphore::new(0));
     let permits = semaphore.clone();
     let concurrency = config.concurrency;
@@ -124,62 +162,241 @@ async fn run_measured(
     });
 
     let mut join_set = JoinSet::new();
+    let submission_start = Instant::now();
     for idx in 0..config.total_iters {
         let permit = semaphore
             .clone()
             .acquire_owned()
             .await
             .expect("semaphore is not closed");
-        let client = client.clone();
-        let config = config.clone();
-        let progress = progress.clone();
-        join_set.spawn(async move {
-            if let Some(progress) = &progress {
-                progress.record_started();
-            }
-            let result = run_iteration(client, config, idx, progress.clone())
-                .await
-                .unwrap_or(IterationResult {
-                    outcome: Outcome::DownloadFailed,
-                    submit_ms: None,
-                    ready_ms: None,
-                    read_ms: None,
-                    bytes: 0,
-                    status: None,
-                    read_start: None,
-                    read_end: None,
-                });
-            if let Some(progress) = &progress {
-                progress.record_finished(result.outcome, result.bytes);
-            }
-            drop(permit);
-            result
-        });
+        spawn_iteration(
+            &mut join_set,
+            client.clone(),
+            config.clone(),
+            idx,
+            progress.clone(),
+            permit,
+        );
     }
 
+    let submission_duration_s = submission_start.elapsed().as_secs_f64();
+    let drain_start = Instant::now();
     let mut results = Vec::with_capacity(config.total_iters);
-    while let Some(join_result) = join_set.join_next().await {
-        match join_result {
-            Ok(result) => results.push(result),
-            Err(err) => {
-                eprintln!("iteration task failed: {err}");
-                if let Some(progress) = &progress {
-                    progress.record_finished(Outcome::DownloadFailed, 0);
+    drain_join_set(&mut join_set, &mut results, &progress).await;
+    MeasuredRun {
+        results,
+        submission_duration_s,
+        drain_duration_s: drain_start.elapsed().as_secs_f64(),
+        scheduled: config.total_iters,
+        missed_starts: 0,
+    }
+}
+
+async fn run_measured_duration_closed_loop(
+    client: Arc<Client>,
+    config: Arc<Config>,
+    progress: Option<Arc<ProgressTracker>>,
+    duration: Duration,
+) -> MeasuredRun {
+    let semaphore = Arc::new(Semaphore::new(0));
+    let permits = semaphore.clone();
+    let concurrency = config.concurrency;
+    let ramp_seconds = config.ramp_seconds;
+    tokio::spawn(async move {
+        if ramp_seconds == 0 {
+            permits.add_permits(concurrency);
+            return;
+        }
+        let interval = Duration::from_secs_f64(ramp_seconds as f64 / concurrency as f64);
+        for _ in 0..concurrency {
+            permits.add_permits(1);
+            tokio::time::sleep(interval).await;
+        }
+    });
+
+    let submission_start = Instant::now();
+    let deadline = submission_start + duration;
+    let mut join_set = JoinSet::new();
+    let mut scheduled = 0usize;
+    loop {
+        if Instant::now() >= deadline {
+            break;
+        }
+        let permit_fut = semaphore.clone().acquire_owned();
+        tokio::pin!(permit_fut);
+        tokio::select! {
+            permit = &mut permit_fut => {
+                let permit = permit.expect("semaphore is not closed");
+                if Instant::now() >= deadline {
+                    drop(permit);
+                    break;
                 }
-                results.push(IterationResult {
-                    outcome: Outcome::DownloadFailed,
-                    submit_ms: None,
-                    ready_ms: None,
-                    read_ms: None,
-                    bytes: 0,
-                    status: None,
-                    read_start: None,
-                    read_end: None,
-                });
+                spawn_iteration(
+                    &mut join_set,
+                    client.clone(),
+                    config.clone(),
+                    scheduled,
+                    progress.clone(),
+                    permit,
+                );
+                scheduled += 1;
             }
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => break,
         }
     }
-    results
+
+    let submission_duration_s = submission_start.elapsed().as_secs_f64();
+    let drain_start = Instant::now();
+    let mut results = Vec::with_capacity(scheduled);
+    drain_join_set(&mut join_set, &mut results, &progress).await;
+    MeasuredRun {
+        results,
+        submission_duration_s,
+        drain_duration_s: drain_start.elapsed().as_secs_f64(),
+        scheduled,
+        missed_starts: 0,
+    }
+}
+
+async fn run_measured_duration_open(
+    client: Arc<Client>,
+    config: Arc<Config>,
+    progress: Option<Arc<ProgressTracker>>,
+    duration: Duration,
+    rps: f64,
+) -> MeasuredRun {
+    let semaphore = Arc::new(Semaphore::new(config.concurrency));
+    let submission_start = Instant::now();
+    let deadline = submission_start + duration;
+    let mut join_set = JoinSet::new();
+    let mut results = Vec::new();
+    let mut scheduled = 0usize;
+    let mut missed_starts = 0usize;
+    let mut start_number = 1usize;
+
+    loop {
+        let planned_offset = planned_open_model_offset(start_number, rps, config.ramp_seconds);
+        let planned_at = submission_start + planned_offset;
+        if planned_at >= deadline {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+            break;
+        }
+        while let Some(join_result) = join_set.try_join_next() {
+            handle_join_result(join_result, &mut results, &progress);
+        }
+        tokio::time::sleep_until(tokio::time::Instant::from_std(planned_at)).await;
+        match semaphore.clone().try_acquire_owned() {
+            Ok(permit) => {
+                spawn_iteration(
+                    &mut join_set,
+                    client.clone(),
+                    config.clone(),
+                    scheduled,
+                    progress.clone(),
+                    permit,
+                );
+                scheduled += 1;
+            }
+            Err(_) => {
+                missed_starts += 1;
+                if let Some(progress) = &progress {
+                    progress.record_missed_start();
+                }
+            }
+        }
+        start_number += 1;
+    }
+
+    let submission_duration_s = submission_start.elapsed().as_secs_f64();
+    let drain_start = Instant::now();
+    drain_join_set(&mut join_set, &mut results, &progress).await;
+    MeasuredRun {
+        results,
+        submission_duration_s,
+        drain_duration_s: drain_start.elapsed().as_secs_f64(),
+        scheduled,
+        missed_starts,
+    }
+}
+
+fn planned_open_model_offset(start_number: usize, rps: f64, ramp_seconds: u64) -> Duration {
+    let n = start_number as f64;
+    let ramp_s = ramp_seconds as f64;
+    let offset_s = if ramp_s <= 0.0 {
+        n / rps
+    } else {
+        let starts_during_ramp = rps * ramp_s / 2.0;
+        if n <= starts_during_ramp {
+            (2.0 * ramp_s * n / rps).sqrt()
+        } else {
+            (n / rps) + (ramp_s / 2.0)
+        }
+    };
+    Duration::from_secs_f64(offset_s)
+}
+
+fn spawn_iteration(
+    join_set: &mut JoinSet<IterationResult>,
+    client: Arc<Client>,
+    config: Arc<Config>,
+    idx: usize,
+    progress: Option<Arc<ProgressTracker>>,
+    permit: OwnedSemaphorePermit,
+) {
+    join_set.spawn(async move {
+        if let Some(progress) = &progress {
+            progress.record_started();
+        }
+        let result = run_iteration(client, config, idx, progress.clone())
+            .await
+            .unwrap_or_else(|_| failed_iteration_result());
+        if let Some(progress) = &progress {
+            progress.record_finished(result.outcome, result.bytes);
+        }
+        drop(permit);
+        result
+    });
+}
+
+async fn drain_join_set(
+    join_set: &mut JoinSet<IterationResult>,
+    results: &mut Vec<IterationResult>,
+    progress: &Option<Arc<ProgressTracker>>,
+) {
+    while let Some(join_result) = join_set.join_next().await {
+        handle_join_result(join_result, results, progress);
+    }
+}
+
+fn handle_join_result(
+    join_result: Result<IterationResult, tokio::task::JoinError>,
+    results: &mut Vec<IterationResult>,
+    progress: &Option<Arc<ProgressTracker>>,
+) {
+    match join_result {
+        Ok(result) => results.push(result),
+        Err(err) => {
+            eprintln!("iteration task failed: {err}");
+            if let Some(progress) = progress {
+                progress.record_finished(Outcome::DownloadFailed, 0);
+            }
+            results.push(failed_iteration_result());
+        }
+    }
+}
+
+fn failed_iteration_result() -> IterationResult {
+    IterationResult {
+        outcome: Outcome::DownloadFailed,
+        submit_ms: None,
+        ready_ms: None,
+        read_ms: None,
+        bytes: 0,
+        status: None,
+        read_start: None,
+        read_end: None,
+        completed_at: Instant::now(),
+    }
 }
 
 async fn run_iteration(
@@ -222,6 +439,7 @@ async fn run_iteration(
             status: Some(submit_status.as_u16()),
             read_start: None,
             read_end: None,
+            completed_at: Instant::now(),
         });
     }
     let submit_json: serde_json::Value = submit_response
@@ -243,6 +461,7 @@ async fn run_iteration(
             status: Some(submit_status.as_u16()),
             read_start: None,
             read_end: None,
+            completed_at: Instant::now(),
         });
     };
 
@@ -259,6 +478,7 @@ async fn run_iteration(
                 status: None,
                 read_start: None,
                 read_end: None,
+                completed_at: Instant::now(),
             });
         }
         let mut poll_headers = base_headers(&config, false)?;
@@ -298,6 +518,7 @@ async fn run_iteration(
                 status: Some(status.as_u16()),
                 read_start: None,
                 read_end: None,
+                completed_at: Instant::now(),
             });
         }
         tokio::time::sleep(config.poll_interval).await;
@@ -326,6 +547,7 @@ async fn run_iteration(
             status: None,
             read_start: Some(read_start),
             read_end: Some(read_end),
+            completed_at: read_end,
         }),
         Err(DownloadError { status }) => Ok(IterationResult {
             outcome: Outcome::DownloadFailed,
@@ -336,6 +558,7 @@ async fn run_iteration(
             status,
             read_start: Some(read_start),
             read_end: Some(read_end),
+            completed_at: read_end,
         }),
     }
 }
@@ -417,4 +640,135 @@ async fn drain_response(response: reqwest::Response) -> Result<u64, reqwest::Err
         total += chunk?.len() as u64;
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn test_config(base_url: String, duration: Duration, rps: Option<f64>) -> Arc<Config> {
+        Arc::new(Config {
+            frontend_url: base_url.clone(),
+            collection: "c".to_string(),
+            auth: "Bearer test".to_string(),
+            payload_json: json!({"request": "test"}),
+            mock_realm: None,
+            mock_role: "default".to_string(),
+            mock_user_prefix: "mock-".to_string(),
+            warmup_iters: 0,
+            concurrency: 1,
+            total_iters: 0,
+            run_limit: RunLimit::Duration { duration, rps },
+            ramp_seconds: 0,
+            poll_interval: Duration::from_millis(1),
+            poll_timeout: Duration::from_secs(5),
+            bobs_svc_template: base_url,
+            max_error_rate: 1.0,
+        })
+    }
+
+    async fn start_test_server(download_delay: Duration) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{addr}");
+        let location_base = base_url.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let location_base = location_base.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let Ok(n) = stream.read(&mut buf).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]);
+                    let Some(first_line) = request.lines().next() else {
+                        return;
+                    };
+                    let mut parts = first_line.split_whitespace();
+                    let method = parts.next().unwrap_or_default();
+                    let path = parts.next().unwrap_or_default();
+                    let response = if method == "POST" && path == "/api/v1/requests/c" {
+                        "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: 14\r\n\r\n{\"id\":\"req-1\"}".to_string()
+                    } else if method == "GET" && path == "/api/v1/requests/req-1" {
+                        format!(
+                            "HTTP/1.1 303 See Other\r\nLocation: {location_base}/download-0/0123abcd\r\nContent-Length: 0\r\n\r\n"
+                        )
+                    } else if method == "GET" && path == "/api/v1/read/api/v1/read/0123abcd" {
+                        tokio::time::sleep(download_delay).await;
+                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_string()
+                    } else if method == "GET" && path == "/api/v1/read/0123abcd" {
+                        tokio::time::sleep(download_delay).await;
+                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_string()
+                    } else {
+                        format!(
+                            "HTTP/1.1 404 Not Found\r\nContent-Length: {}\r\n\r\n{path}",
+                            path.len()
+                        )
+                    };
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        base_url
+    }
+
+    #[tokio::test]
+    async fn duration_closed_loop_stops_scheduling_at_deadline_and_drains_in_flight() {
+        let base_url = start_test_server(Duration::from_millis(500)).await;
+        let client = Arc::new(
+            Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+        );
+        let config = test_config(base_url, Duration::from_millis(20), None);
+        let run =
+            run_measured_duration_closed_loop(client, config, None, Duration::from_millis(20))
+                .await;
+        assert_eq!(run.scheduled, 1);
+        assert_eq!(run.missed_starts, 0);
+        assert_eq!(run.results.len(), 1);
+        assert!(
+            run.submission_duration_s >= 0.015,
+            "{}",
+            run.submission_duration_s
+        );
+        assert!(run.drain_duration_s >= 0.05, "{}", run.drain_duration_s);
+    }
+
+    #[tokio::test]
+    async fn duration_open_model_counts_missed_starts_instead_of_queueing() {
+        let base_url = start_test_server(Duration::from_millis(200)).await;
+        let client = Arc::new(
+            Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+        );
+        let config = test_config(base_url, Duration::from_millis(250), Some(20.0));
+        let progress = Arc::new(ProgressTracker::new(Instant::now()));
+        let run = run_measured_duration_open(
+            client,
+            config,
+            Some(progress.clone()),
+            Duration::from_millis(250),
+            20.0,
+        )
+        .await;
+        assert!(run.scheduled >= 1, "scheduled={}", run.scheduled);
+        assert!(run.missed_starts >= 1, "missed={}", run.missed_starts);
+        assert!(
+            run.submission_duration_s >= 0.24,
+            "{}",
+            run.submission_duration_s
+        );
+        let snapshot = progress.snapshot(Instant::now());
+        assert_eq!(snapshot.counts.scheduled, run.scheduled);
+        assert_eq!(snapshot.counts.missed_starts, run.missed_starts);
+    }
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -35,12 +35,13 @@ metadata:
   GIT_AUTH_TOKEN: '{{ .GH_TOKEN }}'
   PACKAGE_NAME: polytope-fe-worker
   rpm_repo: '{{ .RPM_REPO }}'
-  ecbuild_version: '{{default "3.8.2" .FE_ECBUILD_VERSION}}'
-  eckit_version: '{{default "1.28.3" .FE_ECKIT_VERSION}}'
-  eccodes_version: '{{default "2.33.1" .FE_ECCODES_VERSION}}'
-  fdb_version: '{{default "5.14.0" .FE_FDB_VERSION}}'
-  gribjump_version: '{{default "0.10.2" .FE_GRIBJUMP_VERSION}}'
-  pyfdb_version: '{{default "0.1.0" .FE_PYFDB_VERSION}}'
+  ecbuild_version: '{{default "3.12.0" .FE_ECBUILD_VERSION}}'
+  eckit_version: '{{default "1.33.2" .FE_ECKIT_VERSION}}'
+  eccodes_version: '{{default "2.46.0" .FE_ECCODES_VERSION}}'
+  metkit_version: '{{default "1.18.1" .FE_METKIT_VERSION}}'
+  fdb_version: '{{default "5.21.3" .FE_FDB_VERSION}}'
+  gribjump_version: '{{default "0.12.0" .FE_GRIBJUMP_VERSION}}'
+  pyfdb_version: '{{default "5.21.0.19" .FE_PYFDB_VERSION}}'
 
 .fdb_build_args: &fdb_build_args
   BIN_NAME: fdb-worker

--- a/workers/common/src/delivery/bobs.rs
+++ b/workers/common/src/delivery/bobs.rs
@@ -38,13 +38,24 @@ impl ResultDelivery for BobsPush {
             },
             Err(e) => {
                 let (enduser_id, enduser_realm) = enduser_fields(context.user);
-                if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
-                    tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, error = %e, "result delivery failed");
+                if let Some(source_error) = context.source_error_message() {
+                    if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                        tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, source_error = %source_error, sink_error = %e, "result delivery failed after source stream error");
+                    } else {
+                        tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, source_error = %source_error, sink_error = %e, "result delivery failed after source stream error");
+                    }
+                    Completion::Error {
+                        message: source_error,
+                    }
                 } else {
-                    tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, error = %e, "result delivery failed");
-                }
-                Completion::Error {
-                    message: format!("delivery failed: {e}"),
+                    if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
+                        tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, error = %e, "result delivery failed");
+                    } else {
+                        tracing::error!("event.name" = "worker.delivery.failed", outcome = "error", job.id = %context.job_id, error = %e, "result delivery failed");
+                    }
+                    Completion::Error {
+                        message: format!("delivery failed: {e}"),
+                    }
                 }
             }
         }
@@ -238,6 +249,7 @@ mod tests {
                 DeliveryContext {
                     job_id: "job-1",
                     user: &serde_json::json!({}),
+                    source_error: None,
                 },
             )
             .await;
@@ -351,6 +363,7 @@ mod tests {
                 DeliveryContext {
                     job_id: "job-1",
                     user: &serde_json::json!({}),
+                    source_error: None,
                 },
             )
             .await;
@@ -374,6 +387,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bobs_push_prefers_source_error_when_stream_fails_mid_body() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let bobs_url = format!("http://{addr}");
+
+        let state = Arc::new(StreamingBobsState {
+            base_url: bobs_url.clone(),
+            created_keys: Mutex::new(vec![]),
+            writes: Mutex::new(vec![]),
+            completed: Mutex::new(false),
+        });
+        let app = Router::new()
+            .route("/create", put(streaming_create))
+            .route("/write/{key}/{offset}", post(streaming_write))
+            .route("/complete/{key}", post(streaming_complete))
+            .with_state(state.clone());
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let h2_client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("build h2 client");
+        let push = BobsPush {
+            api_base: bobs_url.clone(),
+            create_client: h2_client.clone(),
+            body_client: h2_client,
+        };
+
+        let source_error = crate::SourceError::new();
+        source_error.set_once(
+            "The requested post-processing is not supported for this data. Details: mars-client error: Serious bug: Representation::croppedRepresentation() not implemented for HEALPixNested[name=H128]",
+        );
+        let stream = futures::stream::iter(vec![
+            Ok::<bytes::Bytes, std::io::Error>(bytes::Bytes::from_static(b"abc")),
+            Err(std::io::Error::other(
+                "mars-client error: Serious bug: Representation::croppedRepresentation() not implemented for HEALPixNested[name=H128]",
+            )),
+        ]);
+        let body = reqwest::Body::wrap_stream(stream);
+
+        let result = push
+            .deliver(
+                "application/octet-stream",
+                None,
+                body,
+                &serde_json::json!({}),
+                DeliveryContext {
+                    job_id: "job-1",
+                    user: &serde_json::json!({}),
+                    source_error: Some(source_error),
+                },
+            )
+            .await;
+
+        match result {
+            Completion::Error { message } => {
+                assert!(
+                    message.contains("not supported for this data"),
+                    "mapped source message should win, got: {message}"
+                );
+                assert!(message.contains("croppedRepresentation"));
+                assert!(!message.starts_with("delivery failed:"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+        assert!(
+            !*state.completed.lock().unwrap(),
+            "BOBS object must not be completed after a source stream error"
+        );
+    }
+
+    #[tokio::test]
     async fn bobs_push_returns_error_when_unreachable() {
         let h2_client = reqwest::Client::builder()
             .http2_prior_knowledge()
@@ -393,6 +479,7 @@ mod tests {
                 DeliveryContext {
                     job_id: "job-1",
                     user: &serde_json::json!({}),
+                    source_error: None,
                 },
             )
             .await;
@@ -442,6 +529,7 @@ mod tests {
                 DeliveryContext {
                     job_id: "job-1",
                     user: &serde_json::json!({}),
+                    source_error: None,
                 },
             )
             .await;

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -50,14 +50,17 @@ pub async fn make_delivery(config: &DeliveryConfig) -> Box<dyn ResultDelivery> {
                 .trim_start_matches("http://")
                 .trim_start_matches("https://");
             let api_base = format!("http://{host}/api/v1");
-            // Two separate clients so the large (16 MiB+) body uploads on
-            // `body_client` cannot head-of-line-block the small `create`/`complete`
-            // requests on a shared h2 connection. Both keep their connection pools
-            // warm: forcing a cold TCP+h2 handshake per create (the previous
-            // `pool_max_idle_per_host(0)`) made the create path fail under load with
-            // "error sending request" while the warm body path stayed healthy.
+            // create_client deliberately keeps NO idle connections
+            // (pool_max_idle_per_host(0)). Each create opens a fresh connection to
+            // the BOBS *service*, so kube-proxy re-load-balances it across BOBS
+            // pods and spools spread evenly. A warm pooled h2 connection would pin
+            // ALL of a worker's creates to one BOBS pod, concentrating load and
+            // memory (and OOM risk) on that pod. The body write/complete then follow
+            // the per-pod write_url returned by create, so body_client correctly
+            // tracks whichever pod owns each spool.
             let create_client = reqwest::Client::builder()
                 .http2_prior_knowledge()
+                .pool_max_idle_per_host(0)
                 .build()
                 .expect("build BOBS create_client");
             let body_client = reqwest::Client::builder()

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -50,9 +50,14 @@ pub async fn make_delivery(config: &DeliveryConfig) -> Box<dyn ResultDelivery> {
                 .trim_start_matches("http://")
                 .trim_start_matches("https://");
             let api_base = format!("http://{host}/api/v1");
+            // Two separate clients so the large (16 MiB+) body uploads on
+            // `body_client` cannot head-of-line-block the small `create`/`complete`
+            // requests on a shared h2 connection. Both keep their connection pools
+            // warm: forcing a cold TCP+h2 handshake per create (the previous
+            // `pool_max_idle_per_host(0)`) made the create path fail under load with
+            // "error sending request" while the warm body path stayed healthy.
             let create_client = reqwest::Client::builder()
                 .http2_prior_knowledge()
-                .pool_max_idle_per_host(0)
                 .build()
                 .expect("build BOBS create_client");
             let body_client = reqwest::Client::builder()

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -1,13 +1,20 @@
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 
-use crate::Completion;
 use crate::delivery_config::{DeliveryConfig, DeliveryType};
+use crate::{Completion, SourceError};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DeliveryContext<'a> {
     pub job_id: &'a str,
     pub user: &'a serde_json::Value,
+    pub source_error: Option<SourceError>,
+}
+
+impl DeliveryContext<'_> {
+    pub fn source_error_message(&self) -> Option<String> {
+        self.source_error.as_ref().and_then(SourceError::message)
+    }
 }
 
 pub(crate) fn enduser_fields(user: &serde_json::Value) -> (Option<&str>, Option<&str>) {
@@ -131,7 +138,7 @@ impl ResultDelivery for DirectDelivery {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         metadata: &serde_json::Value,
-        _context: DeliveryContext<'_>,
+        context: DeliveryContext<'_>,
     ) -> Completion {
         if metadata.get("buffer_full_output").and_then(|v| v.as_bool()) == Some(true) {
             return Completion::Error {
@@ -143,6 +150,7 @@ impl ResultDelivery for DirectDelivery {
             content_encoding: content_encoding.map(str::to_string),
             content_length: None,
             body,
+            source_error: context.source_error,
         }
     }
 }

--- a/workers/common/src/delivery/s3.rs
+++ b/workers/common/src/delivery/s3.rs
@@ -27,16 +27,32 @@ impl ResultDelivery for S3Push {
         content_encoding: Option<&str>,
         body: reqwest::Body,
         _metadata: &serde_json::Value,
-        _context: DeliveryContext<'_>,
+        context: DeliveryContext<'_>,
     ) -> Completion {
-        match self.push(content_type, content_encoding, body).await {
+        match self
+            .push(
+                content_type,
+                content_encoding,
+                body,
+                context.source_error.clone(),
+            )
+            .await
+        {
             Ok(location) => Completion::Redirect {
                 location,
                 message: "result available for download".to_string(),
             },
-            Err(e) => Completion::Error {
-                message: format!("delivery failed: {e}"),
-            },
+            Err(e) => {
+                if let Some(source_error) = context.source_error_message() {
+                    Completion::Error {
+                        message: source_error,
+                    }
+                } else {
+                    Completion::Error {
+                        message: format!("delivery failed: {e}"),
+                    }
+                }
+            }
         }
     }
 }
@@ -47,6 +63,7 @@ impl S3Push {
         content_type: &str,
         content_encoding: Option<&str>,
         body: reqwest::Body,
+        source_error: Option<crate::SourceError>,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let s3_key = self.next_key();
 
@@ -66,7 +83,10 @@ impl S3Push {
             .ok_or("missing upload_id from CreateMultipartUpload")?
             .to_string();
 
-        let parts = match self.upload_stream_parts(&s3_key, &upload_id, body).await {
+        let parts = match self
+            .upload_stream_parts(&s3_key, &upload_id, body, source_error)
+            .await
+        {
             Ok(parts) => parts,
             Err(err) => {
                 let _ = self
@@ -101,13 +121,26 @@ impl S3Push {
         s3_key: &str,
         upload_id: &str,
         body: reqwest::Body,
+        source_error: Option<crate::SourceError>,
     ) -> Result<Vec<CompletedPart>, Box<dyn std::error::Error + Send + Sync>> {
         let mut completed_parts = Vec::new();
         let mut stream = ByteStream::from_body_1_x(body);
         let mut buffer = BytesMut::new();
         let mut part_number: i32 = 1;
 
-        while let Some(chunk) = stream.try_next().await? {
+        loop {
+            let next = match stream.try_next().await {
+                Ok(next) => next,
+                Err(err) => {
+                    if let Some(message) =
+                        source_error.as_ref().and_then(crate::SourceError::message)
+                    {
+                        return Err(message.into());
+                    }
+                    return Err(err.into());
+                }
+            };
+            let Some(chunk) = next else { break };
             buffer.extend_from_slice(&chunk);
 
             while buffer.len() >= S3_PART_SIZE_BYTES {
@@ -250,6 +283,7 @@ mod tests {
                 DeliveryContext {
                     job_id: "job-1",
                     user: &serde_json::json!({}),
+                    source_error: None,
                 },
             )
             .await;

--- a/workers/common/src/encoding.rs
+++ b/workers/common/src/encoding.rs
@@ -1,7 +1,9 @@
 use async_compression::tokio::bufread::{GzipEncoder, ZstdEncoder};
 use bytes::Bytes;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::delivery_config::Codec;
@@ -34,7 +36,25 @@ pub fn encode_stream<S>(stream: S, codec: &Codec) -> reqwest::Body
 where
     S: Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin + 'static,
 {
-    reqwest::Body::wrap_stream(compress_to_stream(stream, codec))
+    encode_stream_counted(stream, codec).0
+}
+
+/// Like [`encode_stream`], but also returns a counter that tallies the number of
+/// post-encoding bytes (i.e. the bytes actually delivered) as the body is
+/// consumed downstream. The counter only reaches its final value once the
+/// returned body has been fully streamed, so read it after delivery completes.
+pub fn encode_stream_counted<S>(stream: S, codec: &Codec) -> (reqwest::Body, Arc<AtomicU64>)
+where
+    S: Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin + 'static,
+{
+    let counter = Arc::new(AtomicU64::new(0));
+    let counter_clone = Arc::clone(&counter);
+    let counted = compress_to_stream(stream, codec).inspect(move |item| {
+        if let Ok(chunk) = item {
+            counter_clone.fetch_add(chunk.len() as u64, Ordering::Relaxed);
+        }
+    });
+    (reqwest::Body::wrap_stream(counted), counter)
 }
 
 #[cfg(test)]
@@ -102,5 +122,33 @@ mod tests {
         let decoder = GzipDecoder::new(reader);
         let decompressed = collect_stream(ReaderStream::new(decoder)).await;
         assert_eq!(decompressed, data);
+    }
+
+    #[tokio::test]
+    async fn encode_stream_counted_tallies_identity_bytes() {
+        use http_body_util::BodyExt;
+        let data = vec![b'x'; 4096];
+        let (body, counter) = encode_stream_counted(make_stream(data.clone()), &Codec::Identity);
+        // Counter only settles once the body is fully consumed.
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+        let delivered = body.collect().await.unwrap().to_bytes();
+        assert_eq!(delivered.len(), data.len());
+        assert_eq!(counter.load(Ordering::Relaxed), data.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn encode_stream_counted_counts_post_encoding_bytes() {
+        use http_body_util::BodyExt;
+        let data = vec![b'a'; 10_000];
+        let (body, counter) = encode_stream_counted(make_stream(data.clone()), &Codec::Gzip);
+        let delivered = body.collect().await.unwrap().to_bytes();
+        let counted = counter.load(Ordering::Relaxed);
+        // The counter reflects bytes actually delivered (post-compression), not input size.
+        assert_eq!(counted as usize, delivered.len());
+        assert!(
+            counted < data.len() as u64,
+            "gzip of repetitive data should be smaller than the {}-byte input, got {counted}",
+            data.len()
+        );
     }
 }

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -127,6 +127,8 @@ enum CompletionRequest {
     Error { message: String },
 }
 
+pub const DEFAULT_POLL_TIMEOUT_MS: u64 = 3000;
+
 #[derive(Debug, Clone)]
 pub struct WorkerConfig {
     pub broker_url: String,
@@ -201,15 +203,27 @@ pub trait Processor: Send + Sync {
 
 async fn worker_task<P: Processor + 'static>(
     config: WorkerConfig,
-    client: reqwest::Client,
+    worker_index: usize,
     delivery: std::sync::Arc<dyn ResultDelivery>,
     processor: std::sync::Arc<P>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> Result<(), reqwest::Error> {
+    let mut poll_cycle: u64 = 0;
     loop {
         if *shutdown.borrow() {
             break;
         }
+
+        poll_cycle = poll_cycle.saturating_add(1);
+        tracing::debug!(
+            "event.name" = "worker.broker.poll_cycle.started",
+            worker_index,
+            poll_cycle,
+            broker_url = %config.broker_url,
+            poll_timeout_ms = config.poll_timeout_ms,
+            "worker broker poll cycle started"
+        );
+        let client = reqwest::Client::builder().build()?;
 
         let response = tokio::select! {
             biased;
@@ -430,7 +444,6 @@ pub async fn run_worker_loop<P: Processor + 'static>(
             .unwrap();
     });
 
-    let client = reqwest::Client::builder().build()?;
     let delivery: std::sync::Arc<dyn ResultDelivery> =
         std::sync::Arc::from(make_delivery(&delivery_config).await);
     let processor = std::sync::Arc::new(processor);
@@ -439,7 +452,6 @@ pub async fn run_worker_loop<P: Processor + 'static>(
     let mut tasks = Vec::with_capacity(config.worker_concurrency);
     for worker_index in 0..config.worker_concurrency {
         let task_config = config.clone();
-        let task_client = client.clone();
         let task_delivery = delivery.clone();
         let task_processor = processor.clone();
         let task_shutdown = shutdown_rx.clone();
@@ -447,7 +459,7 @@ pub async fn run_worker_loop<P: Processor + 'static>(
             tracing::debug!(worker_index, "worker task started");
             let result = worker_task(
                 task_config,
-                task_client,
+                worker_index,
                 task_delivery,
                 task_processor,
                 task_shutdown,
@@ -491,14 +503,17 @@ mod tests {
     use axum::{
         Router,
         body::Bytes,
-        extract::{Path, State},
+        extract::{ConnectInfo, Path, State},
         http::StatusCode,
         routing::{get, post, put},
     };
     use futures::TryStreamExt;
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        net::SocketAddr,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     #[test]
@@ -690,6 +705,39 @@ mod tests {
         StatusCode::OK
     }
 
+    #[derive(Default)]
+    struct ConnectionState {
+        work_calls: AtomicUsize,
+        work_peers: Mutex<Vec<SocketAddr>>,
+        complete_peers: Mutex<Vec<SocketAddr>>,
+    }
+
+    async fn connection_work(
+        ConnectInfo(peer): ConnectInfo<SocketAddr>,
+        State(state): State<Arc<ConnectionState>>,
+    ) -> Result<axum::Json<WorkItem>, StatusCode> {
+        state.work_peers.lock().unwrap().push(peer);
+        let call = state.work_calls.fetch_add(1, Ordering::SeqCst);
+        if call == 1 {
+            Ok(axum::Json(WorkItem {
+                job_id: "job-connection".into(),
+                request: serde_json::json!({"foo": "bar"}),
+                user: serde_json::json!({}),
+                metadata: serde_json::json!({}),
+            }))
+        } else {
+            Err(StatusCode::NO_CONTENT)
+        }
+    }
+
+    async fn connection_complete(
+        ConnectInfo(peer): ConnectInfo<SocketAddr>,
+        State(state): State<Arc<ConnectionState>>,
+    ) -> StatusCode {
+        state.complete_peers.lock().unwrap().push(peer);
+        StatusCode::OK
+    }
+
     struct StubProcessor;
 
     #[async_trait]
@@ -731,6 +779,79 @@ mod tests {
         async fn process(&self, _work: WorkItem) -> ProcessResult {
             ProcessResult::error("internal error")
         }
+    }
+
+    #[tokio::test]
+    async fn empty_poll_rotates_connection_and_job_callbacks_stay_sticky() {
+        let state = Arc::new(ConnectionState::default());
+        let app = Router::new()
+            .route("/work", get(connection_work))
+            .route("/heartbeat/{job_id}", post(broker_heartbeat))
+            .route("/complete/data/{job_id}", post(connection_complete))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let config = WorkerConfig {
+            broker_url: format!("http://{addr}"),
+            poll_timeout_ms: 10,
+            heartbeat_interval: Duration::from_secs(60),
+            retry_backoff: Duration::from_millis(5),
+            management_port: 0,
+            worker_concurrency: 1,
+        };
+
+        let run = tokio::spawn(run_worker_loop(
+            config,
+            delivery_config::DeliveryConfig {
+                delivery_type: delivery_config::DeliveryType::Direct,
+                bobs_url: None,
+                s3_bucket: None,
+                s3_region: None,
+                s3_endpoint_url: None,
+                s3_force_path_style: None,
+                s3_access_key_id: None,
+                s3_secret_access_key: None,
+                s3_presigned_url_expiry_secs: None,
+                s3_public_url: None,
+                s3_key_prefix: String::new(),
+            },
+            StubProcessor,
+        ));
+
+        for _ in 0..50 {
+            if !state.complete_peers.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        run.abort();
+
+        let work_peers = state.work_peers.lock().unwrap().clone();
+        let complete_peers = state.complete_peers.lock().unwrap().clone();
+        assert!(
+            work_peers.len() >= 2,
+            "expected an empty poll and then a job poll"
+        );
+        assert_eq!(complete_peers.len(), 1, "expected one completion callback");
+        assert_ne!(
+            work_peers[0], work_peers[1],
+            "empty poll and next poll should use different TCP connections"
+        );
+        assert_eq!(
+            work_peers[1], complete_peers[0],
+            "job completion must reuse the job poll connection for in-job stickiness"
+        );
     }
 
     #[tokio::test]

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -32,10 +32,36 @@ fn codec_from_accept_encoding(accept_encoding: Option<&str>) -> Codec {
 
 pub type RawStream = Box<dyn Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send + Unpin>;
 
+#[derive(Debug, Clone, Default)]
+pub struct SourceError {
+    message: Arc<Mutex<Option<String>>>,
+}
+
+impl SourceError {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_once(&self, message: impl Into<String>) {
+        let mut slot = self.message.lock().expect("source error mutex poisoned");
+        if slot.is_none() {
+            *slot = Some(message.into());
+        }
+    }
+
+    pub fn message(&self) -> Option<String> {
+        self.message
+            .lock()
+            .expect("source error mutex poisoned")
+            .clone()
+    }
+}
+
 pub enum ProcessResult {
     Success {
         content_type: String,
         body: RawStream,
+        source_error: Option<SourceError>,
     },
     Reject {
         reason: String,
@@ -50,6 +76,19 @@ impl ProcessResult {
         Self::Success {
             content_type: content_type.into(),
             body,
+            source_error: None,
+        }
+    }
+
+    pub fn success_with_source_error(
+        content_type: impl Into<String>,
+        body: RawStream,
+        source_error: SourceError,
+    ) -> Self {
+        Self::Success {
+            content_type: content_type.into(),
+            body,
+            source_error: Some(source_error),
         }
     }
 
@@ -83,6 +122,7 @@ pub enum Completion {
         content_encoding: Option<String>,
         content_length: Option<u64>,
         body: reqwest::Body,
+        source_error: Option<SourceError>,
     },
     Redirect {
         location: String,
@@ -108,6 +148,7 @@ impl Completion {
             content_encoding,
             content_length,
             body,
+            source_error: None,
         }
     }
 
@@ -493,7 +534,11 @@ async fn worker_task<P: Processor + 'static>(
         // None for non-Success outcomes (which do not emit worker.job.completed).
         let mut byte_counter: Option<Arc<AtomicU64>> = None;
         let completion = match process_result {
-            ProcessResult::Success { content_type, body } => {
+            ProcessResult::Success {
+                content_type,
+                body,
+                source_error,
+            } => {
                 let codec = codec_from_accept_encoding(work.metadata["accept_encoding"].as_str());
                 let content_encoding = codec.content_encoding_header().map(str::to_string);
                 let (encoded, counter) = encode_stream_counted(body, &codec);
@@ -508,6 +553,7 @@ async fn worker_task<P: Processor + 'static>(
                         DeliveryContext {
                             job_id: &work.job_id,
                             user: &work.user,
+                            source_error,
                         },
                     )
                     .await;
@@ -542,6 +588,7 @@ async fn worker_task<P: Processor + 'static>(
                 content_encoding,
                 content_length,
                 body,
+                source_error,
             } => {
                 let mut request = client
                     .post(config.complete_data_url_for_work(&work))
@@ -553,7 +600,30 @@ async fn worker_task<P: Processor + 'static>(
                 if let Some(encoding) = content_encoding {
                     request = request.header(reqwest::header::CONTENT_ENCODING, encoding);
                 }
-                (request.send().await?, "data")
+                match request.send().await {
+                    Ok(resp) => (resp, "data"),
+                    Err(err) => {
+                        if let Some(message) = source_error.and_then(|source| source.message()) {
+                            tracing::error!(
+                                "event.name" = "worker.delivery.failed",
+                                outcome = "error",
+                                job.id = %work.job_id,
+                                source_error = %message,
+                                sink_error = %err,
+                                "direct result delivery failed after source stream error"
+                            );
+                            let payload = CompletionRequest::Error { message };
+                            let resp = client
+                                .post(config.complete_error_url_for_work(&work))
+                                .json(&payload)
+                                .send()
+                                .await?;
+                            (resp, "error")
+                        } else {
+                            return Err(err.into());
+                        }
+                    }
+                }
             }
             Completion::Reject { reason } => {
                 let payload = CompletionRequest::Reject { reason };
@@ -1092,6 +1162,29 @@ mod tests {
         }
     }
 
+    struct SourceFailingStreamProcessor;
+
+    #[async_trait]
+    impl Processor for SourceFailingStreamProcessor {
+        async fn process(&self, _work: WorkItem) -> ProcessResult {
+            let source_error = SourceError::new();
+            source_error.set_once(
+                "The requested post-processing is not supported for this data. Details: mars-client error: Serious bug: Representation::croppedRepresentation() not implemented for HEALPixNested[name=H128]",
+            );
+            let stream = futures::stream::iter(vec![
+                Ok::<bytes::Bytes, std::io::Error>(bytes::Bytes::from(vec![1u8, 2, 3])),
+                Err(std::io::Error::other(
+                    "mars-client error: Serious bug: Representation::croppedRepresentation() not implemented for HEALPixNested[name=H128]",
+                )),
+            ]);
+            ProcessResult::success_with_source_error(
+                "application/octet-stream",
+                Box::new(stream),
+                source_error,
+            )
+        }
+    }
+
     struct RejectProcessor;
 
     #[async_trait]
@@ -1331,6 +1424,96 @@ mod tests {
         let writes = bobs_state.writes.lock().unwrap();
         assert_eq!(writes.len(), 1);
         assert_eq!(writes[0], vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn worker_with_bobs_delivery_posts_source_error_completion() {
+        let bobs_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let bobs_addr = bobs_listener.local_addr().unwrap();
+        let bobs_url = format!("http://{bobs_addr}");
+        let bobs_api_base = format!("{bobs_url}/api/v1");
+
+        let bobs_state = Arc::new(BobsState {
+            write_base_url: bobs_api_base.clone(),
+            calls: Mutex::new(vec![]),
+            writes: Mutex::new(vec![]),
+        });
+        let bobs_app = Router::new()
+            .route("/api/v1/create", put(bobs_create))
+            .route("/api/v1/write/{key}/{offset}", post(bobs_write))
+            .route("/api/v1/complete/{key}", post(bobs_complete))
+            .with_state(bobs_state.clone());
+        tokio::spawn(async move { axum::serve(bobs_listener, bobs_app).await.unwrap() });
+
+        let broker_state = Arc::new(BrokerState::default());
+        let broker_app = Router::new()
+            .route("/work", get(broker_work))
+            .route("/heartbeat/{job_id}", post(broker_heartbeat))
+            .route("/complete/data/{job_id}", post(broker_complete_data))
+            .route(
+                "/complete/redirect/{job_id}",
+                post(broker_complete_redirect),
+            )
+            .route("/complete/reject/{job_id}", post(broker_complete_reject))
+            .route("/complete/error/{job_id}", post(broker_complete_error))
+            .with_state(broker_state.clone());
+        let broker_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let broker_addr = broker_listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(broker_listener, broker_app).await.unwrap() });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let config = WorkerConfig {
+            broker_url: format!("http://{broker_addr}"),
+            poll_timeout_ms: 10,
+            heartbeat_interval: Duration::from_millis(5),
+            retry_backoff: Duration::from_millis(5),
+            management_port: 0,
+            worker_concurrency: 1,
+        };
+
+        let run = tokio::spawn(run_worker_loop(
+            config,
+            delivery_config::DeliveryConfig {
+                delivery_type: delivery_config::DeliveryType::Bobs,
+                bobs_url: Some(bobs_url.clone()),
+
+                s3_bucket: None,
+                s3_region: None,
+                s3_endpoint_url: None,
+                s3_force_path_style: None,
+                s3_access_key_id: None,
+                s3_secret_access_key: None,
+                s3_presigned_url_expiry_secs: None,
+                s3_public_url: None,
+                s3_key_prefix: String::new(),
+            },
+            SourceFailingStreamProcessor,
+        ));
+        for _ in 0..40 {
+            if !broker_state.completions.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        run.abort();
+
+        let completions = broker_state.completions.lock().unwrap();
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].0, "error");
+        let body: serde_json::Value = serde_json::from_slice(&completions[0].1).unwrap();
+        let message = body["message"].as_str().unwrap();
+        assert!(message.contains("not supported for this data"));
+        assert!(message.contains("croppedRepresentation"));
+        assert!(!completions.iter().any(|(kind, _)| kind == "redirect"));
+        drop(completions);
+
+        let calls = bobs_state.calls.lock().unwrap();
+        assert!(calls.contains(&"create".to_string()));
+        assert!(
+            !calls.contains(&"complete".to_string()),
+            "BOBS object must not be completed after source stream error"
+        );
     }
 
     #[tokio::test]

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -14,7 +16,7 @@ pub mod management;
 
 use crate::delivery::{DeliveryContext, ResultDelivery, make_delivery};
 use crate::delivery_config::{Codec, DeliveryConfig};
-use crate::encoding::encode_stream;
+use crate::encoding::encode_stream_counted;
 
 fn codec_from_accept_encoding(accept_encoding: Option<&str>) -> Codec {
     let enc = accept_encoding.unwrap_or("");
@@ -322,11 +324,15 @@ async fn worker_task<P: Processor + 'static>(
         let process_ms = process_started.elapsed().as_millis() as u64;
 
         let mut deliver_ms: u64 = 0;
+        // Counts post-encoding bytes as the result body streams to delivery.
+        // None for non-Success outcomes (which do not emit worker.job.completed).
+        let mut byte_counter: Option<Arc<AtomicU64>> = None;
         let completion = match process_result {
             ProcessResult::Success { content_type, body } => {
                 let codec = codec_from_accept_encoding(work.metadata["accept_encoding"].as_str());
                 let content_encoding = codec.content_encoding_header().map(str::to_string);
-                let encoded = encode_stream(body, &codec);
+                let (encoded, counter) = encode_stream_counted(body, &codec);
+                byte_counter = Some(counter);
                 let deliver_started = Instant::now();
                 let completion = delivery
                     .deliver(
@@ -413,11 +419,17 @@ async fn worker_task<P: Processor + 'static>(
             }
         };
         let complete_ms = complete_started.elapsed().as_millis() as u64;
+        // Bytes delivered for this job, counted as the encoded body streamed out.
+        // Fully settled by now: the body was consumed during delivery/completion.
+        let bytes = byte_counter
+            .as_ref()
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .unwrap_or(0);
         if matches!(outcome, "data" | "redirect") {
             if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
-                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job completed");
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, bytes, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job completed");
             } else {
-                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "job completed");
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, bytes, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "job completed");
             }
         }
         if response.status() != StatusCode::OK && response.status() != StatusCode::NOT_FOUND {

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -203,6 +203,55 @@ pub trait Processor: Send + Sync {
     async fn process(&self, work: WorkItem) -> ProcessResult;
 }
 
+/// Grace window before a *sustained* broker-poll failure is logged at WARN, and
+/// also the re-warn interval once it has. Transient failures — most importantly
+/// a frontend rollout, where the per-cycle reconnect keeps landing the worker on
+/// healthy replicas so only the odd cycle fails — never accumulate this much
+/// *continuous* failure, so they stay at debug (silent at RUST_LOG=info).
+const POLL_FAILURE_GRACE: Duration = Duration::from_secs(30);
+
+/// Tracks consecutive broker-poll failures so a worker only warns once it has
+/// been unable to get work from *any* broker for [`POLL_FAILURE_GRACE`],
+/// re-warning at most once per interval. Any successful poll — real work or a
+/// clean 204 "no work" — resets it.
+struct PollHealth {
+    failing_since: Option<Instant>,
+    last_warned: Option<Instant>,
+}
+
+impl PollHealth {
+    const fn new() -> Self {
+        Self {
+            failing_since: None,
+            last_warned: None,
+        }
+    }
+
+    /// Record a failed poll cycle. Returns `true` if the caller should log at
+    /// WARN (failures have persisted past the grace window and we haven't warned
+    /// within the last interval), `false` to log at debug. `now` is injected so
+    /// the threshold logic is unit-testable.
+    fn record_failure(&mut self, now: Instant) -> bool {
+        let since = *self.failing_since.get_or_insert(now);
+        if now.saturating_duration_since(since) < POLL_FAILURE_GRACE {
+            return false;
+        }
+        match self.last_warned {
+            Some(last) if now.saturating_duration_since(last) < POLL_FAILURE_GRACE => false,
+            _ => {
+                self.last_warned = Some(now);
+                true
+            }
+        }
+    }
+
+    /// Record a successful poll: the broker is reachable and healthy.
+    fn record_success(&mut self) {
+        self.failing_since = None;
+        self.last_warned = None;
+    }
+}
+
 async fn worker_task<P: Processor + 'static>(
     config: WorkerConfig,
     worker_index: usize,
@@ -212,6 +261,7 @@ async fn worker_task<P: Processor + 'static>(
 ) -> Result<(), reqwest::Error> {
     let mut poll_cycle: u64 = 0;
     let mut idle_anchor = Instant::now();
+    let mut poll_health = PollHealth::new();
     loop {
         if *shutdown.borrow() {
             break;
@@ -241,7 +291,11 @@ async fn worker_task<P: Processor + 'static>(
                 match result {
                     Ok(response) => response,
                     Err(err) => {
-                        tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, error = %err, "worker poll failed");
+                        if poll_health.record_failure(Instant::now()) {
+                            tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, error = %err, "worker poll failing for >30s");
+                        } else {
+                            tracing::debug!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, error = %err, "worker poll failed (transient)");
+                        }
                         tokio::time::sleep(config.retry_backoff).await;
                         continue;
                     }
@@ -250,6 +304,7 @@ async fn worker_task<P: Processor + 'static>(
         };
 
         if response.status() == StatusCode::NO_CONTENT {
+            poll_health.record_success();
             tracing::debug!(
                 "event.name" = "worker.broker.poll.empty",
                 worker_index,
@@ -261,15 +316,26 @@ async fn worker_task<P: Processor + 'static>(
             continue;
         }
         if !response.status().is_success() {
-            tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, status = %response.status(), "worker poll returned unexpected status");
+            if poll_health.record_failure(Instant::now()) {
+                tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, status = %response.status(), "worker poll returning unexpected status for >30s");
+            } else {
+                tracing::debug!("event.name" = "worker.broker.poll.failed", outcome = "error", broker_url = %config.broker_url, status = %response.status(), "worker poll returned unexpected status (transient)");
+            }
             tokio::time::sleep(config.retry_backoff).await;
             continue;
         }
 
         let work: WorkItem = match response.json().await {
-            Ok(work) => work,
+            Ok(work) => {
+                poll_health.record_success();
+                work
+            }
             Err(err) => {
-                tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", error = %err, "worker failed to decode work item");
+                if poll_health.record_failure(Instant::now()) {
+                    tracing::warn!("event.name" = "worker.broker.poll.failed", outcome = "error", error = %err, "worker failing to decode work item for >30s");
+                } else {
+                    tracing::debug!("event.name" = "worker.broker.poll.failed", outcome = "error", error = %err, "worker failed to decode work item (transient)");
+                }
                 tokio::time::sleep(config.retry_backoff).await;
                 continue;
             }
@@ -533,6 +599,27 @@ pub async fn run_worker_loop<P: Processor + 'static>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poll_health_warns_only_after_sustained_failure() {
+        let mut h = PollHealth::new();
+        let t0 = Instant::now();
+        // Failures inside the grace window stay quiet (debug), e.g. a rollout.
+        assert!(!h.record_failure(t0));
+        assert!(!h.record_failure(t0 + Duration::from_secs(5)));
+        assert!(!h.record_failure(t0 + Duration::from_secs(29)));
+        // Crossing the grace window warns exactly once.
+        assert!(h.record_failure(t0 + Duration::from_secs(31)));
+        // Then it is rate-limited within the next interval...
+        assert!(!h.record_failure(t0 + Duration::from_secs(40)));
+        // ...and re-warns after another interval of continuous failure.
+        assert!(h.record_failure(t0 + Duration::from_secs(62)));
+        // A successful poll resets the clock: the grace window starts over.
+        h.record_success();
+        assert!(!h.record_failure(t0 + Duration::from_secs(63)));
+        assert!(!h.record_failure(t0 + Duration::from_secs(90)));
+        assert!(h.record_failure(t0 + Duration::from_secs(94)));
+    }
     use axum::{
         Router,
         body::Bytes,

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use futures::Stream;
@@ -209,6 +209,7 @@ async fn worker_task<P: Processor + 'static>(
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> Result<(), reqwest::Error> {
     let mut poll_cycle: u64 = 0;
+    let mut idle_anchor = Instant::now();
     loop {
         if *shutdown.borrow() {
             break;
@@ -225,6 +226,7 @@ async fn worker_task<P: Processor + 'static>(
         );
         let client = reqwest::Client::builder().build()?;
 
+        let poll_started = Instant::now();
         let response = tokio::select! {
             biased;
             changed = shutdown.changed() => {
@@ -246,6 +248,14 @@ async fn worker_task<P: Processor + 'static>(
         };
 
         if response.status() == StatusCode::NO_CONTENT {
+            tracing::debug!(
+                "event.name" = "worker.broker.poll.empty",
+                worker_index,
+                poll_cycle,
+                broker_url = %config.broker_url,
+                wait_ms = poll_started.elapsed().as_millis() as u64,
+                "worker poll returned no work"
+            );
             continue;
         }
         if !response.status().is_success() {
@@ -263,11 +273,13 @@ async fn worker_task<P: Processor + 'static>(
             }
         };
 
+        let poll_wait_ms = poll_started.elapsed().as_millis() as u64;
+        let idle_ms = idle_anchor.elapsed().as_millis() as u64;
         let (enduser_id, enduser_realm) = enduser_fields(&work.user);
         if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
-            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job started");
+            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job started");
         } else {
-            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, "job started");
+            tracing::info!("event.name" = "worker.job.started", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, "job started");
         }
 
         let stop = std::sync::Arc::new(tokio::sync::Notify::new());
@@ -305,14 +317,18 @@ async fn worker_task<P: Processor + 'static>(
             }
         });
 
+        let process_started = Instant::now();
         let process_result = processor.process(work.clone()).await;
+        let process_ms = process_started.elapsed().as_millis() as u64;
 
+        let mut deliver_ms: u64 = 0;
         let completion = match process_result {
             ProcessResult::Success { content_type, body } => {
                 let codec = codec_from_accept_encoding(work.metadata["accept_encoding"].as_str());
                 let content_encoding = codec.content_encoding_header().map(str::to_string);
                 let encoded = encode_stream(body, &codec);
-                delivery
+                let deliver_started = Instant::now();
+                let completion = delivery
                     .deliver(
                         &content_type,
                         content_encoding.as_deref(),
@@ -323,7 +339,9 @@ async fn worker_task<P: Processor + 'static>(
                             user: &work.user,
                         },
                     )
-                    .await
+                    .await;
+                deliver_ms = deliver_started.elapsed().as_millis() as u64;
+                completion
             }
             ProcessResult::Reject { reason } => {
                 if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
@@ -346,6 +364,7 @@ async fn worker_task<P: Processor + 'static>(
         stop.notify_one();
         let _ = heartbeat.await;
 
+        let complete_started = Instant::now();
         let (response, outcome) = match completion {
             Completion::Complete {
                 content_type,
@@ -393,11 +412,12 @@ async fn worker_task<P: Processor + 'static>(
                 (resp, "redirect")
             }
         };
+        let complete_ms = complete_started.elapsed().as_millis() as u64;
         if matches!(outcome, "data" | "redirect") {
             if let (Some(enduser_id), Some(enduser_realm)) = (enduser_id, enduser_realm) {
-                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job completed");
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "enduser.id" = %enduser_id, "enduser.realm" = %enduser_realm, "job completed");
             } else {
-                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, "job completed");
+                tracing::info!("event.name" = "worker.job.completed", outcome = "success", job.id = %work.job_id, poll_wait_ms, idle_ms, process_ms, deliver_ms, complete_ms, "job completed");
             }
         }
         if response.status() != StatusCode::OK && response.status() != StatusCode::NOT_FOUND {
@@ -407,6 +427,7 @@ async fn worker_task<P: Processor + 'static>(
                 tracing::error!("event.name" = "worker.job.failed", outcome = "error", status=%response.status(), job.id=%work.job_id, "worker completion returned unexpected status");
             }
         }
+        idle_anchor = Instant::now();
     }
 
     Ok(())

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -282,10 +282,22 @@ impl WorkerConfig {
     }
 
     fn callback_base_for_work(&self, work: &WorkItem) -> String {
-        work.callback_url
-            .as_deref()
-            .and_then(|callback_url| self.validated_callback_base(callback_url))
-            .unwrap_or_else(|| self.broker_url.trim_end_matches('/').to_string())
+        let advertised = work.callback_url.as_deref();
+        let validated =
+            advertised.and_then(|callback_url| self.validated_callback_base(callback_url));
+        let used_direct = validated.is_some();
+        let base = validated.unwrap_or_else(|| self.broker_url.trim_end_matches('/').to_string());
+        tracing::debug!(
+            "event.name" = "worker.callback.base.resolved",
+            "job.id" = %work.job_id,
+            outcome = if used_direct { "direct" } else { "lb_fallback" },
+            direct = used_direct,
+            advertised_callback_url = advertised.unwrap_or("<none>"),
+            resolved_callback_base = %base,
+            broker_url = %self.broker_url,
+            "resolved worker callback base url (direct=broker pod, lb_fallback=load-balanced service)"
+        );
+        base
     }
 
     fn validated_callback_base(&self, callback_url: &str) -> Option<String> {

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -1,3 +1,4 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -71,6 +72,8 @@ pub struct WorkItem {
     pub request: serde_json::Value,
     pub user: serde_json::Value,
     pub metadata: serde_json::Value,
+    #[serde(default)]
+    pub callback_url: Option<String>,
 }
 
 #[derive(Debug)]
@@ -169,10 +172,26 @@ impl WorkerConfig {
         )
     }
 
+    pub fn heartbeat_url_for_work(&self, work: &WorkItem) -> String {
+        format!(
+            "{}/heartbeat/{}",
+            self.callback_base_for_work(work),
+            work.job_id
+        )
+    }
+
     pub fn complete_data_url(&self, job_id: &str) -> String {
         format!(
             "{}/complete/data/{job_id}",
             self.broker_url.trim_end_matches('/')
+        )
+    }
+
+    pub fn complete_data_url_for_work(&self, work: &WorkItem) -> String {
+        format!(
+            "{}/complete/data/{}",
+            self.callback_base_for_work(work),
+            work.job_id
         )
     }
 
@@ -183,10 +202,26 @@ impl WorkerConfig {
         )
     }
 
+    pub fn complete_reject_url_for_work(&self, work: &WorkItem) -> String {
+        format!(
+            "{}/complete/reject/{}",
+            self.callback_base_for_work(work),
+            work.job_id
+        )
+    }
+
     pub fn complete_error_url(&self, job_id: &str) -> String {
         format!(
             "{}/complete/error/{job_id}",
             self.broker_url.trim_end_matches('/')
+        )
+    }
+
+    pub fn complete_error_url_for_work(&self, work: &WorkItem) -> String {
+        format!(
+            "{}/complete/error/{}",
+            self.callback_base_for_work(work),
+            work.job_id
         )
     }
 
@@ -196,6 +231,69 @@ impl WorkerConfig {
             self.broker_url.trim_end_matches('/')
         )
     }
+
+    pub fn complete_redirect_url_for_work(&self, work: &WorkItem) -> String {
+        format!(
+            "{}/complete/redirect/{}",
+            self.callback_base_for_work(work),
+            work.job_id
+        )
+    }
+
+    fn callback_base_for_work(&self, work: &WorkItem) -> String {
+        work.callback_url
+            .as_deref()
+            .and_then(|callback_url| self.validated_callback_base(callback_url))
+            .unwrap_or_else(|| self.broker_url.trim_end_matches('/').to_string())
+    }
+
+    fn validated_callback_base(&self, callback_url: &str) -> Option<String> {
+        let callback = reqwest::Url::parse(callback_url).ok()?;
+        if callback.scheme() != "http"
+            || callback.query().is_some()
+            || callback.fragment().is_some()
+        {
+            return None;
+        }
+        if !callback.username().is_empty() || callback.password().is_some() {
+            return None;
+        }
+
+        let expected_port = reqwest::Url::parse(&self.broker_url)
+            .ok()
+            .and_then(|url| url.port_or_known_default())?;
+        if callback.port_or_known_default()? != expected_port {
+            return None;
+        }
+
+        let host: IpAddr = callback
+            .host_str()?
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse()
+            .ok()?;
+        if !is_private_cluster_ip(host) {
+            return None;
+        }
+
+        Some(callback.as_str().trim_end_matches('/').to_string())
+    }
+}
+
+fn is_private_cluster_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_private_cluster_ipv4(ip),
+        IpAddr::V6(ip) => is_private_cluster_ipv6(ip),
+    }
+}
+
+fn is_private_cluster_ipv4(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    ip.is_private() || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+}
+
+fn is_private_cluster_ipv6(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
 }
 
 #[async_trait]
@@ -353,7 +451,8 @@ async fn worker_task<P: Processor + 'static>(
         let stop = std::sync::Arc::new(tokio::sync::Notify::new());
         let stop_heartbeat = stop.clone();
         let heartbeat_client = client.clone();
-        let heartbeat_cfg = config.clone();
+        let heartbeat_url = config.heartbeat_url_for_work(&work);
+        let heartbeat_interval = config.heartbeat_interval;
         let job_id = work.job_id.clone();
         let heartbeat_enduser_id = enduser_id.map(str::to_string);
         let heartbeat_enduser_realm = enduser_realm.map(str::to_string);
@@ -361,8 +460,8 @@ async fn worker_task<P: Processor + 'static>(
             loop {
                 tokio::select! {
                     _ = stop_heartbeat.notified() => break,
-                    _ = tokio::time::sleep(heartbeat_cfg.heartbeat_interval) => {
-                        match heartbeat_client.post(heartbeat_cfg.heartbeat_url(&job_id)).send().await {
+                    _ = tokio::time::sleep(heartbeat_interval) => {
+                        match heartbeat_client.post(&heartbeat_url).send().await {
                             Ok(resp) if resp.status() == StatusCode::OK => {}
                             Ok(resp) if resp.status() == StatusCode::NOT_FOUND => break,
                             Ok(resp) => {
@@ -445,7 +544,7 @@ async fn worker_task<P: Processor + 'static>(
                 body,
             } => {
                 let mut request = client
-                    .post(config.complete_data_url(&work.job_id))
+                    .post(config.complete_data_url_for_work(&work))
                     .header(reqwest::header::CONTENT_TYPE, content_type)
                     .body(body);
                 if let Some(content_length) = content_length {
@@ -459,7 +558,7 @@ async fn worker_task<P: Processor + 'static>(
             Completion::Reject { reason } => {
                 let payload = CompletionRequest::Reject { reason };
                 let resp = client
-                    .post(config.complete_reject_url(&work.job_id))
+                    .post(config.complete_reject_url_for_work(&work))
                     .json(&payload)
                     .send()
                     .await?;
@@ -468,7 +567,7 @@ async fn worker_task<P: Processor + 'static>(
             Completion::Error { message } => {
                 let payload = CompletionRequest::Error { message };
                 let resp = client
-                    .post(config.complete_error_url(&work.job_id))
+                    .post(config.complete_error_url_for_work(&work))
                     .json(&payload)
                     .send()
                     .await?;
@@ -477,7 +576,7 @@ async fn worker_task<P: Processor + 'static>(
             Completion::Redirect { location, message } => {
                 let payload = CompletionRequest::Redirect { location, message };
                 let resp = client
-                    .post(config.complete_redirect_url(&work.job_id))
+                    .post(config.complete_redirect_url_for_work(&work))
                     .json(&payload)
                     .send()
                     .await?;
@@ -647,6 +746,113 @@ mod tests {
         assert_eq!(enduser_fields(&serde_json::json!({})), (None, None));
     }
 
+    fn test_worker_config() -> WorkerConfig {
+        WorkerConfig {
+            broker_url: "http://polytope-test-frontend:9001/test_pool".to_string(),
+            poll_timeout_ms: 10,
+            heartbeat_interval: Duration::from_secs(60),
+            retry_backoff: Duration::from_millis(5),
+            management_port: 0,
+            worker_concurrency: 1,
+        }
+    }
+
+    fn test_work_with_callback(callback_url: Option<&str>) -> WorkItem {
+        WorkItem {
+            job_id: "job-1".to_string(),
+            request: serde_json::json!({}),
+            user: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            callback_url: callback_url.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn worker_uses_valid_callback_url_for_job_callbacks() {
+        let config = test_worker_config();
+        let work = test_work_with_callback(Some("http://10.1.2.3:9001/test_pool"));
+
+        assert_eq!(
+            config.work_url(),
+            "http://polytope-test-frontend:9001/test_pool/work?timeout_ms=10"
+        );
+        assert_eq!(
+            config.heartbeat_url_for_work(&work),
+            "http://10.1.2.3:9001/test_pool/heartbeat/job-1"
+        );
+        assert_eq!(
+            config.complete_data_url_for_work(&work),
+            "http://10.1.2.3:9001/test_pool/complete/data/job-1"
+        );
+        assert_eq!(
+            config.complete_redirect_url_for_work(&work),
+            "http://10.1.2.3:9001/test_pool/complete/redirect/job-1"
+        );
+        assert_eq!(
+            config.complete_reject_url_for_work(&work),
+            "http://10.1.2.3:9001/test_pool/complete/reject/job-1"
+        );
+        assert_eq!(
+            config.complete_error_url_for_work(&work),
+            "http://10.1.2.3:9001/test_pool/complete/error/job-1"
+        );
+    }
+
+    #[test]
+    fn worker_falls_back_to_broker_url_without_callback_url() {
+        let config = test_worker_config();
+        let work = test_work_with_callback(None);
+
+        assert_eq!(
+            config.heartbeat_url_for_work(&work),
+            "http://polytope-test-frontend:9001/test_pool/heartbeat/job-1"
+        );
+        assert_eq!(
+            config.complete_data_url_for_work(&work),
+            "http://polytope-test-frontend:9001/test_pool/complete/data/job-1"
+        );
+    }
+
+    #[test]
+    fn worker_rejects_invalid_callback_urls_and_falls_back_to_broker_url() {
+        let config = test_worker_config();
+        for callback_url in [
+            "https://10.1.2.3:9001/test_pool",
+            "http://10.1.2.3:9002/test_pool",
+            "http://127.0.0.1:9001/test_pool",
+            "http://169.254.169.254:9001/test_pool",
+            "http://8.8.8.8:9001/test_pool",
+            "http://frontend-abcde:9001/test_pool",
+            "http://10.1.2.3:9001/test_pool?x=1",
+        ] {
+            let work = test_work_with_callback(Some(callback_url));
+            assert_eq!(
+                config.heartbeat_url_for_work(&work),
+                "http://polytope-test-frontend:9001/test_pool/heartbeat/job-1",
+                "callback should be rejected: {callback_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn worker_accepts_private_cluster_callback_ranges() {
+        let config = test_worker_config();
+        for callback_url in [
+            "http://10.1.2.3:9001/test_pool",
+            "http://172.16.2.3:9001/test_pool",
+            "http://192.168.2.3:9001/test_pool",
+            "http://100.64.2.3:9001/test_pool",
+            "http://[fd00::1]:9001/test_pool",
+        ] {
+            let work = test_work_with_callback(Some(callback_url));
+            assert_ne!(
+                config.heartbeat_url_for_work(&work),
+                "http://polytope-test-frontend:9001/test_pool/heartbeat/job-1",
+                "callback should be accepted: {callback_url}"
+            );
+        }
+    }
+
     #[derive(Default)]
     struct MockState {
         delivered: Mutex<bool>,
@@ -664,6 +870,7 @@ mod tests {
                 request: serde_json::json!({"foo": "bar"}),
                 user: serde_json::json!({}),
                 metadata: serde_json::json!({}),
+                callback_url: None,
             }))
         }
     }
@@ -724,6 +931,7 @@ mod tests {
                 request: serde_json::json!({"foo": "bar"}),
                 user: serde_json::json!({}),
                 metadata: state.work_metadata.lock().unwrap().clone(),
+                callback_url: None,
             }))
         }
     }
@@ -844,6 +1052,7 @@ mod tests {
                 request: serde_json::json!({"foo": "bar"}),
                 user: serde_json::json!({}),
                 metadata: serde_json::json!({}),
+                callback_url: None,
             }))
         } else {
             Err(StatusCode::NO_CONTENT)
@@ -1326,6 +1535,7 @@ mod tests {
                 request: serde_json::json!({"index": poll}),
                 user: serde_json::json!({}),
                 metadata: serde_json::json!({}),
+                callback_url: None,
             }))
         } else {
             Err(StatusCode::NO_CONTENT)

--- a/workers/fdb-worker/src/main.rs
+++ b/workers/fdb-worker/src/main.rs
@@ -69,7 +69,7 @@ impl Processor for FdbProcessor {
 struct Cli {
     #[arg(long, default_value = "http://127.0.0.1:9001")]
     broker_url: String,
-    #[arg(long, default_value_t = 30000)]
+    #[arg(long, default_value_t = polytope_worker_common::DEFAULT_POLL_TIMEOUT_MS)]
     poll_timeout_ms: u64,
     #[arg(long, default_value_t = 10.0)]
     heartbeat_secs: f64,
@@ -101,7 +101,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     polytope_observability::init_tracing("polytope-worker-fdb");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
-    info!(worker_concurrency, "resolved worker concurrency");
+    info!(
+        worker_concurrency,
+        poll_timeout_ms = cli.poll_timeout_ms,
+        "resolved worker settings"
+    );
     let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
         std::process::exit(1);

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -4,13 +4,66 @@ use bytes::Bytes;
 use clap::Parser;
 use mars_client::{Error as MarsError, MarsClient};
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
-use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, run_worker_loop};
+use polytope_worker_common::{
+    ProcessResult, Processor, SourceError, WorkItem, WorkerConfig, run_worker_loop,
+};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, warn};
 
 mod convert;
 mod k8s;
 mod port_cleanup;
+
+fn mars_user_message(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+    if lower.contains("data not yet available") || lower.contains("scheduled for after") {
+        if let Some(release_time) = extract_release_time(raw) {
+            format!("Data not released yet. Release time is {release_time}.")
+        } else {
+            "Data not released yet. Please try again later.".to_string()
+        }
+    } else if lower.contains("croppedrepresentation") || lower.contains("not implemented for") {
+        format!("The requested post-processing is not supported for this data. Details: {raw}")
+    } else if lower.contains("restricted_access") || lower.contains("not authorised") {
+        format!("You do not have access to some of the requested data. Details: {raw}")
+    } else if lower.contains("mars_expected_fields")
+        || (lower.contains("expected") && lower.contains("got"))
+    {
+        format!("Some of the requested data is not available. Details: {raw}")
+    } else if lower.contains("syntax error")
+        || lower.contains("invalid value")
+        || lower.contains("assertion failed")
+    {
+        format!("Your request is invalid. Details: {raw}")
+    } else if lower.contains("mars_cache_corruption")
+        || lower.contains("uncatched")
+        || lower.contains("signal 1")
+    {
+        format!("The data retrieval system hit an internal error. Details: {raw}")
+    } else {
+        format!("Your request could not be completed. Details: {raw}")
+    }
+}
+
+fn invalidated_user_message() -> String {
+    "The data stream was interrupted before completing. Please retry.".to_string()
+}
+
+fn extract_release_time(raw: &str) -> Option<String> {
+    let lower = raw.to_lowercase();
+    let idx = lower.find("scheduled for after")?;
+    let start = idx + "scheduled for after".len();
+    let tail = raw[start..].trim_start_matches([' ', ':']);
+    let end = tail
+        .find(|c: char| c == ',' || c == '.' || c == '\n' || c == '\r')
+        .unwrap_or(tail.len());
+    let value = tail[..end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
 
 struct MarsProcessor {
     /// Port the C++ MARS client binds for DHS callbacks. We forcibly close any
@@ -37,6 +90,8 @@ impl Processor for MarsProcessor {
             .to_owned();
 
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(32);
+        let source_error = SourceError::new();
+        let source_error_for_task = source_error.clone();
         let local_port = self.local_port;
         let env_lock = self.env_lock.clone();
         tokio::task::spawn_blocking(move || {
@@ -51,14 +106,18 @@ impl Processor for MarsProcessor {
             let mut client = match MarsClient::new() {
                 Ok(c) => c,
                 Err(e) => {
-                    let _ = tx.blocking_send(Err(std::io::Error::other(e)));
+                    let raw = e.to_string();
+                    source_error_for_task.set_once(mars_user_message(&raw));
+                    let _ = tx.blocking_send(Err(std::io::Error::other(raw)));
                     return;
                 }
             };
             let mut stream = match client.retrieve(request_map) {
                 Ok(s) => s,
                 Err(e) => {
-                    let _ = tx.blocking_send(Err(std::io::Error::other(e)));
+                    let raw = e.to_string();
+                    source_error_for_task.set_once(mars_user_message(&raw));
+                    let _ = tx.blocking_send(Err(std::io::Error::other(raw)));
                     return;
                 }
             };
@@ -78,14 +137,16 @@ impl Processor for MarsProcessor {
                     }
                     Err(MarsError::Invalidated { offset }) => {
                         warn!(offset, "mars stream invalidated — unrecoverable");
-                        let _ = tx.blocking_send(Err(std::io::Error::other(format!(
-                            "stream invalidated at byte offset {offset}"
-                        ))));
+                        let raw = format!("stream invalidated at byte offset {offset}");
+                        source_error_for_task.set_once(invalidated_user_message());
+                        let _ = tx.blocking_send(Err(std::io::Error::other(raw)));
                         break;
                     }
                     Err(e) => {
                         warn!("mars stream error: {e}");
-                        let _ = tx.blocking_send(Err(std::io::Error::other(e)));
+                        let raw = e.to_string();
+                        source_error_for_task.set_once(mars_user_message(&raw));
+                        let _ = tx.blocking_send(Err(std::io::Error::other(raw)));
                         break;
                     }
                 }
@@ -114,7 +175,58 @@ impl Processor for MarsProcessor {
         });
 
         let stream = ReceiverStream::new(rx);
-        ProcessResult::success("application/x-grib", Box::new(stream))
+        ProcessResult::success_with_source_error(
+            "application/x-grib",
+            Box::new(stream),
+            source_error,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mars_user_message_matches_data_not_released() {
+        assert_eq!(
+            mars_user_message(
+                "mars - ERROR - Data not yet available. Scheduled for after 11:45:00, (11:45:00)"
+            ),
+            "Data not released yet. Release time is 11:45:00."
+        );
+        assert_eq!(
+            mars_user_message("Data not yet available"),
+            "Data not released yet. Please try again later."
+        );
+    }
+
+    #[test]
+    fn mars_user_message_matches_unsupported_postprocessing() {
+        let msg = mars_user_message(
+            "mars-client error: Serious bug: Representation::croppedRepresentation() not implemented for HEALPixNested[name=H128]",
+        );
+        assert!(msg.contains("not supported for this data"));
+        assert!(msg.contains("croppedRepresentation"));
+    }
+
+    #[test]
+    fn mars_user_message_matches_other_known_classes() {
+        assert!(mars_user_message("MARS_RESTRICTED_ACCESS_TO_DATA").contains("do not have access"));
+        assert!(
+            mars_user_message("MARS_EXPECTED_FIELDS Expected 2, got 1").contains("not available")
+        );
+        assert!(mars_user_message("syntax error near param").contains("request is invalid"));
+        assert!(mars_user_message("MARS_CACHE_CORRUPTION").contains("internal error"));
+        assert!(mars_user_message("something else").contains("could not be completed"));
+    }
+
+    #[test]
+    fn invalidated_message_matches_mapping() {
+        assert_eq!(
+            invalidated_user_message(),
+            "The data stream was interrupted before completing. Please retry."
+        );
     }
 }
 
@@ -158,7 +270,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
-    info!(worker_concurrency, poll_timeout_ms = cli.poll_timeout_ms, "resolved worker settings");
+    info!(
+        worker_concurrency,
+        poll_timeout_ms = cli.poll_timeout_ms,
+        "resolved worker settings"
+    );
 
     let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -320,7 +320,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(test)]
-mod tests {
+mod processor_tests {
     use super::*;
     use serde_json::json;
 
@@ -336,6 +336,7 @@ mod tests {
                 request: json!({}),
                 user: json!({}),
                 metadata: json!({}),
+                callback_url: None,
             })
             .await;
         assert!(matches!(result, ProcessResult::Error { .. }));

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -122,7 +122,7 @@ impl Processor for MarsProcessor {
 struct Cli {
     #[arg(long, default_value = "http://127.0.0.1:9001")]
     broker_url: String,
-    #[arg(long, default_value_t = 30000)]
+    #[arg(long, default_value_t = polytope_worker_common::DEFAULT_POLL_TIMEOUT_MS)]
     poll_timeout_ms: u64,
     #[arg(long, default_value_t = 10.0)]
     heartbeat_secs: f64,
@@ -158,7 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
-    info!(worker_concurrency, "resolved worker concurrency");
+    info!(worker_concurrency, poll_timeout_ms = cli.poll_timeout_ms, "resolved worker settings");
 
     let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");

--- a/workers/polytope-fe-worker/Dockerfile
+++ b/workers/polytope-fe-worker/Dockerfile
@@ -55,12 +55,13 @@ RUN cd workers/polytope-fe-worker && cargo build --release -p ${PACKAGE_NAME}
 # FDB Build (from source)
 ###############################
 FROM python:3.11-bookworm AS fdb-build
-ARG ecbuild_version=3.8.2
-ARG eccodes_version=2.33.1
-ARG eckit_version=1.28.3
-ARG fdb_version=5.14.0
-ARG gribjump_version=0.10.2
-ARG pyfdb_version=0.1.0
+ARG ecbuild_version=3.12.0
+ARG eccodes_version=2.46.0
+ARG eckit_version=1.33.2
+ARG metkit_version=1.18.1
+ARG fdb_version=5.21.3
+ARG gribjump_version=0.12.0
+ARG pyfdb_version=5.21.0.19
 
 RUN apt-get update && apt-get install -y cmake gnupg build-essential net-tools bison flex git libaec-dev && rm -rf /var/lib/apt/lists/*
 
@@ -83,26 +84,25 @@ RUN git clone --depth 1 --branch ${eccodes_version} https://github.com/ecmwf/ecc
     && ecbuild --prefix=/opt/fdb -- -DENABLE_FORTRAN=OFF -DCMAKE_PREFIX_PATH=/opt/fdb /source/eccodes \
     && make -j$(nproc) && make install
 
-RUN git clone --depth 1 --branch 1.11.22 https://github.com/ecmwf/metkit.git /source/metkit \
+RUN git clone --depth 1 --branch ${metkit_version} https://github.com/ecmwf/metkit.git /source/metkit \
     && mkdir -p /build/metkit && cd /build/metkit \
-    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH=/opt/fdb /source/metkit \
+    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH=/opt/fdb -DENABLE_TESTS=OFF -DENABLE_BUILD_TOOLS=OFF -DENABLE_MARS2GRIB=OFF /source/metkit \
     && make -j$(nproc) && make install
 
 RUN git clone --depth 1 --branch ${fdb_version} https://github.com/ecmwf/fdb.git /source/fdb \
     && mkdir -p /build/fdb && cd /build/fdb \
-    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH="/opt/fdb;/opt/fdb/eckit;/opt/fdb/metkit" -DCMAKE_CXX_FLAGS=-fpermissive /source/fdb \
+    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH="/opt/fdb;/opt/fdb/eckit;/opt/fdb/metkit" -DENABLE_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpermissive /source/fdb \
     && make -j$(nproc) && make install
 
 RUN git clone --depth 1 --branch ${gribjump_version} https://github.com/ecmwf/gribjump.git /source/gribjump \
     && mkdir -p /build/gribjump && cd /build/gribjump \
-    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH=/opt/fdb /source/gribjump \
+    && ecbuild --prefix=/opt/fdb -- -DCMAKE_PREFIX_PATH=/opt/fdb -DENABLE_TESTS=OFF /source/gribjump \
     && make -j$(nproc) && make install
 
 RUN rm -rf /source /build
 
-RUN git clone --single-branch --branch ${pyfdb_version} https://github.com/ecmwf/pyfdb.git \
-    && python -m pip install "numpy<2.0" --user \
-    && python -m pip install ./pyfdb --user
+RUN python -m pip install "numpy<2.0" --user \
+    && python -m pip install "pyfdb==${pyfdb_version}" --user
 
 
 

--- a/workers/polytope-fe-worker/polytope.py
+++ b/workers/polytope-fe-worker/polytope.py
@@ -69,10 +69,21 @@ class PolytopeDataSource:
             if isinstance(v, (int, float)) and not isinstance(v, bool):
                 r[k] = str(v)
 
-        # Start with a per-request deepcopy of the base config
+        # Start with a per-request deepcopy of the base config. The base pool
+        # config may carry no "options" at all (a single FE pool that selects the
+        # per-dataset datacube/options at routing time via job metadata), so do
+        # not assume "options" exists.
         polytope_mars_config = copy.deepcopy(self.config)
+        polytope_mars_config.setdefault("options", {})
 
-        # Merge trusted metadata options if present
+        # The pre_path axis list comes from the base pool config (self.pre_path,
+        # popped from options in __init__). A trusted metadata block may replace
+        # the whole datacube/options for this dataset, including its own pre_path
+        # axis list, so prefer the metadata-supplied list when present.
+        pre_path_axes = self.pre_path
+
+        # Merge trusted metadata options if present (written only by the broker
+        # set_metadata action; never sourced from the client request).
         metadata_polytope_mars = request.metadata.get("polytope_mars")
         if metadata_polytope_mars is not None:
             if not isinstance(metadata_polytope_mars, dict):
@@ -87,21 +98,27 @@ class PolytopeDataSource:
                     raise ValueError(
                         "request.metadata['polytope_mars']['options'] must be a dict"
                     )
-                polytope_mars_config["options"].update(metadata_polytope_mars["options"])
-        else:
-            # Backward compatibility: build pre_path from request when no metadata
-            pre_path = {}
-            for k, v in r.items():
-                v = v.split("/") if isinstance(v, str) else v
-                if k in self.pre_path:
-                    if isinstance(v, list):
-                        if self.gh70_fix_step_ranges:
-                            if k == "param":
-                                pre_path[k] = v[0]
-                        if len(v) == 1:
-                            v = v[0]
-                            pre_path[k] = v
-            polytope_mars_config["options"]["pre_path"] = pre_path
+                merged_options = copy.deepcopy(metadata_polytope_mars["options"])
+                # pre_path in an options block is a list of axis names; pop it so
+                # it is not left as a list where the per-request dict is expected.
+                if "pre_path" in merged_options:
+                    pre_path_axes = merged_options.pop("pre_path")
+                polytope_mars_config["options"].update(merged_options)
+
+        # Build the per-request pre_path dict from the selected axis list (works
+        # for both the metadata path and the backward-compatible base-config path).
+        pre_path = {}
+        for k, v in r.items():
+            v = v.split("/") if isinstance(v, str) else v
+            if k in pre_path_axes:
+                if isinstance(v, list):
+                    if self.gh70_fix_step_ranges:
+                        if k == "param":
+                            pre_path[k] = v[0]
+                    if len(v) == 1:
+                        v = v[0]
+                        pre_path[k] = v
+        polytope_mars_config["options"]["pre_path"] = pre_path
 
         if self.gh69_fix_grids:
             change_grids(r, polytope_mars_config)

--- a/workers/polytope-fe-worker/polytope.py
+++ b/workers/polytope-fe-worker/polytope.py
@@ -69,20 +69,39 @@ class PolytopeDataSource:
             if isinstance(v, (int, float)) and not isinstance(v, bool):
                 r[k] = str(v)
 
-        pre_path = {}
-        for k, v in r.items():
-            v = v.split("/") if isinstance(v, str) else v
-            if k in self.pre_path:
-                if isinstance(v, list):
-                    if self.gh70_fix_step_ranges:
-                        if k == "param":
-                            pre_path[k] = v[0]
-                    if len(v) == 1:
-                        v = v[0]
-                        pre_path[k] = v
-
+        # Start with a per-request deepcopy of the base config
         polytope_mars_config = copy.deepcopy(self.config)
-        polytope_mars_config["options"]["pre_path"] = pre_path
+
+        # Merge trusted metadata options if present
+        metadata_polytope_mars = request.metadata.get("polytope_mars")
+        if metadata_polytope_mars is not None:
+            if not isinstance(metadata_polytope_mars, dict):
+                raise ValueError(
+                    f"request.metadata['polytope_mars'] must be a dict, got {type(metadata_polytope_mars).__name__}"
+                )
+            # Overlay only allowed structural keys: datacube and options
+            if "datacube" in metadata_polytope_mars:
+                polytope_mars_config["datacube"] = metadata_polytope_mars["datacube"]
+            if "options" in metadata_polytope_mars:
+                if not isinstance(metadata_polytope_mars["options"], dict):
+                    raise ValueError(
+                        "request.metadata['polytope_mars']['options'] must be a dict"
+                    )
+                polytope_mars_config["options"].update(metadata_polytope_mars["options"])
+        else:
+            # Backward compatibility: build pre_path from request when no metadata
+            pre_path = {}
+            for k, v in r.items():
+                v = v.split("/") if isinstance(v, str) else v
+                if k in self.pre_path:
+                    if isinstance(v, list):
+                        if self.gh70_fix_step_ranges:
+                            if k == "param":
+                                pre_path[k] = v[0]
+                        if len(v) == 1:
+                            v = v[0]
+                            pre_path[k] = v
+            polytope_mars_config["options"]["pre_path"] = pre_path
 
         if self.gh69_fix_grids:
             change_grids(r, polytope_mars_config)

--- a/workers/polytope-fe-worker/requirements.txt
+++ b/workers/polytope-fe-worker/requirements.txt
@@ -1,6 +1,6 @@
-polytope-mars==0.3.7
-polytope-python==2.1.2
-covjsonkit==0.2.10
-PyYAML==6.0.2
-pyfdb @ git+https://github.com/ecmwf/pyfdb.git@0.1.0
-pygribjump @ git+https://github.com/ecmwf/gribjump.git@0.10.2
+polytope-mars==0.3.12
+polytope-python==2.1.15
+covjsonkit==0.2.20
+PyYAML==6.0.3
+pyfdb==5.21.0.19
+pygribjump @ git+https://github.com/ecmwf/gribjump.git@0.12.0

--- a/workers/polytope-fe-worker/run_polytope_worker.py
+++ b/workers/polytope-fe-worker/run_polytope_worker.py
@@ -15,9 +15,10 @@ class _User:
 
 
 class _Request:
-    def __init__(self, request_payload, user_payload):
+    def __init__(self, request_payload, user_payload, metadata_payload=None):
         self.coerced_request = request_payload
         self.user = _User(user_payload)
+        self.metadata = metadata_payload if metadata_payload is not None else {}
         self.id = "remote-worker"
 
 
@@ -59,7 +60,11 @@ def process(payload_json):
     datasource = _get_datasource(payload["config_path"])
     t_init = time.monotonic()
 
-    request = _Request(payload["request"], payload.get("user"))
+    request = _Request(
+        payload["request"],
+        payload.get("user"),
+        payload.get("metadata", {})
+    )
 
     try:
         timings = datasource.retrieve(request)
@@ -95,7 +100,11 @@ def main():
     from polytope import PolytopeDataSource
 
     datasource = PolytopeDataSource(config)
-    request = _Request(payload["request"], payload.get("user"))
+    request = _Request(
+        payload["request"],
+        payload.get("user"),
+        payload.get("metadata", {})
+    )
 
     try:
         datasource.retrieve(request)

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -193,7 +193,11 @@ import json
 
 def process(payload_json):
     payload = json.loads(payload_json)
-    output = json.dumps({"echo": payload["request"]}).encode("utf-8")
+    # Fail if metadata is not present
+    assert "metadata" in payload, "metadata field missing from PyO3 payload"
+    # Fail if metadata value is not passed through
+    assert payload["metadata"].get("test_key") == "test_value", "metadata content not preserved"
+    output = json.dumps({"echo": payload["request"], "metadata": payload["metadata"]}).encode("utf-8")
     return (output, '{"total_ms": 0}')
 "#,
         )
@@ -219,7 +223,8 @@ def process(payload_json):
                 job_id: "job-1".into(),
                 request: json!({"class": "od"}),
                 user: json!({}),
-                metadata: json!({}),
+                metadata: json!({"test_key": "test_value"}),
+                callback_url: None,
             })
             .await;
 

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -79,7 +79,7 @@ impl Processor for PolytopeProcessor {
 struct Cli {
     #[arg(long, default_value = "http://127.0.0.1:9001")]
     broker_url: String,
-    #[arg(long, default_value_t = 30000)]
+    #[arg(long, default_value_t = polytope_worker_common::DEFAULT_POLL_TIMEOUT_MS)]
     poll_timeout_ms: u64,
     #[arg(long, default_value_t = 10.0)]
     heartbeat_secs: f64,
@@ -113,7 +113,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     polytope_observability::init_tracing("polytope-worker-polytope-fe");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
-    info!(worker_concurrency, "resolved worker concurrency");
+    info!(
+        worker_concurrency,
+        poll_timeout_ms = cli.poll_timeout_ms,
+        "resolved worker settings"
+    );
 
     let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");

--- a/workers/polytope-fe-worker/tests/__init__.py
+++ b/workers/polytope-fe-worker/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for polytope-fe-worker

--- a/workers/polytope-fe-worker/tests/test_metadata_options.py
+++ b/workers/polytope-fe-worker/tests/test_metadata_options.py
@@ -1,0 +1,442 @@
+"""
+Test trusted metadata options merging in PolytopeDataSource.
+
+Proves that:
+1. Trusted metadata can override datacube and options per request
+2. Client request fields (polytope_mars, metadata, pre_path, use_catalogue) do not influence config
+3. Two sequential requests on one datasource use different metadata blocks
+4. self.config is never mutated by metadata overlay
+"""
+
+import copy
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from polytope import PolytopeDataSource
+
+
+class FakePolytopeMars:
+    """Fake PolytopeMars that records what config it was initialized with."""
+
+    def __init__(self, config, log_context=None):
+        self.config = copy.deepcopy(config)
+        self.log_context = log_context
+
+    def extract(self, request):
+        """Return a fake result including config details."""
+        return {
+            "datacube": self.config.get("datacube", {}),
+            "options": self.config.get("options", {}),
+            "request": request,
+        }
+
+
+class FakeRequest:
+    """Minimal request object for testing."""
+
+    def __init__(self, coerced_request, metadata=None):
+        self.coerced_request = coerced_request
+        self.metadata = metadata if metadata is not None else {}
+        self.id = "test-request"
+        self.user = FakeUser()
+
+
+class FakeUser:
+    """Minimal user object for testing."""
+
+    def __init__(self):
+        self.realm = "test"
+        self.username = "test-user"
+
+
+@pytest.fixture
+def base_config():
+    """Base worker config without metadata."""
+    return {
+        "type": "polytope",
+        "datacube": {
+            "type": "fdb",
+            "config": "/tmp/test.yaml",
+            "axis": ["class", "stream", "date"],
+        },
+        "options": {
+            "pre_path": {},
+            "use_catalogue": False,
+            "engine_options": {},
+            "axis_config": [
+                {
+                    "axis_name": "step",
+                    "transformations": [{"name": "type_change", "type": "int"}],
+                }
+            ],
+        },
+        "gribjump_config": {
+            "gribjump_servers": [{"host": "localhost", "port": 9999}]
+        },
+    }
+
+
+@pytest.fixture
+def mock_polytope_mars(monkeypatch):
+    """Replace PolytopeMars with FakePolytopeMars."""
+    # Mock the import location where PolytopeMars is used
+    import sys
+    import types
+    
+    # Create fake polytope_mars.api module
+    fake_polytope_mars_api = types.ModuleType("polytope_mars.api")
+    fake_polytope_mars_api.PolytopeMars = FakePolytopeMars
+    
+    # Create parent modules
+    if "polytope_mars" not in sys.modules:
+        sys.modules["polytope_mars"] = types.ModuleType("polytope_mars")
+    sys.modules["polytope_mars.api"] = fake_polytope_mars_api
+    
+    # Create fake polytope_feature.utility.exceptions module
+    fake_polytope_feature = types.ModuleType("polytope_feature")
+    fake_polytope_feature_utility = types.ModuleType("polytope_feature.utility")
+    fake_polytope_feature_utility_exceptions = types.ModuleType("polytope_feature.utility.exceptions")
+    
+    # Define a fake PolytopeError exception
+    class PolytopeError(Exception):
+        def __init__(self, message):
+            self.message = message
+            super().__init__(message)
+    
+    fake_polytope_feature_utility_exceptions.PolytopeError = PolytopeError
+    
+    sys.modules["polytope_feature"] = fake_polytope_feature
+    sys.modules["polytope_feature.utility"] = fake_polytope_feature_utility
+    sys.modules["polytope_feature.utility.exceptions"] = fake_polytope_feature_utility_exceptions
+    
+    yield
+    
+    # Cleanup
+    for module_name in [
+        "polytope_mars.api",
+        "polytope_feature.utility.exceptions",
+        "polytope_feature.utility",
+        "polytope_feature",
+    ]:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+
+def test_metadata_datacube_overlay(base_config, mock_polytope_mars, tmp_path):
+    """Test that metadata can override datacube structure."""
+    # Setup temp config file
+    config_file = tmp_path / "test_config.yaml"
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+    original_config = copy.deepcopy(datasource.config)
+
+    # Request with metadata that changes datacube
+    request = FakeRequest(
+        coerced_request={"class": "od", "stream": "oper"},
+        metadata={
+            "polytope_mars": {
+                "datacube": {
+                    "type": "fdb",
+                    "config": "/tmp/different.yaml",
+                    "axis": ["dataset", "date", "time"],
+                }
+            }
+        },
+    )
+
+    timings = datasource.retrieve(request)
+
+    # Verify the constructed config used the metadata datacube
+    result = json.loads(datasource.output)
+    assert result["datacube"]["axis"] == ["dataset", "date", "time"]
+    assert result["datacube"]["config"] == "/tmp/different.yaml"
+
+    # Verify self.config was not mutated
+    assert datasource.config == original_config
+
+
+def test_metadata_options_overlay(base_config, mock_polytope_mars, tmp_path):
+    """Test that metadata can override options including pre_path, use_catalogue, engine_options."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+    original_config = copy.deepcopy(datasource.config)
+
+    # Request with metadata that changes options
+    request = FakeRequest(
+        coerced_request={"class": "od", "stream": "oper", "date": "20260101"},
+        metadata={
+            "polytope_mars": {
+                "options": {
+                    "pre_path": {"class": "od", "stream": "oper"},
+                    "use_catalogue": True,
+                    "engine_options": {"compact_result": True, "limit": 1000},
+                    "axis_config": [
+                        {
+                            "axis_name": "date",
+                            "transformations": [{"name": "type_change", "type": "date"}],
+                        }
+                    ],
+                }
+            }
+        },
+    )
+
+    timings = datasource.retrieve(request)
+
+    # Verify the constructed config used the metadata options
+    result = json.loads(datasource.output)
+    assert result["options"]["pre_path"] == {"class": "od", "stream": "oper"}
+    assert result["options"]["use_catalogue"] is True
+    assert result["options"]["engine_options"] == {"compact_result": True, "limit": 1000}
+    assert len(result["options"]["axis_config"]) == 1
+    assert result["options"]["axis_config"][0]["axis_name"] == "date"
+
+    # Verify self.config was not mutated
+    assert datasource.config == original_config
+
+
+def test_client_request_fields_ignored(base_config, mock_polytope_mars, tmp_path):
+    """Test that client request fields named metadata/polytope_mars/pre_path/use_catalogue do not influence config."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+
+    # Request with malicious client-supplied fields trying to override config
+    request = FakeRequest(
+        coerced_request={
+            "class": "od",
+            "stream": "oper",
+            # These client-supplied fields should be IGNORED for config purposes
+            "metadata": {"polytope_mars": {"datacube": {"type": "evil"}}},
+            "polytope_mars": {"datacube": {"type": "evil"}},
+            "pre_path": {"malicious": "value"},
+            "use_catalogue": "client_supplied",
+            "datacube": {"type": "client_evil"},
+        },
+        metadata={
+            "polytope_mars": {
+                "options": {
+                    "pre_path": {"class": "od"},
+                    "use_catalogue": True,
+                }
+            }
+        },
+    )
+
+    timings = datasource.retrieve(request)
+
+    # Verify the config used ONLY trusted metadata, not client request fields
+    result = json.loads(datasource.output)
+    assert result["datacube"]["type"] == "fdb"  # Original, not "evil" or "client_evil"
+    assert result["options"]["pre_path"] == {"class": "od"}  # From trusted metadata
+    assert result["options"]["use_catalogue"] is True  # From trusted metadata
+
+    # Verify the client request fields were passed through to extract but didn't alter config
+    assert "metadata" in result["request"]
+    assert "polytope_mars" in result["request"]
+    assert "pre_path" in result["request"]
+
+
+def test_two_sequential_requests_different_metadata(base_config, mock_polytope_mars, tmp_path):
+    """Test that two sequential requests on one datasource use different metadata blocks."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+    original_config = copy.deepcopy(datasource.config)
+
+    # First request with metadata A
+    request1 = FakeRequest(
+        coerced_request={"class": "od", "stream": "oper"},
+        metadata={
+            "polytope_mars": {
+                "datacube": {"type": "fdb", "axis": ["class", "stream"]},
+                "options": {"pre_path": {"class": "od"}, "use_catalogue": False},
+            }
+        },
+    )
+
+    datasource.retrieve(request1)
+    result1 = json.loads(datasource.output)
+
+    # Verify first request used metadata A
+    assert result1["datacube"]["axis"] == ["class", "stream"]
+    assert result1["options"]["pre_path"] == {"class": "od"}
+    assert result1["options"]["use_catalogue"] is False
+
+    # Second request with metadata B
+    request2 = FakeRequest(
+        coerced_request={"dataset": "climate-dt", "date": "20260101"},
+        metadata={
+            "polytope_mars": {
+                "datacube": {"type": "fdb", "axis": ["dataset", "date", "time"]},
+                "options": {
+                    "pre_path": {"dataset": "climate-dt"},
+                    "use_catalogue": True,
+                    "engine_options": {"compact": True},
+                },
+            }
+        },
+    )
+
+    datasource.retrieve(request2)
+    result2 = json.loads(datasource.output)
+
+    # Verify second request used metadata B (completely different)
+    assert result2["datacube"]["axis"] == ["dataset", "date", "time"]
+    assert result2["options"]["pre_path"] == {"dataset": "climate-dt"}
+    assert result2["options"]["use_catalogue"] is True
+    assert result2["options"]["engine_options"] == {"compact": True}
+
+    # Verify self.config was never mutated and is still the original
+    assert datasource.config == original_config
+
+
+def test_metadata_must_be_dict(base_config, mock_polytope_mars):
+    """Test that non-dict metadata values raise an error."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+
+    # Request with non-dict polytope_mars metadata
+    request = FakeRequest(
+        coerced_request={"class": "od"},
+        metadata={"polytope_mars": "not_a_dict"},
+    )
+
+    with pytest.raises(ValueError, match="must be a dict"):
+        datasource.retrieve(request)
+
+
+def test_metadata_options_must_be_dict(base_config, mock_polytope_mars):
+    """Test that non-dict options in metadata raise an error."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    datasource = PolytopeDataSource(base_config)
+
+    # Request with non-dict options in metadata
+    request = FakeRequest(
+        coerced_request={"class": "od"},
+        metadata={"polytope_mars": {"options": "not_a_dict"}},
+    )
+
+    with pytest.raises(ValueError, match="options.*must be a dict"):
+        datasource.retrieve(request)
+
+
+def test_no_metadata_uses_fallback_prepath(base_config, mock_polytope_mars):
+    """Test that when no metadata is present, the legacy pre_path building logic runs."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+    base_config["options"]["pre_path"] = []  # Will be popped in __init__
+
+    datasource = PolytopeDataSource(base_config)
+    # Manually set pre_path list for testing
+    datasource.pre_path = ["class", "stream"]
+
+    # Request with no metadata
+    request = FakeRequest(
+        coerced_request={
+            "class": "od",
+            "stream": "oper",
+            "date": "20260101",
+        },
+        metadata={},  # No polytope_mars metadata
+    )
+
+    datasource.retrieve(request)
+    result = json.loads(datasource.output)
+
+    # Verify fallback pre_path logic ran and extracted class/stream from request
+    assert result["options"]["pre_path"]["class"] == "od"
+    assert result["options"]["pre_path"]["stream"] == "oper"
+
+
+def test_change_grids_runs_after_metadata_overlay(base_config, mock_polytope_mars):
+    """Test that change_grids() intra-dataset refinement runs after metadata overlay."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+    base_config["gh69_fix_grids"] = True
+
+    datasource = PolytopeDataSource(base_config)
+
+    # Request with metadata AND a dataset that triggers change_grids
+    request = FakeRequest(
+        coerced_request={
+            "class": "ng",
+            "resolution": "standard",
+            "date": "20260101",
+        },
+        metadata={
+            "polytope_mars": {
+                "options": {
+                    "use_catalogue": True,
+                    "axis_config": [
+                        {
+                            "axis_name": "step",
+                            "transformations": [
+                                {"name": "mapper", "type": "octahedral", "resolution": 64}
+                            ],
+                        }
+                    ],
+                }
+            }
+        },
+    )
+
+    datasource.retrieve(request)
+    result = json.loads(datasource.output)
+
+    # Verify change_grids ran and modified the mapper resolution to h128
+    mapper_found = False
+    for axis in result["options"]["axis_config"]:
+        for trans in axis.get("transformations", []):
+            if trans.get("name") == "mapper":
+                mapper_found = True
+                assert trans["resolution"] == 128  # change_grids should set this
+    assert mapper_found, "mapper transformation should exist"
+
+
+def test_preserved_trusted_metadata_namespaces(base_config, mock_polytope_mars):
+    """Test that metadata overlay preserves other trusted metadata keys like cost, admin_overrides."""
+    base_config["gribjump_config"] = {"gribjump_servers": []}
+
+    # Add mock for request attributes that would carry other metadata
+    request = FakeRequest(
+        coerced_request={"class": "od"},
+        metadata={
+            "cost": 1500,
+            "admin_overrides": {"bypass_rate_limit": True},
+            "accept_encoding": ["gzip"],
+            "buffer_full_output": False,
+            "polytope_mars": {
+                "options": {
+                    "pre_path": {"class": "od"},
+                }
+            },
+        },
+    )
+
+    datasource = PolytopeDataSource(base_config)
+
+    # Just verify it doesn't break and uses the polytope_mars part correctly
+    datasource.retrieve(request)
+    result = json.loads(datasource.output)
+
+    # Verify polytope_mars metadata was used
+    assert result["options"]["pre_path"] == {"class": "od"}
+
+    # Verify the request still has the other metadata (not stripped)
+    assert request.metadata["cost"] == 1500
+    assert request.metadata["admin_overrides"]["bypass_rate_limit"] is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/workers/polytope-fe-worker/tests/test_metadata_options.py
+++ b/workers/polytope-fe-worker/tests/test_metadata_options.py
@@ -438,5 +438,77 @@ def test_preserved_trusted_metadata_namespaces(base_config, mock_polytope_mars):
     assert request.metadata["admin_overrides"]["bypass_rate_limit"] is True
 
 
+@pytest.fixture
+def base_config_no_options():
+    """Single-FE-pool base config that carries NO 'options' key at all.
+
+    This mirrors the LUMI deployment, where every per-dataset datacube/options
+    block is supplied at routing time via job metadata (set_metadata action),
+    so the static pool config has only the shared gribjump/datacube scaffolding.
+    """
+    return {
+        "type": "polytope",
+        "datacube": {"type": "gribjump", "config": "/tmp/test.yaml"},
+        "gribjump_config": {
+            "gribjump_servers": [{"host": "localhost", "port": 9999}]
+        },
+    }
+
+
+def test_metadata_options_when_base_has_no_options(
+    base_config_no_options, mock_polytope_mars
+):
+    """Regression: a base config without 'options' must not KeyError, and a
+    metadata options block carrying pre_path as a LIST of axis names must be
+    converted to the per-request pre_path dict (previously raised
+    KeyError: 'options', breaking every FE request on a single-pool deployment).
+    """
+    request = FakeRequest(
+        {
+            "class": "d1",
+            "dataset": "on-demand-extremes-dt",
+            "date": "20230820",
+            "param": "146",
+            "step": "0-10",
+        },
+        metadata={
+            "polytope_mars": {
+                "datacube": {"type": "gribjump"},
+                "options": {
+                    # pre_path is a LIST of axis names, as in the per-dataset
+                    # datasource config ported into the set_metadata block.
+                    "pre_path": ["class", "dataset", "date", "param"],
+                    "use_catalogue": False,
+                    "axis_config": [
+                        {
+                            "axis_name": "step",
+                            "transformations": [{"name": "type_change", "type": "int"}],
+                        }
+                    ],
+                },
+            }
+        },
+    )
+
+    datasource = PolytopeDataSource(base_config_no_options)
+    # Must not raise KeyError: 'options'
+    datasource.retrieve(request)
+    result = json.loads(datasource.output)
+
+    # pre_path list -> per-request dict for single-valued, in-list axes
+    assert result["options"]["pre_path"] == {
+        "class": "d1",
+        "dataset": "on-demand-extremes-dt",
+        "date": "20230820",
+        "param": "146",
+    }
+    # non-pre_path axes (step) are not promoted into pre_path
+    assert "step" not in result["options"]["pre_path"]
+    # other metadata options survived the merge
+    assert result["options"]["use_catalogue"] is False
+    # base config is untouched (still no options key)
+    assert "options" not in base_config_no_options
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/workers/test-worker/src/lib.rs
+++ b/workers/test-worker/src/lib.rs
@@ -103,6 +103,54 @@ fn stress_usize(request: &serde_json::Value, key: &str) -> Option<usize> {
     stress_u64(request, key).and_then(|value| usize::try_from(value).ok())
 }
 
+/// Parse an optional weighted size distribution from the request's stress block:
+/// `response_bytes_choices: [{ "bytes": <usize>, "weight": <u64=1> }, ...]`.
+/// Lets one loadgen payload drive a mixed distribution of object sizes -- the
+/// worker samples a size per job (the loadgen sends a single fixed payload, so
+/// the distribution has to live here, where the size is generated).
+fn stress_response_bytes_choices(request: &serde_json::Value) -> Option<Vec<(usize, u64)>> {
+    let arr = nested_stress_config(request)?
+        .get("response_bytes_choices")?
+        .as_array()?;
+    let mut choices: Vec<(usize, u64)> = Vec::new();
+    for item in arr {
+        let bytes = item
+            .get("bytes")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| usize::try_from(v).ok())?;
+        let weight = item
+            .get("weight")
+            .and_then(|w| w.as_u64())
+            .unwrap_or(1)
+            .max(1);
+        choices.push((bytes, weight));
+    }
+    if choices.is_empty() {
+        None
+    } else {
+        Some(choices)
+    }
+}
+
+/// Pick a size from the weighted choices, keyed by the job id so the draw is
+/// deterministic per job (reproducible) yet well spread across distinct jobs.
+fn sample_weighted_response_bytes(choices: &[(usize, u64)], seed: &str) -> usize {
+    let total: u64 = choices.iter().map(|(_, w)| *w).sum();
+    if total == 0 {
+        return choices.first().map(|(b, _)| *b).unwrap_or(0);
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(seed, &mut hasher);
+    let mut pick = std::hash::Hasher::finish(&hasher) % total;
+    for (bytes, weight) in choices {
+        if pick < *weight {
+            return *bytes;
+        }
+        pick -= *weight;
+    }
+    choices.last().map(|(b, _)| *b).unwrap_or(0)
+}
+
 struct StressStream {
     remaining: usize,
     chunk: bytes::Bytes,
@@ -182,8 +230,13 @@ impl Processor for BehaviourProcessor {
                 let delay_ms = stress_u64(&work.request, "delay_ms")
                     .unwrap_or(*default_delay_ms)
                     .min(*max_delay_ms);
-                let response_bytes = stress_usize(&work.request, "response_bytes")
-                    .unwrap_or(*default_response_bytes);
+                // A weighted `response_bytes_choices` distribution (sampled per
+                // job) takes precedence over a fixed `response_bytes`.
+                let response_bytes = match stress_response_bytes_choices(&work.request) {
+                    Some(choices) => sample_weighted_response_bytes(&choices, &work.job_id),
+                    None => stress_usize(&work.request, "response_bytes")
+                        .unwrap_or(*default_response_bytes),
+                };
                 let chunk_bytes = stress_usize(&work.request, "chunk_bytes")
                     .unwrap_or(*default_chunk_bytes)
                     .min(*max_chunk_bytes)
@@ -197,5 +250,54 @@ impl Processor for BehaviourProcessor {
                 ProcessResult::success(&self.config.content_type, Box::new(stream))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod weighted_size_tests {
+    use super::{sample_weighted_response_bytes, stress_response_bytes_choices};
+
+    #[test]
+    fn sampling_only_returns_choice_sizes() {
+        let choices = vec![(16usize, 1u64), (200, 8), (1000, 8), (20000, 1)];
+        for i in 0..2000 {
+            let v = sample_weighted_response_bytes(&choices, &format!("job-{i}"));
+            assert!(
+                choices.iter().any(|(b, _)| *b == v),
+                "sampled {v} not in choice set"
+            );
+        }
+    }
+
+    #[test]
+    fn sampling_biases_toward_heavy_weights() {
+        // 200 and 1000 carry weight 8 each (16 of 18 total mass).
+        let choices = vec![(16usize, 1u64), (200, 8), (1000, 8), (20000, 1)];
+        let n = 6000;
+        let dense = (0..n)
+            .filter(|i| {
+                let v = sample_weighted_response_bytes(&choices, &format!("job-{i}"));
+                v == 200 || v == 1000
+            })
+            .count();
+        let frac = dense as f64 / n as f64;
+        assert!(frac > 0.80, "dense-band fraction too low: {frac}");
+    }
+
+    #[test]
+    fn parses_choices_with_default_weight() {
+        let req = serde_json::json!({"stress": {"response_bytes_choices": [
+            {"bytes": 16, "weight": 2}, {"bytes": 200}
+        ]}});
+        assert_eq!(
+            stress_response_bytes_choices(&req).unwrap(),
+            vec![(16usize, 2u64), (200usize, 1u64)]
+        );
+    }
+
+    #[test]
+    fn no_choices_block_returns_none() {
+        let req = serde_json::json!({"stress": {"response_bytes": 16}});
+        assert!(stress_response_bytes_choices(&req).is_none());
     }
 }

--- a/workers/test-worker/src/lib.rs
+++ b/workers/test-worker/src/lib.rs
@@ -6,7 +6,6 @@ const DEFAULT_STRESS_DELAY_MS: u64 = 0;
 const DEFAULT_STRESS_RESPONSE_BYTES: usize = 1024;
 const DEFAULT_STRESS_CHUNK_BYTES: usize = 1024 * 1024;
 const DEFAULT_STRESS_MAX_DELAY_MS: u64 = 10_000;
-const DEFAULT_STRESS_MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const DEFAULT_STRESS_MAX_CHUNK_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
@@ -42,8 +41,9 @@ pub enum Behaviour {
         default_chunk_bytes: usize,
         #[serde(default = "default_stress_max_delay_ms")]
         max_delay_ms: u64,
-        #[serde(default = "default_stress_max_response_bytes")]
-        max_response_bytes: usize,
+        // response_bytes is streamed lazily (StressStream), so there is no
+        // allocation to bound -- no max_response_bytes cap. chunk_bytes is a
+        // real per-chunk allocation, so it keeps a cap.
         #[serde(default = "default_stress_max_chunk_bytes")]
         max_chunk_bytes: usize,
     },
@@ -67,10 +67,6 @@ pub fn default_stress_chunk_bytes() -> usize {
 
 pub fn default_stress_max_delay_ms() -> u64 {
     DEFAULT_STRESS_MAX_DELAY_MS
-}
-
-pub fn default_stress_max_response_bytes() -> usize {
-    DEFAULT_STRESS_MAX_RESPONSE_BYTES
 }
 
 pub fn default_stress_max_chunk_bytes() -> usize {
@@ -181,15 +177,13 @@ impl Processor for BehaviourProcessor {
                 default_response_bytes,
                 default_chunk_bytes,
                 max_delay_ms,
-                max_response_bytes,
                 max_chunk_bytes,
             } => {
                 let delay_ms = stress_u64(&work.request, "delay_ms")
                     .unwrap_or(*default_delay_ms)
                     .min(*max_delay_ms);
                 let response_bytes = stress_usize(&work.request, "response_bytes")
-                    .unwrap_or(*default_response_bytes)
-                    .min(*max_response_bytes);
+                    .unwrap_or(*default_response_bytes);
                 let chunk_bytes = stress_usize(&work.request, "chunk_bytes")
                     .unwrap_or(*default_chunk_bytes)
                     .min(*max_chunk_bytes)

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -135,7 +135,9 @@ mod tests {
     /// Collect all stream chunks into a single flat byte vec.
     async fn collect_success_body(result: ProcessResult) -> (String, Vec<u8>) {
         match result {
-            ProcessResult::Success { content_type, body } => {
+            ProcessResult::Success {
+                content_type, body, ..
+            } => {
                 let bytes = body
                     .try_fold(Vec::new(), |mut acc, chunk| async move {
                         acc.extend_from_slice(&chunk);
@@ -152,7 +154,9 @@ mod tests {
     /// Collect all stream chunks, preserving individual chunk boundaries.
     async fn collect_success_chunks(result: ProcessResult) -> (String, Vec<Vec<u8>>) {
         match result {
-            ProcessResult::Success { content_type, body } => {
+            ProcessResult::Success {
+                content_type, body, ..
+            } => {
                 let chunks = body.try_collect::<Vec<_>>().await.unwrap();
                 let chunks: Vec<Vec<u8>> = chunks.into_iter().map(|b| b.to_vec()).collect();
                 (content_type, chunks)

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info, warn};
 struct Cli {
     #[arg(long, default_value = "http://127.0.0.1:9001")]
     broker_url: String,
-    #[arg(long, default_value_t = 30000)]
+    #[arg(long, default_value_t = polytope_worker_common::DEFAULT_POLL_TIMEOUT_MS)]
     poll_timeout_ms: u64,
     #[arg(long, default_value_t = 10.0)]
     heartbeat_secs: f64,
@@ -40,7 +40,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     polytope_observability::init_tracing("polytope-worker-test");
     let cli = Cli::parse();
     let worker_concurrency = resolved_worker_concurrency(cli.worker_concurrency);
-    info!(worker_concurrency, "resolved worker concurrency");
+    info!(
+        worker_concurrency,
+        poll_timeout_ms = cli.poll_timeout_ms,
+        "resolved worker settings"
+    );
     let config = WorkerConfigFile::load(&cli.config_path).unwrap_or_else(|err| {
         tracing::error!("event.name" = "startup.config.failed", outcome = "error", config_path = %cli.config_path, error = %err, "failed to load config");
         std::process::exit(1);

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -237,7 +237,6 @@ mod tests {
             default_response_bytes: 10,
             default_chunk_bytes: default_stress_chunk_bytes(),
             max_delay_ms: 1000,
-            max_response_bytes: 1000,
             max_chunk_bytes: default_stress_max_chunk_bytes(),
         })
         .process(stress_work(50, 123))
@@ -251,29 +250,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stress_caps_request_values() {
-        let result = processor(Behaviour::Stress {
-            default_delay_ms: 0,
-            default_response_bytes: 10,
-            default_chunk_bytes: default_stress_chunk_bytes(),
-            max_delay_ms: 0,
-            max_response_bytes: 32,
-            max_chunk_bytes: default_stress_max_chunk_bytes(),
-        })
-        .process(stress_work(500, 500))
-        .await;
-        let (_, body) = collect_success_body(result).await;
-        assert_eq!(body.len(), 32);
-    }
-
-    #[tokio::test]
     async fn stress_defaults_when_request_has_no_stress_block() {
         let result = processor(Behaviour::Stress {
             default_delay_ms: 0,
             default_response_bytes: 17,
             default_chunk_bytes: default_stress_chunk_bytes(),
             max_delay_ms: 0,
-            max_response_bytes: 100,
             max_chunk_bytes: default_stress_max_chunk_bytes(),
         })
         .process(dummy_work())
@@ -305,7 +287,6 @@ mod tests {
             default_response_bytes: 1000,
             default_chunk_bytes: default_stress_chunk_bytes(),
             max_delay_ms: 0,
-            max_response_bytes: 10_000,
             max_chunk_bytes: default_stress_max_chunk_bytes(),
         })
         .process(stress_work_with_chunk(0, 1000, 256))
@@ -335,7 +316,6 @@ mod tests {
             default_response_bytes: 2048,
             default_chunk_bytes: 1024,
             max_delay_ms: 0,
-            max_response_bytes: 10_000,
             max_chunk_bytes: 512,
         })
         .process(stress_work_with_chunk(0, 2048, 10_000))
@@ -366,7 +346,6 @@ mod tests {
             default_response_bytes: 1000,
             default_chunk_bytes: 256,
             max_delay_ms: 0,
-            max_response_bytes: 10_000,
             max_chunk_bytes: default_stress_max_chunk_bytes(),
         })
         .process(stress_work(0, 1000))


### PR DESCRIPTION
## Changes

### Load generator
- Add Rust load generator crate; document and package it.
- Emit live progress snapshots.
- Add peak windowed throughput metric.
- Add duration-based soak mode.

### FE worker
- Bump gribjump/FDB stack to 0.12.0 / 5.21.3 for new-system extraction.
- Lock down FE worker metadata pass-through from Rust to PyO3.
- Fix metadata options merge when base config has no options.
- Add tests for Python FE worker metadata options merging.

### Workers / broker
- Route worker callbacks to dispatching broker.
- Rebalance broker polling between jobs.
- Debounce broker-poll failure warnings (warn only after 30s).
- Propagate MARS stream errors through worker delivery.
- Emit delivered byte count on `worker.job.completed`.
- Keep BOBS create connection pool warm; re-load-balance creates across BOBS.
- Bump bits for worker error completion semantics.

### Frontend
- Add isolated internal poll listener.
- Add `Polytope-Mock-User` header for synthetic user impersonation; require `Polytope-Mock-Roles` when set.
- Copy loadgen workspace member into the Docker build.

### Observability
- Per-stage timing for workers and frontend submit path.

### test-worker
- Weighted per-job `response_bytes_choices` sampling.
- Remove `max_response_bytes` cap (response is streamed).

## CI

- `cargo fmt --all -- --check`
- `cargo test -p polytope-server`
- `cargo test -p polytope-server-integration-tests`
