### PR TITLE
feat(download): set Content-Disposition with a request-id filename

### DIFF
--- a/frontend/src/api/download.rs
+++ b/frontend/src/api/download.rs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for shaping data-download responses.
+//!
+//! `Content-Disposition` gives clients (browsers, `curl -OJ`, ...) a filename
+//! for the download. The base name is the polytope request id (for
+//! traceability) and the extension is derived from the worker-declared content
+//! type. This logic is mirrored in the two other sinks that also serve
+//! downloads:
+//!   - `bobs` (`src/http/mod.rs::{sanitise_filename_stem, download_extension}`)
+//!     for the object-store redirect path, and
+//!   - the S3 delivery sink (`workers/common/src/delivery/s3.rs`).
+//! Keep the three in sync when adding new media types.
+
+/// Map a content type to a download file extension (without the dot).
+///
+/// Content-type strings may carry parameters (e.g. `application/json;
+/// charset=utf-8`); only the base type is considered.
+pub fn extension_for(content_type: &str) -> &'static str {
+    let base = content_type.split(';').next().unwrap_or_default().trim();
+    match base {
+        "application/x-grib" => "grib",
+        "application/prs.coverage+json" => "covjson",
+        _ => "bin",
+    }
+}
+
+/// Restrict the filename stem to a safe, header-injection-proof character set.
+/// Falls back to `data` if nothing usable remains.
+fn sanitise_stem(id: &str) -> String {
+    let stem: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    if stem.is_empty() {
+        "data".to_string()
+    } else {
+        stem
+    }
+}
+
+/// Build a `Content-Disposition` header value that forces a download named
+/// `<request-id>.<ext>`.
+pub fn content_disposition_for(id: &str, content_type: &str) -> String {
+    format!(
+        "attachment; filename=\"{}.{}\"",
+        sanitise_stem(id),
+        extension_for(content_type)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_known_content_types() {
+        assert_eq!(extension_for("application/x-grib"), "grib");
+        assert_eq!(extension_for("application/prs.coverage+json"), "covjson");
+        assert_eq!(extension_for("application/octet-stream"), "bin");
+        assert_eq!(extension_for("something/unknown"), "bin");
+        // content-type parameters are ignored; only the base type matters
+        assert_eq!(
+            extension_for("application/prs.coverage+json; charset=utf-8"),
+            "covjson"
+        );
+    }
+
+    #[test]
+    fn builds_content_disposition_from_id_and_type() {
+        assert_eq!(
+            content_disposition_for("abc-123", "application/x-grib"),
+            "attachment; filename=\"abc-123.grib\""
+        );
+    }
+
+    #[test]
+    fn sanitises_unsafe_ids() {
+        // quotes / path separators / control chars are stripped
+        assert_eq!(
+            content_disposition_for("a\"b/c", "application/x-grib"),
+            "attachment; filename=\"abc.grib\""
+        );
+        // an id with nothing usable falls back to `data`
+        assert_eq!(
+            content_disposition_for("///", "application/x-grib"),
+            "attachment; filename=\"data.grib\""
+        );
+    }
+}

--- a/frontend/src/api/mod.rs
+++ b/frontend/src/api/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod download;
 pub mod mcp;
 pub mod openmeteo;
 pub mod v1;

--- a/frontend/src/api/v1.rs
+++ b/frontend/src/api/v1.rs
@@ -376,7 +376,11 @@ pub async fn get_request(
                 if size >= 0 {
                     Response::builder()
                         .status(StatusCode::OK)
-                        .header(header::CONTENT_TYPE, content_type)
+                        .header(header::CONTENT_TYPE, content_type.clone())
+                        .header(
+                            header::CONTENT_DISPOSITION,
+                            super::download::content_disposition_for(&id, &content_type),
+                        )
                         .header(header::CONTENT_LENGTH, size)
                         .body(Body::from_stream(stream))
                         .unwrap()
@@ -389,7 +393,11 @@ pub async fn get_request(
                     let body = buf.freeze();
                     Response::builder()
                         .status(StatusCode::OK)
-                        .header(header::CONTENT_TYPE, content_type)
+                        .header(header::CONTENT_TYPE, content_type.clone())
+                        .header(
+                            header::CONTENT_DISPOSITION,
+                            super::download::content_disposition_for(&id, &content_type),
+                        )
                         .header(header::CONTENT_LENGTH, body.len())
                         .body(Body::from(body))
                         .unwrap()

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -152,9 +152,11 @@ pub async fn submit_collection(
                 size,
                 stream,
             } => {
+                let disposition = super::download::content_disposition_for(&id, &content_type);
                 let mut builder = Response::builder()
                     .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, content_type);
+                    .header(header::CONTENT_TYPE, content_type)
+                    .header(header::CONTENT_DISPOSITION, disposition);
                 if size >= 0 {
                     builder = builder.header(header::CONTENT_LENGTH, size);
                 }
@@ -247,9 +249,11 @@ pub async fn poll(State(state): State<Arc<AppState>>, Path(id): Path<String>) ->
                 size,
                 stream,
             } => {
+                let disposition = super::download::content_disposition_for(&id, &content_type);
                 let mut builder = Response::builder()
                     .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, content_type);
+                    .header(header::CONTENT_TYPE, content_type)
+                    .header(header::CONTENT_DISPOSITION, disposition);
                 if size >= 0 {
                     builder = builder.header(header::CONTENT_LENGTH, size);
                 }

--- a/workers/common/src/delivery/s3.rs
+++ b/workers/common/src/delivery/s3.rs
@@ -15,6 +15,40 @@ use crate::Completion;
 
 const S3_PART_SIZE_BYTES: usize = 5 * 1024 * 1024;
 
+/// Map a content type to a download file extension (without the dot). Mirrored
+/// in the frontend (`frontend/src/api/download.rs`) and in `bobs`
+/// (`src/http/mod.rs`); keep the three in sync.
+fn extension_for(content_type: &str) -> &'static str {
+    let base = content_type.split(';').next().unwrap_or_default().trim();
+    match base {
+        "application/x-grib" => "grib",
+        "application/prs.coverage+json" => "covjson",
+        _ => "bin",
+    }
+}
+
+/// Restrict the filename stem to a safe character set, falling back to `data`.
+fn sanitise_stem(id: &str) -> String {
+    let stem: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    if stem.is_empty() {
+        "data".to_string()
+    } else {
+        stem
+    }
+}
+
+/// `attachment; filename="<request-id>.<ext>"`.
+fn content_disposition_for(id: &str, content_type: &str) -> String {
+    format!(
+        "attachment; filename=\"{}.{}\"",
+        sanitise_stem(id),
+        extension_for(content_type)
+    )
+}
+
 pub(super) struct S3Push {
     pub(super) bucket: String,
     pub(super) key_prefix: String,
@@ -38,6 +72,7 @@ impl ResultDelivery for S3Push {
                 content_type,
                 content_encoding,
                 body,
+                context.job_id,
                 context.source_error.clone(),
             )
             .await
@@ -69,6 +104,7 @@ impl S3Push {
         content_type: &str,
         content_encoding: Option<&str>,
         body: reqwest::Body,
+        job_id: &str,
         source_error: Option<crate::SourceError>,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let s3_key = self.next_key();
@@ -78,7 +114,8 @@ impl S3Push {
             .create_multipart_upload()
             .bucket(&self.bucket)
             .key(&s3_key)
-            .content_type(content_type);
+            .content_type(content_type)
+            .content_disposition(content_disposition_for(job_id, content_type));
         if let Some(encoding) = content_encoding {
             create_req = create_req.content_encoding(encoding);
         }
@@ -274,6 +311,22 @@ impl S3Push {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn download_filename_maps_known_content_types() {
+        assert_eq!(extension_for("application/x-grib"), "grib");
+        assert_eq!(extension_for("application/prs.coverage+json"), "covjson");
+        assert_eq!(extension_for("application/octet-stream"), "bin");
+        assert_eq!(
+            content_disposition_for("req-42", "application/x-grib"),
+            "attachment; filename=\"req-42.grib\""
+        );
+        // unsafe ids are sanitised
+        assert_eq!(
+            content_disposition_for("a\"b/c", "application/prs.coverage+json"),
+            "attachment; filename=\"abc.covjson\""
+        );
+    }
 
     #[tokio::test]
     async fn s3_push_returns_error_when_unreachable() {


### PR DESCRIPTION
## What

Data downloads now carry `Content-Disposition: attachment; filename="<request-id>.<ext>"`.

Previously:
- the direct-stream path (`v1` + `v2` `JobResult::Success`) sent `Content-Type`
  but **no** `Content-Disposition`;
- the S3 delivery sink stored no disposition on the object.

Now both set it. The extension is derived from the worker-declared content type
(`application/x-grib → grib`, `application/prs.coverage+json → covjson`, else
`bin`); the request-id stem is sanitised to `[A-Za-z0-9-_]` (fallback `data`) to
prevent header injection.

- Frontend uses the request `id`; helper in `frontend/src/api/download.rs`.
- S3 uses `context.job_id` (the storage key is a random UUID) and bakes the
  disposition into the object at `create_multipart_upload`, so both presigned
  and public-URL GETs return it.

## Why

Fixes "missing Content-Disposition header in download request". Feature
extractions (`prs.coverage+json`) and MARS/FDB field requests (`x-grib`) now
download with correctly-named files. Mapping mirrors the bobs read handler
(companion PR in `bobs`); keep the three sinks in sync when adding media types.

## Tests

`cargo fmt --all` + `cargo test --all` (0 failures), incl. new unit tests for
the extension map, disposition builder, and id sanitisation.