### PR TITLE
fix(mars-worker): classify connection-reset and 0-messages-retrieved as recoverable

### DIFF
--- a/workers/mars-worker/Cargo.lock
+++ b/workers/mars-worker/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "mars-worker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/workers/mars-worker/Cargo.toml
+++ b/workers/mars-worker/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "mars-worker"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/workers/mars-worker/src/main.rs
+++ b/workers/mars-worker/src/main.rs
@@ -50,8 +50,15 @@ impl ClassifiedMarsError {
 }
 
 fn classify_mars_error(raw: &str) -> ClassifiedMarsError {
+    // Note: Most of these are based on potentially out of date confluence pages. 
+    // Empirically observed errors are marked with a comment
     let lower = raw.to_lowercase();
-    if lower.contains("data not yet available") || lower.contains("scheduled for after") {
+    // observed, may be worth retrying in code before returning to the user
+    if lower.contains("connection reset by peer") || lower.contains("socket read failed") { 
+        ClassifiedMarsError::recoverable(format!(
+            "The data retrieval connection was interrupted. Please try again."
+        ))
+    } else if lower.contains("data not yet available") || lower.contains("scheduled for after") {
         let message = if let Some(release_time) = extract_release_time(raw) {
             format!("Data not released yet. Release time is {release_time}.")
         } else {
@@ -69,6 +76,7 @@ fn classify_mars_error(raw: &str) -> ClassifiedMarsError {
     } else if lower.contains("mars_expected_fields")
         || lower.contains("data not found")
         || lower.contains("no data found")
+        || lower.contains("0 message retrieved out of") //observed
     {
         ClassifiedMarsError::recoverable(format!(
             "Some of the requested data is not available. Details: {raw}"
@@ -277,6 +285,12 @@ mod tests {
             "Data not found",
             "syntax error near param",
             "invalid value for date",
+            // Empirically observed in production: TCP teardown mid-transfer.
+            "[ERROR] Socket read failed (TCPClient[port=0]) (Connection reset by peer)",
+            "Connection reset by peer",
+            // Empirically observed in production: same family as mars_expected_fields.
+            "[ERROR] Exception: UserError: 0 message retrieved out of 48 expected",
+            "UserError: 0 message retrieved out of 1 expected",
         ] {
             assert_eq!(
                 classify_mars_error(raw).disposition,


### PR DESCRIPTION
## Problem

Two error patterns observed in production logs were falling through to the unknown-error catch-all, which classifies errors as `RestartWorker`. This caused unnecessary pod restarts for what are request-level failures.

**Pattern 1 — TCP teardown mid-transfer:**
```
[ERROR] Socket read failed (TCPClient[...]) (Connection reset by peer)
[ERROR] Exception: UserError: 0 message retrieved out of 48 expected
```
An intermittent connection issue. The user should retry; the worker should survive.

**Pattern 2 — data simply not in archive:**
```
[ERROR] Exception: UserError: 0 message retrieved out of 49 expected
```
Semantically identical to `MARS_EXPECTED_FIELDS` / `Data not found` — the requested fields don't exist in the archive.

## Changes

- `connection reset by peer` / `socket read failed` → `Recoverable` (moved to top of chain; potential future candidate for automatic worker-side retry)
- `0 message retrieved out of` → `Recoverable`, same bucket as `mars_expected_fields`
- Added a comment that most of the existing pattern list is based on potentially out-of-date Confluence docs; empirically observed patterns are now marked
- Test cases added for both patterns using the verbatim log strings from production

## Verification

Deployed to lumi-test (`2.2.0.dev0-7-g0c91d0a`) and ran an extremes-dt request for a date with no data in the archive. Result:
- User receives: `400 Some of the requested data is not available. Details: mars-client error: UserError: 0 message retrieved out of 16 expected.`
- All mars/mars-heavy pods: **0 restarts** after the request completed