### PR TITLE
Open-source compliance prep

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 /target
 **/target
 /.git

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI
 
 on:
@@ -5,6 +9,9 @@ on:
     branches:
       - '**'
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   fmt:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release (disabled)
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: REUSE Compliance
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  reuse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5   # v4
+      - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5  # v6.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 target/
 .cargo/config.toml
 .sisyphus
@@ -13,3 +17,5 @@ AGENTS.md
 # Pi/Weave runtime artefacts (plans, sessions, runtime notes)
 .weave/
 METRICS_PLAN.md
+.claude/
+.omc/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+repos:
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v6.0.0
+    hooks:
+      - id: reuse
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt (workspace)
+        entry: cargo fmt --all
+        language: system
+        pass_filenames: false

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+title: "polytope-server"
+abstract: "A Polytope HTTP frontend and worker services for feature extraction and retrieval of meteorological data, built on the bits request broker and bobs data staging service."
+authors:
+  - name: "European Centre for Medium-Range Weather Forecasts (ECMWF)"
+    website: "https://www.ecmwf.int"
+version: "2.0.0"
+date-released: "2026-07-09"
+repository-code: "https://github.com/ecmwf/polytope-server"
+url: "https://github.com/ecmwf/polytope-server"
+license: Apache-2.0
+keywords:
+  - "polytope"
+  - "meteorological-data"
+  - "data-retrieval"
+  - "web-service"
+  - "rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [workspace]
 members = [
     "observability",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,196 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 1996- European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-------------------------------------------------------------------------------
+
+In applying this licence, ECMWF does not waive the privileges and immunities
+granted to it by virtue of its status as an intergovernmental organisation
+nor does it submit to any jurisdiction.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+European Centre for Medium-Range Weather Forecasts (ECMWF)
+Copyright 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+This product includes software developed at ECMWF (https://www.ecmwf.int).
+
+In applying this licence, ECMWF does not waive the privileges and immunities
+granted to it by virtue of its status as an intergovernmental organisation
+nor does it submit to any jurisdiction.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # polytope-server
 
-A Rust workspace containing a Polytope frontend plus separate worker crates, backed by [Bits](http://github.com/ecmwf/bits-broker) for request routing and processing, and [Bobs](http://github.com/ecmwf/bobs) for efficient data staging.
+A Rust workspace containing a Polytope frontend plus separate worker crates, backed by [Bits](https://github.com/ecmwf/bits-broker) for request routing and processing, and [Bobs](https://github.com/ecmwf/bobs) for efficient data staging.
+
+[![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/incubating_badge.svg)](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity#incubating)
+
+> [!IMPORTANT]
+> This software is **Incubating** and subject to ECMWF's guidelines on [Software Maturity](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity).
 
 ## Workspace layout
 
@@ -76,7 +87,7 @@ collections:
         url: "http://ops-backend/api"
 ```
 
-See `config.example.yaml` for a starting point, [docs/request-ids.md](docs/request-ids.md) for request ID and rollout guidance, and the [bits documentation](../bits) for the full bits config schema.
+See `config.example.yaml` for a starting point, [docs/request-ids.md](docs/request-ids.md) for request ID and rollout guidance, and the [bits documentation](https://github.com/ecmwf/bits-broker) for the full bits config schema.
 
 ## Running
 
@@ -164,3 +175,7 @@ The current layout is designed so the crates can be moved later with minimal chu
 - the only in-repo worker dependency is `workers/common/`
 
 If a worker needs to move to its own repository later, it should mostly be a matter of copying that crate plus `workers/common/` (or publishing `workers/common/` as its own crate).
+
+## License
+
+[Apache License 2.0](LICENSE) In applying this licence, ECMWF does not waive the privileges and immunities granted to it by virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+
+# Human-facing LICENSE and NOTICE files (outside LICENSES/) and metadata files
+# that carry no comment syntax.
+[[annotations]]
+path = ["LICENSE", "NOTICE", "CITATION.cff"]
+precedence = "closest"
+SPDX-FileCopyrightText = "2026 European Centre for Medium-Range Weather Forecasts (ECMWF)"
+SPDX-License-Identifier = "Apache-2.0"
+
+# Generated lockfiles and data/config files without a comment syntax.
+[[annotations]]
+path = [
+  "**/Cargo.lock",
+  "pytest.ini",
+  "**/requirements.txt",
+  "dev/otel/grafana/dashboards/**",
+]
+precedence = "closest"
+SPDX-FileCopyrightText = "2026 European Centre for Medium-Range Weather Forecasts (ECMWF)"
+SPDX-License-Identifier = "Apache-2.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this software, please report it
+responsibly. **Do not open a public GitHub issue, pull request, or discussion**,
+as this may put users at risk before a fix is available.
+
+Instead, report it privately using **GitHub private vulnerability reporting**:
+open this repository's **Security** tab and click **Report a vulnerability**.
+Your report is visible only to you and to the repository's administrators and
+security managers.
+
+If private vulnerability reporting is not available on this repository, report
+it through the [ECMWF Support Portal](https://support.ecmwf.int) instead,
+stating the affected repository.
+
+In either case, please include where possible:
+
+- a description of the vulnerability and its potential impact;
+- the steps, configuration, or input needed to reproduce it;
+- any known mitigations or workarounds.
+
+We will acknowledge receipt within 5 business days and aim to provide an initial
+assessment within 10 business days. Please give us a reasonable opportunity to
+investigate and release a fix before any public disclosure.
+
+## Supported Versions
+
+Unless stated otherwise for a specific release, security updates are applied to
+the latest released version only. Users are encouraged to stay up to date with
+the latest release.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+| Older   | No        |
+
+## Scope
+
+This policy applies to the code maintained in this repository. Vulnerabilities
+in third-party dependencies should be reported to their respective maintainers;
+where such a vulnerability also affects this project, please still let us know
+through the channel above so we can track and address the impact.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope_client"
 version = "0.2.0"

--- a/client/src/auth.rs
+++ b/client/src/auth.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use base64::{prelude::BASE64_STANDARD, Engine};
 use serde_json::Value;
 use std::{error::Error, fs};

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::error::Error;
 use std::fmt;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod auth;
 pub mod error;
 pub mod polytope_client;

--- a/client/src/polytope_client.rs
+++ b/client/src/polytope_client.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     auth::AuthHeader,
     error::PolytopeError,

--- a/client/src/response.rs
+++ b/client/src/response.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 

--- a/client/tests/polytope_client_test.rs
+++ b/client/tests/polytope_client_test.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use polytope_client::polytope_client::PolytopeClient;
 use regex::Regex;
 use serde_json::json;

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 server:
   host: "0.0.0.0"   # optional, default 0.0.0.0
   port: 3000         # optional, default 3000

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 server:
   host: "0.0.0.0"
   port: 3001

--- a/dev/otel/docker-compose.yml
+++ b/dev/otel/docker-compose.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   prometheus:
     image: prom/prometheus:v3.1.0

--- a/dev/otel/grafana/dashboards.yaml
+++ b/dev/otel/grafana/dashboards.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: 1
 
 providers:

--- a/dev/otel/grafana/datasources.yaml
+++ b/dev/otel/grafana/datasources.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: 1
 
 datasources:

--- a/dev/otel/prometheus.yaml
+++ b/dev/otel/prometheus.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 global:
   scrape_interval: 15s
 

--- a/docs/admin-mocking.md
+++ b/docs/admin-mocking.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Admin mocking
 
 Admin mocking is an operational facility for configured Polytope admins. It lets an admin submit a protected request with one or both of these headers:

--- a/docs/admin-role-mocking.md
+++ b/docs/admin-role-mocking.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Admin role mocking
 
 The canonical documentation for admin role and time mocking is now `docs/admin-mocking.md`.

--- a/docs/error-responses.md
+++ b/docs/error-responses.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Error responses
 
 Every response that reaches a user carries a request ID, and every error body is

--- a/docs/job-metadata-options.md
+++ b/docs/job-metadata-options.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Job Metadata Options
 
 ## Overview

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Model Context Protocol frontend
 
 Polytope can expose a Model Context Protocol (MCP) endpoint at `/mcp`. The

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Metrics
 
 This page lists the raw metrics emitted by Polytope Server components and related scrape targets in the local monitoring stack, and what each one means. Prometheus names assume the `opentelemetry-prometheus` exporter used by the local dev stack.

--- a/docs/request-ids.md
+++ b/docs/request-ids.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Request IDs
 
 Polytope request IDs are opaque public identifiers returned by BITS. Clients and server code must store and pass them back exactly as received, without parsing structure from the string.

--- a/examples/admin-mock-roles.sh
+++ b/examples/admin-mock-roles.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 : "${POLYTOPE_URL:?Set POLYTOPE_URL to the Polytope server base URL, for example https://polytope.example.org}"

--- a/examples/admin-mock-time.sh
+++ b/examples/admin-mock-time.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 : "${POLYTOPE_URL:?Set POLYTOPE_URL to the Polytope server base URL, for example https://polytope.example.org}"

--- a/examples/mcp-config.yaml
+++ b/examples/mcp-config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 server:
   host: "0.0.0.0"
   port: 3000

--- a/examples/request-id-config.yaml
+++ b/examples/request-id-config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Minimal request-ID-aware deployment identity example.
 # Tags are 1-3 lower-case alphanumeric characters.
 polytope:

--- a/examples/set-metadata-routing.yaml
+++ b/examples/set-metadata-routing.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Example: Using set_metadata to Attach Trusted Job Metadata
 #
 # This example demonstrates how the `set_metadata` transform action attaches

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope-server"
 version = "0.1.0"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###############################
 # Shared base: Rust + system deps
 ###############################

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # frontend
 
 This crate contains the Polytope HTTP frontend only.

--- a/frontend/src/actions/check_date.rs
+++ b/frontend/src/actions/check_date.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, CheckAction, CheckResult};

--- a/frontend/src/actions/check_has_key.rs
+++ b/frontend/src/actions/check_has_key.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, CheckAction, CheckResult};

--- a/frontend/src/actions/check_has_license.rs
+++ b/frontend/src/actions/check_has_license.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, CheckAction, CheckResult};

--- a/frontend/src/actions/check_has_role.rs
+++ b/frontend/src/actions/check_has_role.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/frontend/src/actions/check_match.rs
+++ b/frontend/src/actions/check_match.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/frontend/src/actions/check_rate_limit.rs
+++ b/frontend/src/actions/check_rate_limit.rs
@@ -1,2 +1,6 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Rate limiting is enforced by BITS dispatcher `user_limit`.
 // This module intentionally registers no frontend check action.

--- a/frontend/src/actions/check_schedule.rs
+++ b/frontend/src/actions/check_schedule.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, CheckAction, CheckResult};

--- a/frontend/src/actions/coercion.rs
+++ b/frontend/src/actions/coercion.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeSet;
 
 use bits::actions::ActionError;

--- a/frontend/src/actions/date_check.rs
+++ b/frontend/src/actions/date_check.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{Duration, Local, NaiveDate};
 
 use crate::actions::coercion::request_field_as_strings;

--- a/frontend/src/actions/mod.rs
+++ b/frontend/src/actions/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod check_date;
 mod check_has_key;
 mod check_has_license;

--- a/frontend/src/actions/schedule.rs
+++ b/frontend/src/actions/schedule.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fs;
 
 use bits::Job;

--- a/frontend/src/actions/transform_coercion.rs
+++ b/frontend/src/actions/transform_coercion.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, TransformAction, TransformResult};

--- a/frontend/src/actions/transform_defaults.rs
+++ b/frontend/src/actions/transform_defaults.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/frontend/src/actions/transform_metadata.rs
+++ b/frontend/src/actions/transform_metadata.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, TransformAction, TransformResult};

--- a/frontend/src/actions/transform_patch.rs
+++ b/frontend/src/actions/transform_patch.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use async_trait::async_trait;

--- a/frontend/src/api/mcp.rs
+++ b/frontend/src/api/mcp.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod mcp;
 pub mod openmeteo;
 pub mod v1;

--- a/frontend/src/api/openmeteo/mod.rs
+++ b/frontend/src/api/openmeteo/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod params;
 mod response;
 mod variables;

--- a/frontend/src/api/openmeteo/params.rs
+++ b/frontend/src/api/openmeteo/params.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]

--- a/frontend/src/api/openmeteo/response.rs
+++ b/frontend/src/api/openmeteo/response.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde_json::{Map, Value, json};
 
 pub struct VariableResult {

--- a/frontend/src/api/openmeteo/variables.rs
+++ b/frontend/src/api/openmeteo/variables.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #[derive(Clone)]
 pub enum ParamKind {
     Direct {

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/frontend/src/auth/admin.rs
+++ b/frontend/src/auth/admin.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use authotron_types::User as AuthUser;

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;

--- a/frontend/src/auth/mock_roles.rs
+++ b/frontend/src/auth/mock_roles.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use axum::http::{HeaderMap, HeaderName};

--- a/frontend/src/auth/mock_time.rs
+++ b/frontend/src/auth/mock_time.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::http::{HeaderMap, HeaderName};
 use chrono::{DateTime, NaiveDate, NaiveTime, SecondsFormat, Utc};
 

--- a/frontend/src/auth/mod.rs
+++ b/frontend/src/auth/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod admin;
 pub mod middleware;
 pub mod mock_roles;

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::de;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod actions;
 pub mod api;
 pub mod auth;

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use clap::Parser;
 
 use polytope_server::config::ServerConfig;

--- a/frontend/src/metkit_expansion.rs
+++ b/frontend/src/metkit_expansion.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bits::Job;
 use bits::actions::{ActionError, TransformAction, TransformResult};

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::auth::AuthClient;

--- a/frontend/src/support.rs
+++ b/frontend/src/support.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! User-facing error enrichment.
 //!
 //! A single outer middleware gives every request a request ID (minted in the

--- a/frontend/tests/observability.rs
+++ b/frontend/tests/observability.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{collections::HashMap, sync::Arc};
 
 use axum::{Router, routing::get};

--- a/frontend/tests/support_errors.rs
+++ b/frontend/tests/support_errors.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! End-to-end checks that user-facing errors carry support guidance + a request
 //! ID, and that the error body stays a flat string→string object (so the Python
 //! `polytope-client`, which flattens every value and crashes on non-strings,

--- a/frontend/tests/v1_parity.rs
+++ b/frontend/tests/v1_parity.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Backwards-compatibility checks: the v1 API keeps parity with the legacy
 //! Python polytope-server on the response shapes that clients depend on.
 

--- a/loadgen/Cargo.toml
+++ b/loadgen/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "loadgen"
 version = "0.1.0"

--- a/loadgen/Dockerfile
+++ b/loadgen/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###############################
 # Shared base: Rust + cargo-chef + system deps
 ###############################

--- a/loadgen/README.md
+++ b/loadgen/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # loadgen
 
 Single-pod async load generator for Polytope BOBS download flow.

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use futures_util::StreamExt;
 use loadgen::{
     Config, IterationResult, Outcome, ProgressTracker, RunLimit, SummaryMetadata,

--- a/observability/Cargo.toml
+++ b/observability/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope-observability"
 version = "0.1.0"

--- a/observability/src/env_filter.rs
+++ b/observability/src/env_filter.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use tracing_subscriber::EnvFilter;
 
 const DEFAULT_FILTER: &str =

--- a/observability/src/formatter.rs
+++ b/observability/src/formatter.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::redaction::{redact_field, redact_json, redact_string};
 use crate::resource::Resource;
 use serde_json::{Map, Number, Value};

--- a/observability/src/lib.rs
+++ b/observability/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod env_filter;
 mod formatter;
 mod redaction;

--- a/observability/src/redaction.rs
+++ b/observability/src/redaction.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use regex::Regex;
 use serde_json::Value;
 use std::sync::OnceLock;

--- a/observability/src/resource.rs
+++ b/observability/src/resource.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde_json::{Map, Value};
 
 #[derive(Debug, Clone)]

--- a/observability/src/test_helper.rs
+++ b/observability/src/test_helper.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::formatter::{JsonFieldFormatter, OtelJsonFormatter};
 use serde_json::Value;
 use std::io;

--- a/observability/tests/test_helper.rs
+++ b/observability/tests/test_helper.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use polytope_observability::test_helper::capturing_subscriber;
 use tracing_subscriber::prelude::*;
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ─── Environment variables ────────────────────────────────────────────────────
 #
 # Required:

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope-server-integration-tests"
 version = "0.1.0"

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::error::Error;
 use std::sync::Arc;
 

--- a/tests/quick_test.sh
+++ b/tests/quick_test.sh
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 http://127.0.0.1:46515/edr/collections/operational-data/position?f=json&datetime=2026-03-18T00%3A00%3A00Z%2F2026-03-20T00%3A00%3A00Z&parameter-name=2t&coords=POINT(60+13)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end tests: polytope-client (v1) against a live deployment.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration test: polytope-client <-> polytope-server <-> mock data backend.
 

--- a/utils/metkit/.cargo/config.toml
+++ b/utils/metkit/.cargo/config.toml
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [env]
 RUST_TEST_THREADS = "1"

--- a/utils/metkit/Cargo.toml
+++ b/utils/metkit/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "metkit"
 version = "0.1.0"

--- a/utils/metkit/build.rs
+++ b/utils/metkit/build.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     let eckit_include = std::env::var("ECKIT_INCLUDE_DIR")
         .unwrap_or_else(|_| "../../../mars-client-bundle/eckit/src".to_string());

--- a/utils/metkit/src/bridge.cc
+++ b/utils/metkit/src/bridge.cc
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "bridge.h"
 
 #include "metkit/mars/MarsExpansion.h"

--- a/utils/metkit/src/bridge.h
+++ b/utils/metkit/src/bridge.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "rust/cxx.h"

--- a/utils/metkit/src/lib.rs
+++ b/utils/metkit/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 #[cxx::bridge(namespace = "metkit::bridge")]

--- a/utils/metkit/tests/integration.rs
+++ b/utils/metkit/tests/integration.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 #[test]

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # workers
 
 The worker side of the repository is split into separate crates so each worker can evolve or move independently.

--- a/workers/common/Cargo.toml
+++ b/workers/common/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope-worker-common"
 version = "0.1.0"

--- a/workers/common/README.md
+++ b/workers/common/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # workers/common
 
 Shared worker runtime for the `polytope-server` workspace.

--- a/workers/common/src/config.rs
+++ b/workers/common/src/config.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::delivery_config::DeliveryConfig;
 
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/worker/config.yaml";

--- a/workers/common/src/delivery/bobs.rs
+++ b/workers/common/src/delivery/bobs.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 
 use super::{DeliveryContext, ResultDelivery, enduser_fields};

--- a/workers/common/src/delivery/mod.rs
+++ b/workers/common/src/delivery/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 

--- a/workers/common/src/delivery/s3.rs
+++ b/workers/common/src/delivery/s3.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use aws_sdk_s3::{
     presigning::PresigningConfig,

--- a/workers/common/src/delivery_config.rs
+++ b/workers/common/src/delivery_config.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 /// How the worker should deliver its result.

--- a/workers/common/src/encoding.rs
+++ b/workers/common/src/encoding.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_compression::tokio::bufread::{GzipEncoder, ZstdEncoder};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};

--- a/workers/common/src/lib.rs
+++ b/workers/common/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/workers/common/src/management.rs
+++ b/workers/common/src/management.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::{Json, Router, routing::get};

--- a/workers/common/src/metrics.rs
+++ b/workers/common/src/metrics.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Worker lifecycle metrics.
 //!
 //! Uses the OpenTelemetry global meter provider. All instruments are

--- a/workers/common/tests/observability.rs
+++ b/workers/common/tests/observability.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use polytope_observability::test_helper::capturing_subscriber;
 use tracing_subscriber::prelude::*;
 

--- a/workers/fdb-worker/Cargo.toml
+++ b/workers/fdb-worker/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "fdb-worker"
 version = "0.1.0"

--- a/workers/fdb-worker/Dockerfile
+++ b/workers/fdb-worker/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###############################
 # Shared base: Rust + cargo-chef + system deps (built once)
 ###############################

--- a/workers/fdb-worker/src/main.rs
+++ b/workers/fdb-worker/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use clap::Parser;

--- a/workers/mars-worker/Cargo.toml
+++ b/workers/mars-worker/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "mars-worker"
 version = "0.1.0"

--- a/workers/mars-worker/Dockerfile
+++ b/workers/mars-worker/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG MARS_BUILD_FROM_SOURCE=false
 
 ###############################

--- a/workers/mars-worker/src/convert.rs
+++ b/workers/mars-worker/src/convert.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use serde_json::Value;

--- a/workers/mars-worker/src/k8s.rs
+++ b/workers/mars-worker/src/k8s.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::future::Future;

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::k8s::NodePortManager;
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/workers/mars-worker/src/port_cleanup.rs
+++ b/workers/mars-worker/src/port_cleanup.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Forcibly release leaked MARS DHS callback sockets.
 //!
 //! `mars-client-cpp` (via metkit's `DHSProtocol`) opens an ephemeral TCP

--- a/workers/polytope-fe-worker/Cargo.toml
+++ b/workers/polytope-fe-worker/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "polytope-fe-worker"
 version = "0.1.0"

--- a/workers/polytope-fe-worker/Dockerfile
+++ b/workers/polytope-fe-worker/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###############################
 # Shared base: Rust + cargo-chef + system deps (built once)
 ###############################

--- a/workers/polytope-fe-worker/polytope.py
+++ b/workers/polytope-fe-worker/polytope.py
@@ -1,22 +1,6 @@
+# SPDX-FileCopyrightText: 2022 European Centre for Medium-Range Weather Forecasts (ECMWF)
 #
-# Copyright 2022 European Centre for Medium-Range Weather Forecasts (ECMWF)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation nor
-# does it submit to any jurisdiction.
-#
+# SPDX-License-Identifier: Apache-2.0
 
 import copy
 import json

--- a/workers/polytope-fe-worker/run_polytope_worker.py
+++ b/workers/polytope-fe-worker/run_polytope_worker.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import sys
 import time

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use clap::Parser;
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};

--- a/workers/polytope-fe-worker/tests/__init__.py
+++ b/workers/polytope-fe-worker/tests/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Test package for polytope-fe-worker

--- a/workers/polytope-fe-worker/tests/test_metadata_options.py
+++ b/workers/polytope-fe-worker/tests/test_metadata_options.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test trusted metadata options merging in PolytopeDataSource.
 

--- a/workers/test-worker/Cargo.toml
+++ b/workers/test-worker/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "test-worker"
 version = "0.1.0"

--- a/workers/test-worker/Dockerfile
+++ b/workers/test-worker/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###############################
 # Shared base: Rust + cargo-chef + system deps
 ###############################

--- a/workers/test-worker/src/lib.rs
+++ b/workers/test-worker/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use polytope_worker_common::{ProcessResult, Processor, WorkItem};
 use serde::Deserialize;

--- a/workers/test-worker/src/main.rs
+++ b/workers/test-worker/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use clap::Parser;
 use polytope_worker_common::config::{DEFAULT_CONFIG_PATH, WorkerConfigFile};
 use polytope_worker_common::{WorkerConfig, run_worker_loop};


### PR DESCRIPTION
- Apache-2.0 `LICENSE` (ECMWF copyright + intergovernmental notice) + `NOTICE` + `LICENSES/`
- SPDX/REUSE headers on all files (passes `reuse lint`) + `REUSE.toml`
- `SECURITY.md`, `CITATION.cff`
- README: Incubating maturity badge + disclaimer, License section, fixed broken `../bits` link
- REUSE + rustfmt pre-commit config + REUSE CI check
- `ci.yaml`: least-privilege permissions
- `.gitignore` hardening