### PR TITLE
Derive request ID from URL, not the X-Request-Id header

### DIFF
--- a/docs/admin-mocking.md
+++ b/docs/admin-mocking.md
@@ -23,7 +23,7 @@ If both headers are present, they are parsed and authorized independently but un
 
 ## Shared audit model
 
-Accepted mock requests emit structured audit events. The audit data records the real authenticated identity, the mock value accepted by Polytope, the request path, and `request_id` from `X-Request-Id` when present.
+Accepted mock requests emit structured audit events. The audit data records the real authenticated identity, the mock value accepted by Polytope, the request path, and the `request_id` derived from the request URL when present.
 
 The accepted-request events are:
 

--- a/docs/error-responses.md
+++ b/docs/error-responses.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Error responses
 
-Every response that reaches a user carries a request ID, and every error body is
-a single, self-contained, human-readable message that says what happened, what to
-do, and where to raise a support ticket — quoting the request ID.
+Every error body is a single, self-contained, human-readable message that says
+what happened, what to do, and where to raise a support ticket — quoting the
+request ID when one is available.
 
 This is produced centrally by one outer middleware
 (`frontend/src/support.rs`), so no handler can forget it and the shape is
@@ -16,10 +16,14 @@ uniform across the whole API.
 
 ## The contract
 
-- **Success and error responses** carry an `X-Request-Id` header. It is reused
-  from an inbound `X-Request-Id` when the caller (or an ingress) supplied one,
-  otherwise minted in the BITS request-ID format. Treat it as an opaque string
-  (see [request-ids.md](./request-ids.md)).
+- **The request ID** identifies a request for support and log correlation. It
+  comes from the URL path for endpoints that act on an existing request (e.g.
+  `GET /api/v2/requests/{id}`), or is the ID that BITS generated when it accepted
+  a new job on a submit (also returned in the `Location` header). The frontend
+  never reads it from an inbound header and never mints one just to report it, so
+  requests with no associated ID (e.g. listing collections) have none. It is an
+  opaque string (see [request-ids.md](./request-ids.md)) and, when available, is
+  quoted inside the error `message` below.
 - **Error responses** (HTTP status `>= 400`) have a JSON body of exactly:
 
   ```json
@@ -34,10 +38,10 @@ uniform across the whole API.
   API surfaces with external error contracts keep their native body shape:
   `/edr/*` preserves OGC EDR error responses, and `/openmeteo/*` preserves the
   Open-Meteo `{"error": true, "reason": "..."}` shape when that API is enabled.
-  They still receive the `X-Request-Id` and security headers.
+  They still receive the security headers.
 
-Clients should display `message` verbatim. The request ID is inside the text and
-also in the `X-Request-Id` header.
+Clients should display `message` verbatim; the request ID, when available, is
+inside the text.
 
 ## Wording by error class
 

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -133,7 +133,7 @@ pub async fn submit_collection(
     super::audit_mock_job_submission(mock_audit.as_ref().map(|Extension(audit)| audit), &id);
     super::audit_mock_time_job_submission(mock_time_extensions.mock_time_audit.as_ref(), &id);
 
-    match state.bits.poll(&id, Some(POLL_TIMEOUT)).await {
+    let mut response = match state.bits.poll(&id, Some(POLL_TIMEOUT)).await {
         PollOutcome::Pending { id, .. } => {
             let status = local_pending_status(&state, &id);
             pending_redirect(&id, status)
@@ -204,7 +204,13 @@ pub async fn submit_collection(
                 (StatusCode::OK, Json(json!({"status": "cancelled"}))).into_response()
             }
         },
-    }
+    };
+    // Surface the BITS-generated request ID so the outer middleware can quote it
+    // in error responses (helps correlate with logs).
+    response
+        .extensions_mut()
+        .insert(crate::support::RequestId(id));
+    response
 }
 
 pub async fn public_poll(

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -501,6 +501,68 @@ targets:
     }
 
     #[tokio::test]
+    async fn post_that_fails_after_id_assignment_reports_the_id() {
+        // A POST that BITS accepts (so an ID is assigned) but that then fails
+        // downstream must surface that ID to the user, even though the client
+        // sent no `X-Request-Id`. This exercises the real `submit_collection`
+        // handler behind the support middleware end to end.
+        let (bits, handle) = make_bits_with_route("ecmwf");
+        let mut collections = HashMap::new();
+        collections.insert("ecmwf".to_string(), handle);
+        let state = Arc::new(AppState {
+            bits,
+            auth_client: None,
+            collections,
+            allow_anonymous: false,
+            admin_bypass_roles: None,
+            support: Default::default(),
+            completed_redirects: std::sync::Mutex::new(std::collections::HashMap::new()),
+            completed_redirect_ttl: std::time::Duration::from_secs(600),
+        });
+        let app = Router::new()
+            .route(
+                "/api/v2/{collection}/requests",
+                post(super::submit_collection),
+            )
+            .with_state(state.clone())
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                crate::support::request_context_middleware,
+            ));
+
+        let resp = app
+            .oneshot(
+                Request::post("/api/v2/ecmwf/requests")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // BITS accepted the job and assigned an ID; the request then failed.
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        // The assigned ID survives the error rewrite on the response extension...
+        let id = resp
+            .extensions()
+            .get::<crate::support::RequestId>()
+            .expect("assigned request ID present on the response")
+            .0
+            .clone();
+        assert!(!id.is_empty());
+
+        // ...and is quoted back to the user in the rewritten error message.
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        let msg = json["message"].as_str().expect("error body has a message");
+        assert!(
+            msg.contains(&format!("quote your request ID {id}")),
+            "error message should quote the assigned ID; got: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn submit_known_collection_routes_to_handle() {
         let (bits, handle) = make_bits_with_route("ecmwf");
         let mut collections = HashMap::new();

--- a/frontend/src/auth/middleware.rs
+++ b/frontend/src/auth/middleware.rs
@@ -18,8 +18,8 @@ use axum::{
 use serde_json::json;
 
 use super::mock_roles::{
-    MockRolesAudit, REQUEST_ID_HEADER, has_mock_roles_header, has_mock_user_header,
-    parse_mock_roles_header, parse_mock_user_header,
+    MockRolesAudit, has_mock_roles_header, has_mock_user_header, parse_mock_roles_header,
+    parse_mock_user_header,
 };
 use super::mock_time::{
     MOCK_TIME_HEADER, MockTimeAudit, has_mock_time_header, normalise_mocked_now,
@@ -212,10 +212,9 @@ pub async fn auth_middleware(
 
             let mut req = req;
             let request_id = req
-                .headers()
-                .get(REQUEST_ID_HEADER)
-                .and_then(|value| value.to_str().ok())
-                .map(str::to_string);
+                .extensions()
+                .get::<crate::support::RequestId>()
+                .map(|rid| rid.0.clone());
             let path = req.uri().path().to_string();
 
             if let Some(mock_time) = mock_time {
@@ -1038,7 +1037,7 @@ mod tests {
                 Request::get("/check")
                     .header("Authorization", "Bearer token")
                     .header("Polytope-Mock-Roles", "beta:viewer,data")
-                    .header("X-Request-Id", "request-123")
+                    .extension(crate::support::RequestId("request-123".to_string()))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1131,7 +1130,7 @@ mod tests {
                 Request::get("/check")
                     .header("Authorization", "Bearer token")
                     .header("Polytope-Mock-Time", "2040-05-06T08:08:09+01:00")
-                    .header("X-Request-Id", "request-456")
+                    .extension(crate::support::RequestId("request-456".to_string()))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1370,7 +1369,7 @@ mod tests {
                     .header("Authorization", "Bearer token")
                     .header("Polytope-Mock-Roles", "beta:viewer,data")
                     .header("Polytope-Mock-Time", "2040-05-06T08:08:09+01:00")
-                    .header("X-Request-Id", "request-789")
+                    .extension(crate::support::RequestId("request-789".to_string()))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/frontend/src/auth/mock_roles.rs
+++ b/frontend/src/auth/mock_roles.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use axum::http::{HeaderMap, HeaderName};
 
 pub const MOCK_ROLES_HEADER: &str = "polytope-mock-roles";
-pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MockRoles {

--- a/frontend/src/support.rs
+++ b/frontend/src/support.rs
@@ -4,8 +4,10 @@
 
 //! User-facing error enrichment.
 //!
-//! A single outer middleware gives every request a request ID (minted in the
-//! BITS ID format, or reused from an inbound `X-Request-Id`) and rewrites any
+//! A single outer middleware derives the request ID from the URL path (for the
+//! endpoints that act on an existing request) or from the ID that BITS generated
+//! when it accepted a new job (surfaced by the handler via a response
+//! extension), and rewrites any
 //! `>= 400` JSON response body into one self-contained, human-readable
 //! `{"message": ...}` field that tells the user what to do and where to raise a
 //! support ticket, quoting their request ID.
@@ -22,10 +24,8 @@ use axum::extract::{Request, State};
 use axum::http::{HeaderName, HeaderValue, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::Response;
-use chrono::Utc;
 use serde_json::json;
 
-use crate::auth::mock_roles::REQUEST_ID_HEADER;
 use crate::state::AppState;
 
 /// Cap on the error body we will buffer to rewrite. Error bodies are tiny JSON;
@@ -170,53 +170,55 @@ async fn transform_error(resp: Response, state: &AppState, request_id: &str) -> 
     Response::from_parts(parts, Body::from(new_body))
 }
 
-/// Outer middleware: assign a request ID, expose it on every response as
-/// `X-Request-Id`, and rewrite error bodies into the support-guidance shape.
+/// Extract the Polytope request ID from the URL path, for the endpoints that act
+/// on an existing request. The ID is an opaque path segment; we do not parse or
+/// validate its internal structure (see docs/request-ids.md).
+fn request_id_from_path(path: &str) -> Option<String> {
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    let id = match segments.as_slice() {
+        ["api", "v1" | "v2", "requests", id] => id,
+        ["api", "v1", "downloads" | "uploads", id] => id,
+        _ => return None,
+    };
+    let id = id.trim();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+/// Outer middleware: resolve the request ID (URL-derived, or BITS-generated and
+/// surfaced by the handler) and rewrite error bodies into the support-guidance
+/// shape, quoting the ID when one is available.
 pub async fn request_context_middleware(
     State(state): State<Arc<AppState>>,
     mut req: Request,
     next: Next,
 ) -> Response {
-    let request_id = req
-        .headers()
-        .get(REQUEST_ID_HEADER)
-        .and_then(|v| v.to_str().ok())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            bits::request_id::encode(
-                state.bits.site(),
-                state.bits.env(),
-                state.bits.broker_slot(),
-                Utc::now(),
-            )
-            .unwrap_or_default()
-        });
+    // The request ID is derived from the URL path for the endpoints that act on
+    // an existing request. We never read it from an inbound header and never
+    // mint one here: the frontend only creates a request ID when BITS accepts a
+    // new job, and the handler surfaces that ID back through a response
+    // extension.
+    let url_request_id = request_id_from_path(req.uri().path());
 
-    if !request_id.is_empty() {
-        if let Ok(hv) = HeaderValue::from_str(&request_id) {
-            req.headers_mut()
-                .insert(HeaderName::from_static(REQUEST_ID_HEADER), hv);
-        }
-        req.extensions_mut().insert(RequestId(request_id.clone()));
+    // Expose the URL-derived ID to inner layers (e.g. auth audit logging).
+    if let Some(id) = &url_request_id {
+        req.extensions_mut().insert(RequestId(id.clone()));
     }
 
     let preserve_native_error_shape = preserves_native_error_shape(req.uri().path());
     let resp = next.run(req).await;
+
+    // Prefer the URL-derived ID; otherwise fall back to an ID that a handler
+    // (e.g. a submit that BITS accepted) surfaced via a response extension. When
+    // neither exists there is simply no ID to report.
+    let request_id = url_request_id
+        .or_else(|| resp.extensions().get::<RequestId>().map(|r| r.0.clone()))
+        .unwrap_or_default();
 
     let mut resp = if resp.status().as_u16() >= 400 && !preserve_native_error_shape {
         transform_error(resp, &state, &request_id).await
     } else {
         resp
     };
-
-    if !request_id.is_empty()
-        && let Ok(hv) = HeaderValue::from_str(&request_id)
-    {
-        resp.headers_mut()
-            .insert(HeaderName::from_static(REQUEST_ID_HEADER), hv);
-    }
 
     // Security / caching headers on every response, matching the legacy Python
     // frontend's `after_request` hook so downstream expectations are preserved.

--- a/frontend/tests/support_errors.rs
+++ b/frontend/tests/support_errors.rs
@@ -16,7 +16,7 @@ use polytope_server::build_app;
 use polytope_server::config::{ServerConfig, SupportConfig};
 use tower::ServiceExt;
 
-fn app() -> axum::Router {
+fn config() -> ServerConfig {
     let yaml = r#"
 polytope:
   site: bol
@@ -30,8 +30,11 @@ support:
   realms:
     desp: "https://platform.destine.eu/contact/"
 "#;
-    let cfg: ServerConfig = serde_yaml::from_str(yaml).expect("config parses");
-    build_app(cfg).expect("app builds").0
+    serde_yaml::from_str(yaml).expect("config parses")
+}
+
+fn app() -> axum::Router {
+    build_app(config()).expect("app builds").0
 }
 
 // A plausible opaque request ID (26-char Crockford base32; see docs/request-ids.md).
@@ -84,6 +87,45 @@ async fn error_on_a_request_path_quotes_the_url_derived_request_id() {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let msg = v["message"].as_str().unwrap();
+    assert!(msg.contains(&format!("quote your request ID {RID}")));
+}
+
+#[tokio::test]
+async fn error_quotes_the_bits_generated_id_surfaced_by_the_handler() {
+    // A client that sends no `X-Request-Id` (e.g. the Python polytope-client)
+    // submitting a request that BITS accepts but then fails: the handler surfaces
+    // the BITS-generated ID via a response extension exactly like
+    // `submit_collection`, and the middleware must quote that ID in the error.
+    async fn boom() -> axum::response::Response {
+        use axum::response::IntoResponse;
+        let mut resp = (
+            StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({ "error": "boom" })),
+        )
+            .into_response();
+        resp.extensions_mut()
+            .insert(polytope_server::support::RequestId(RID.to_string()));
+        resp
+    }
+
+    let (_full_app, state) = build_app(config()).expect("app builds");
+    let router = axum::Router::new()
+        .route("/boom", axum::routing::get(boom))
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            polytope_server::support::request_context_middleware,
+        ));
+
+    // No X-Request-Id header from the client.
+    let resp = router
+        .oneshot(Request::get("/boom").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let msg = v["message"].as_str().unwrap();

--- a/frontend/tests/support_errors.rs
+++ b/frontend/tests/support_errors.rs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end checks that user-facing errors carry support guidance + a request
-//! ID, and that the error body stays a flat string→string object (so the Python
-//! `polytope-client`, which flattens every value and crashes on non-strings,
-//! renders it cleanly).
+//! End-to-end checks that user-facing errors carry support guidance (and a
+//! request ID when one is available), and that the error body stays a flat
+//! string→string object (so the Python `polytope-client`, which flattens every
+//! value and crashes on non-strings, renders it cleanly).
 
 use std::collections::HashMap;
 
@@ -34,8 +34,13 @@ support:
     build_app(cfg).expect("app builds").0
 }
 
+// A plausible opaque request ID (26-char Crockford base32; see docs/request-ids.md).
+const RID: &str = "3k7p9q2r5s8t1v4w6x0y2z5a8b";
+
 #[tokio::test]
-async fn unauthenticated_error_is_rewritten_with_default_url_and_request_id() {
+async fn error_without_a_request_id_omits_the_id() {
+    // `/api/v2/collections` has no request ID in the URL and is not a submit, so
+    // there is no ID to report: the message must not quote one.
     let resp = app()
         .oneshot(
             Request::get("/api/v2/collections")
@@ -46,15 +51,6 @@ async fn unauthenticated_error_is_rewritten_with_default_url_and_request_id() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-
-    let rid = resp
-        .headers()
-        .get("x-request-id")
-        .expect("X-Request-Id header present on error")
-        .to_str()
-        .unwrap()
-        .to_string();
-    assert!(!rid.is_empty());
 
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -70,21 +66,34 @@ async fn unauthenticated_error_is_rewritten_with_default_url_and_request_id() {
     let msg = obj["message"].as_str().unwrap();
     assert!(msg.starts_with("Your request was not authorised"));
     assert!(msg.contains("https://support.ecmwf.int/")); // deployment default (no realm pre-auth)
-    assert!(msg.contains(&rid)); // request ID quoted back to the user
+    assert!(!msg.contains("request ID"), "no ID to quote");
 }
 
 #[tokio::test]
-async fn successful_response_still_carries_request_id_header() {
+async fn error_on_a_request_path_quotes_the_url_derived_request_id() {
+    // The ID lives in the URL path; even an unauthenticated 401 (rejected before
+    // the handler) must quote it in the message.
     let resp = app()
-        .oneshot(Request::get("/api/v2/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::get(format!("/api/v2/requests/{RID}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    assert!(resp.headers().get("x-request-id").is_some());
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let msg = v["message"].as_str().unwrap();
+    assert!(msg.contains(&format!("quote your request ID {RID}")));
 }
 
 #[tokio::test]
-async fn inbound_request_id_is_preserved() {
+async fn inbound_request_id_header_is_ignored() {
+    // No real client supplies this header; a caller-supplied value must never be
+    // trusted or surfaced back to the user.
     let resp = app()
         .oneshot(
             Request::get("/api/v2/collections")
@@ -94,17 +103,10 @@ async fn inbound_request_id_is_preserved() {
         )
         .await
         .unwrap();
-    let rid = resp
-        .headers()
-        .get("x-request-id")
-        .unwrap()
-        .to_str()
-        .unwrap();
-    assert_eq!(rid, "caller-supplied-id");
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(
-        v["message"]
+        !v["message"]
             .as_str()
             .unwrap()
             .contains("caller-supplied-id")


### PR DESCRIPTION
## Problem

The outer support middleware (`frontend/src/support.rs`) obtained the request ID it quotes in user-facing error messages from an inbound **`X-Request-Id` header**, falling back to **minting a brand-new BITS ID** when the header was absent. Both behaviours are wrong:

- **No Polytope client sends `X-Request-Id`.** In our deployments **nginx inserts an `X-Request-Id` header when the client does not provide one**, so the middleware was reading (and quoting back to the user) an nginx-generated correlation ID that has nothing to do with the actual Polytope request ID. Support/log correlation on that value is useless.
- **Minting a throwaway ID** purely so the error text had something to quote produced IDs that map to no real request.

The real request ID is already available: it's in the **URL path** for endpoints that act on an existing request (`/api/v{1,2}/requests/{id}`), or it's the ID **BITS generates** when it accepts a new job on a submit.

## Changes

- **`support.rs`**: resolve the request ID from the URL path (pre-handler), else from a `RequestId` **response extension** surfaced by the v2 submit handler (so failed submits still quote the BITS-generated ID for log correlation). Removed the header read and the BITS-minting fallback.
- **Removed the `X-Request-Id` response header entirely.** Nothing consumed it (verified across clients, config, and sibling services) and it was redundant with the URL / `Location` header. The ID is still quoted inside the error `message` body when available.
- **Auth audit logging** (`auth/middleware.rs`) now uses the URL-derived ID (via the request extension) instead of the header.
- Deleted the now-unused `REQUEST_ID_HEADER` constant.
- Updated docs (`error-responses.md`, `admin-mocking.md`) and rewrote the affected tests.

## Behaviour after this change

The request ID is derived from the URL (or the BITS-generated ID on a v2 submit), quoted in the error message when available, used for audit logging, and **never read from or written to an HTTP header**.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p polytope-server --all-targets -- -D warnings` ✅
- `cargo test -p polytope-server` ✅ (225 lib tests + integration suites)