### PR TITLE
Fix loadgen clippy conditionals

### DIFF
--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -101,10 +101,10 @@ impl Config {
                 if duration_s <= 0.0 || !duration_s.is_finite() {
                     return Err("LOADGEN_DURATION_S must be a positive finite number".to_string());
                 }
-                if let Some(rps) = rps {
-                    if rps <= 0.0 || !rps.is_finite() {
-                        return Err("LOADGEN_RPS must be a positive finite number".to_string());
-                    }
+                if let Some(rps) = rps
+                    && (rps <= 0.0 || !rps.is_finite())
+                {
+                    return Err("LOADGEN_RPS must be a positive finite number".to_string());
                 }
                 RunLimit::Duration {
                     duration: Duration::from_secs_f64(duration_s),

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -702,10 +702,12 @@ mod tests {
                         format!(
                             "HTTP/1.1 303 See Other\r\nLocation: {location_base}/download-0/0123abcd\r\nContent-Length: 0\r\n\r\n"
                         )
-                    } else if method == "GET" && path == "/api/v1/read/api/v1/read/0123abcd" {
-                        tokio::time::sleep(download_delay).await;
-                        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_string()
-                    } else if method == "GET" && path == "/api/v1/read/0123abcd" {
+                    } else if method == "GET"
+                        && matches!(
+                            path,
+                            "/api/v1/read/api/v1/read/0123abcd" | "/api/v1/read/0123abcd"
+                        )
+                    {
                         tokio::time::sleep(download_delay).await;
                         "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_string()
                     } else {


### PR DESCRIPTION
## Changelog
- Collapse the nested optional RPS validation condition.
- Share the identical test-server response for both download routes.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy -p loadgen --all-targets --all-features -- -D warnings`
- `cargo test -p loadgen --all-targets --all-features`