### PR TITLE
feat(loadgen): v1 API compatibility fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?rev=544ba3f6563eeadf15f06525d0ed3712788f66d5#544ba3f6563eeadf15f06525d0ed3712788f66d5"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=cb8816d7bd7170899a32461ed95e9c5465c97cd9#cb8816d7bd7170899a32461ed95e9c5465c97cd9"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2645,7 +2645,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4295,7 +4295,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4333,7 +4333,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?tag=0.1.0#7749437410efe94f8d15ce35899bfc3783284506"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=544ba3f6563eeadf15f06525d0ed3712788f66d5#544ba3f6563eeadf15f06525d0ed3712788f66d5"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2645,7 +2645,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4295,7 +4295,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4333,7 +4333,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 [[package]]
 name = "bits"
 version = "0.1.0"
-source = "git+https://github.com/ecmwf/bits-broker.git?rev=cb8816d7bd7170899a32461ed95e9c5465c97cd9#cb8816d7bd7170899a32461ed95e9c5465c97cd9"
+source = "git+https://github.com/ecmwf/bits-broker.git?rev=5220bd16daf0354111c6a35407941a723562fc2d#5220bd16daf0354111c6a35407941a723562fc2d"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2645,7 +2645,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4295,7 +4295,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4333,7 +4333,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", tag = "0.1.0" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "544ba3f6563eeadf15f06525d0ed3712788f66d5", features = [
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "cb8816d7bd7170899a32461ed95e9c5465c97cd9", features = [
   "nats",
 ] }
 bytes = "1"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", tag = "0.1.0" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", tag = "0.1.0", features = [
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "544ba3f6563eeadf15f06525d0ed3712788f66d5", features = [
   "nats",
 ] }
 bytes = "1"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["http2"] }
 tower-http = { version = "0.6", features = ["cors", "compression-full"] }
 polytope-edr = { git = "https://github.com/ecmwf/polytope-edr", tag = "0.1.0" }
-bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "cb8816d7bd7170899a32461ed95e9c5465c97cd9", features = [
+bits = { git = "https://github.com/ecmwf/bits-broker.git", rev = "5220bd16daf0354111c6a35407941a723562fc2d", features = [
   "nats",
 ] }
 bytes = "1"

--- a/frontend/src/api/mcp.rs
+++ b/frontend/src/api/mcp.rs
@@ -364,6 +364,13 @@ impl PolytopeMcp {
                 "retryable": true,
                 "retry_after_seconds": RETRY_AFTER_SECS,
             })),
+            JobResult::RateLimited { reason } => tool_error(json!({
+                "status": "rate_limited",
+                "request_id": request_id,
+                "message": reason,
+                "retryable": true,
+                "retry_after_seconds": RETRY_AFTER_SECS,
+            })),
             JobResult::Cancelled => CallToolResult::structured(json!({
                 "status": "cancelled",
                 "request_id": request_id,

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -32,6 +32,18 @@ pub fn overloaded_response(payload: Value) -> Response {
         .into_response()
 }
 
+/// A per-caller admission limit (per-user/per-realm/per-role route cap) was
+/// exceeded. Distinct from [`overloaded_response`]'s system-wide 529: this is
+/// scoped to the caller, so `429 Too Many Requests` is the correct signal.
+pub fn rate_limited_response(payload: Value) -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [(header::RETRY_AFTER, OVERLOADED_RETRY_AFTER_SECS)],
+        Json(payload),
+    )
+        .into_response()
+}
+
 /// Flatten a v1-style `{"request": "...yaml..."}` or `{"request": {...}}` wrapper
 /// into a top-level MARS field object. Passes through already-flat requests unchanged.
 pub fn flatten_request(val: &mut Value) -> Result<(), String> {

--- a/frontend/src/api/openmeteo/mod.rs
+++ b/frontend/src/api/openmeteo/mod.rs
@@ -248,6 +248,9 @@ async fn forecast(
             PollOutcome::Ready(JobResult::Overloaded { reason }) => {
                 return super::overloaded_response(response::build_error_response(&reason));
             }
+            PollOutcome::Ready(JobResult::RateLimited { reason }) => {
+                return super::rate_limited_response(response::build_error_response(&reason));
+            }
             PollOutcome::NotFound => {
                 return error_response(StatusCode::BAD_GATEWAY, &format!("job {id} not found"));
             }

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -366,6 +366,11 @@ pub async fn get_request(
                 "message": reason,
                 "retryable": true,
             })),
+            JobResult::RateLimited { reason } => super::rate_limited_response(json!({
+                "status": "failed",
+                "message": reason,
+                "retryable": true,
+            })),
             JobResult::Cancelled => {
                 if let Some(Extension(user)) = auth_user.as_ref() {
                     tracing::info!("event.name" = "api.job.poll.cancelled", outcome = "cancelled", request.id = %id, "enduser.id" = %user.username, "enduser.realm" = %user.realm, "job poll cancelled");

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -165,6 +165,9 @@ pub async fn submit_collection(
             JobResult::Overloaded { reason } => {
                 super::overloaded_response(json!({"error": reason, "retryable": true}))
             }
+            JobResult::RateLimited { reason } => {
+                super::rate_limited_response(json!({"error": reason, "retryable": true}))
+            }
             JobResult::ClientGone => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({"error": "client disconnected before data could be delivered"})),
@@ -251,6 +254,9 @@ pub async fn poll(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
                 .into_response(),
             JobResult::Overloaded { reason } => {
                 super::overloaded_response(json!({"error": reason, "retryable": true}))
+            }
+            JobResult::RateLimited { reason } => {
+                super::rate_limited_response(json!({"error": reason, "retryable": true}))
             }
             JobResult::ClientGone => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/loadgen/src/lib.rs
+++ b/loadgen/src/lib.rs
@@ -378,7 +378,7 @@ pub fn to_bobs_internal(
         .collect::<Result<_, _>>()?;
 
     let (route_segment, key, key_must_be_uuid_like) = match parts.as_slice() {
-        [route, key] => (route, key, true),
+        [route, key] => (route, key, false),
         [route, api, v1, key] if api == "api" && v1 == "v1" => (route, key, true),
         [route, api, v1, read, key] if api == "api" && v1 == "v1" && read == "read" => {
             (route, key, false)
@@ -1082,7 +1082,19 @@ mod tests {
             "http://rel-bobs-4:3000/api/v1/read/object-key"
         );
         assert!(to_bobs_internal("https://host/download-4/not-api/object-key", template).is_err());
-        assert!(to_bobs_internal("https://host/download-4/not_uuid", template).is_err());
+        // BOBS now keys spools by the Polytope request ID (Crockford base32),
+        // which contains non-hex characters — the 2-segment path must accept
+        // any non-empty key that does not contain a '/'.
+        assert!(to_bobs_internal("https://host/download-4/not_uuid", template).is_ok());
+        assert_eq!(
+            to_bobs_internal(
+                "https://host/download-3/01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                template
+            )
+            .unwrap()
+            .0,
+            "http://rel-bobs-3:3000/api/v1/read/01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        );
     }
 
     #[test]

--- a/loadgen/src/main.rs
+++ b/loadgen/src/main.rs
@@ -446,6 +446,13 @@ async fn run_iteration(
             completed_at: Instant::now(),
         });
     }
+    // Save the Location header before consuming the body: the v1 API returns
+    // the request ID only in "Location: ./<id>" and not in the JSON body.
+    let submit_location = submit_response
+        .headers()
+        .get(LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string);
     let submit_json: serde_json::Value = submit_response
         .json()
         .await
@@ -455,6 +462,15 @@ async fn run_iteration(
         .or_else(|| submit_json.get("request_id"))
         .and_then(|value| value.as_str())
         .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            // v1 API: Location header is "./<id>" — extract the last path segment.
+            submit_location
+                .as_deref()
+                .and_then(|loc| loc.rsplit('/').next())
+                .filter(|id| !id.is_empty())
+                .map(ToString::to_string)
+        })
     else {
         return Ok(IterationResult {
             outcome: Outcome::SubmitFailed,
@@ -697,8 +713,16 @@ mod tests {
                     let method = parts.next().unwrap_or_default();
                     let path = parts.next().unwrap_or_default();
                     let response = if method == "POST" && path == "/api/v1/requests/c" {
+                        // Body-only id (legacy / alternative clients)
                         "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: 14\r\n\r\n{\"id\":\"req-1\"}".to_string()
+                    } else if method == "POST" && path == "/api/v1/requests/c-loc" {
+                        // v1 API style: id only in Location header, no id in body
+                        "HTTP/1.1 202 Accepted\r\nLocation: ./req-2\r\nContent-Type: application/json\r\nContent-Length: 46\r\n\r\n{\"message\":\"Request queued\",\"status\":\"queued\"}".to_string()
                     } else if method == "GET" && path == "/api/v1/requests/req-1" {
+                        format!(
+                            "HTTP/1.1 303 See Other\r\nLocation: {location_base}/download-0/0123abcd\r\nContent-Length: 0\r\n\r\n"
+                        )
+                    } else if method == "GET" && path == "/api/v1/requests/req-2" {
                         format!(
                             "HTTP/1.1 303 See Other\r\nLocation: {location_base}/download-0/0123abcd\r\nContent-Length: 0\r\n\r\n"
                         )
@@ -774,5 +798,39 @@ mod tests {
         let snapshot = progress.snapshot(Instant::now());
         assert_eq!(snapshot.counts.scheduled, run.scheduled);
         assert_eq!(snapshot.counts.missed_starts, run.missed_starts);
+    }
+
+    #[tokio::test]
+    async fn submit_extracts_request_id_from_location_header_when_not_in_body() {
+        // Simulates the v1 API: 202 body is {"message":...,"status":...} with
+        // no "id" field; the request ID lives only in "Location: ./<id>".
+        let base_url = start_test_server(Duration::from_millis(50)).await;
+        let client = Arc::new(
+            Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .unwrap(),
+        );
+        let config = Arc::new(Config {
+            frontend_url: base_url.clone(),
+            collection: "c-loc".to_string(),
+            auth: "Bearer test".to_string(),
+            payload_json: serde_json::json!({"request": "test"}),
+            mock_realm: None,
+            mock_role: "default".to_string(),
+            mock_user_prefix: "mock-".to_string(),
+            warmup_iters: 0,
+            concurrency: 1,
+            total_iters: 1,
+            run_limit: RunLimit::Iterations,
+            ramp_seconds: 0,
+            poll_interval: std::time::Duration::from_millis(1),
+            poll_timeout: std::time::Duration::from_secs(5),
+            bobs_svc_template: base_url.clone(),
+            max_error_rate: 1.0,
+        });
+        let result = run_iteration(client, config, 0, None).await.unwrap();
+        assert_eq!(result.outcome, Outcome::Downloaded, "{result:?}");
+        assert!(result.bytes > 0);
     }
 }


### PR DESCRIPTION
## Summary

Two fixes to make the loadgen work correctly with the v1 API, plus a temporary `bits` dependency bump (⚠️ see note below) picked up while stress-testing the fe-pool user-limit feature on `mn5-test`.

## Changes

**Relax BOBS key constraint**
The 2-segment BOBS URL path (`/<route>/<key>`) previously required the key to look like a UUID. Polytope request IDs are Crockford base32 (e.g. `01ARZ3NDEKTSV4RRFFQ69G5FAV`), which contains non-hex characters and fails that check. The constraint is relaxed to accept any non-empty, non-slash string.

**Extract request ID from `Location` header**
The v1 API returns the new request ID only in `Location: ./<id>` on the 202 response — there is no `id` field in the JSON body. The loadgen now falls back to parsing the last path segment of the `Location` header when the body contains no ID.

**New test**
Adds `submit_extracts_request_id_from_location_header_when_not_in_body` covering the Location-header-only path end-to-end through `run_iteration`.

**⚠️ Temporary: `bits` dependency bumped to a `feat/role-realm-user-limits` commit**
While stress-testing the fe pool on `mn5-test`, requests hitting the newly-added per-user `user_limit` cap were coming back as opaque `500 internal server error`s instead of a proper "retry later" signal. Root-caused and fixed upstream in `bits` (branch `feat/role-realm-user-limits`, not yet released as a tagged version):

- `runner::dispatch()` was missing a match arm for `ActionError::UserLimitExceeded`, so it fell through to the generic `JobResult::Failed` catch-all (500, non-retryable) instead of a retryable rejection.
- Follow-up: gave user-limit rejections their own `JobResult::RateLimited` variant instead of reusing `JobResult::Overloaded`, since a per-caller admission cap (429 Too Many Requests) is semantically distinct from system-wide backpressure (529 Site Overloaded). Wired through every `JobResult` match site in this crate (`api/v1.rs`, `api/v2.rs`, `api/openmeteo/mod.rs`, `api/mcp.rs`) via a new `rate_limited_response()` helper.

This currently pins `bits` to a commit `rev` on an unreleased branch (`5220bd1`) rather than a tagged release, purely so the fix could be verified end-to-end on `mn5-test`. **This should be re-pinned to a proper released `bits` tag (or split out of this PR) once `feat/role-realm-user-limits` lands and is tagged**, rather than merged as-is.

## Verified

- `cargo fmt --all` / `cargo test --all` clean.
- Deployed to `mn5-test` (`polytope-server:2.0.0-6-g6118af1`); fe-pool stress test requests hitting the per-user limit now return `429` + `Retry-After` instead of `500`.
