### PR TITLE
feat(polytope-fe-worker): migrate C++ stack to PyPI bundled wheels

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,9 +7,11 @@
 # Required for private GitHub dependencies:
 #   GH_TOKEN                    GitHub token with repository read access
 #
-# C++ library stacks (metkit, fdb, fdb-gribjump, mars) are NOT built here: the
-# app Dockerfiles pull pre-built library images from ECCR (pinned via their
-# *_LIBS_IMAGE build args). See docker/cpp-libs/ and the cpp-libs workflow.
+# C++ library stacks (metkit, fdb, fdb-gribjump, mars) are NOT built here.
+# fdb-worker and mars-worker pull pre-built library images from ECCR (pinned
+# via their *_LIBS_IMAGE build args; see docker/cpp-libs/ and cpp-libs.yaml).
+# polytope-fe-worker uses PyPI manylinux wheels (pyfdb, pygribjump[binary])
+# that bundle their own C++ stack — no separate ECCR image required.
 # ──────────────────────────────────────────────────────────────────────────────
 
 apiVersion: skaffold/v4beta13

--- a/workers/polytope-fe-worker/Dockerfile
+++ b/workers/polytope-fe-worker/Dockerfile
@@ -2,26 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Pre-built C++ FDB + gribjump stack (eckit, libaec, eccodes, metkit, fdb,
-# gribjump) pulled from ECCR.
-# Built and published from docker/cpp-libs/fdb-gribjump by the cpp-libs workflow.
-# The stripped image feeds `release`; the -debug (full-symbol) image feeds `debug`.
-ARG GJ_LIBS_IMAGE=eccr.ecmwf.int/polytope/cpp-fdb-gribjump-libs:fdb5.21.3-gribjump0.12.0-r1
-ARG GJ_LIBS_DEBUG_IMAGE=eccr.ecmwf.int/polytope/cpp-fdb-gribjump-libs-debug:fdb5.21.3-gribjump0.12.0-r1
+# pyfdb and pygribjump[binary] bundle their own C++ stack (fdb5lib, gribjumplib,
+# eccodeslib, metkitlib, eckitlib) via PyPI manylinux wheels — no separate
+# pre-built ECCR image required.
 
 ###############################
 # Shared base: Rust + cargo-chef + system deps (built once)
 ###############################
 FROM docker.io/lukemathwalker/cargo-chef:0.1.77-rust-1.94.1-slim-bookworm@sha256:4787c365155bfff657a58c89e6ce05b99e60d343ee57fd4a0fdcbb2547a8e017 AS chef-base
 RUN apt-get update && apt-get install -y git pkg-config build-essential libssl-dev python3-dev && rm -rf /var/lib/apt/lists/*
-
-###############################
-# FDB + gribjump libraries (pre-built image, /opt/fdb)
-###############################
-FROM ${GJ_LIBS_IMAGE} AS gj-build
-
-# Full-symbol variant, used only by the `debug` target.
-FROM ${GJ_LIBS_DEBUG_IMAGE} AS gj-build-debug
 
 ###############################
 # Prepare the root workspace Cargo Chef recipe
@@ -75,71 +64,70 @@ RUN --mount=type=secret,id=GIT_AUTH_TOKEN,required=true \
     && cargo build --release --locked --package "${PACKAGE_NAME}"
 
 ###############################
-# Python Requirements
+# Python venv
 ###############################
 FROM python:3.11-slim-bookworm AS python-deps
-RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && rm -rf /var/lib/apt/lists/*
 RUN python -m pip install --no-cache-dir uv
 RUN uv venv /opt/venv
 COPY workers/polytope-fe-worker/requirements.txt /requirements.txt
 RUN uv pip install --python /opt/venv/bin/python -r /requirements.txt
 
 ###############################
-# Stage 4: Production Release Image
+# Production image
 ###############################
 FROM python:3.11-slim-bookworm AS release
 ARG VERSION
 ARG REVISION
-ARG GJ_LIBS_IMAGE
 ARG PACKAGE_NAME=polytope-fe-worker
 ARG BIN_NAME=polytope-fe-worker
 LABEL org.opencontainers.image.version="$VERSION" \
       org.opencontainers.image.revision="$REVISION" \
-      org.opencontainers.image.source="https://github.com/ecmwf/polytope-server" \
-      int.ecmwf.polytope.libs-image="$GJ_LIBS_IMAGE"
+      org.opencontainers.image.source="https://github.com/ecmwf/polytope-server"
 
-RUN apt-get update && apt-get install -y ca-certificates libgomp1 libaec0 libcurl4 libopenjp2-7 && rm -rf /var/lib/apt/lists/*
+# Runtime system libs needed by the bundled C++ stack in fdb5lib/gribjumplib
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libgomp1 libaec0 libcurl4 libopenjp2-7 \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-COPY --from=gj-build /opt/fdb/ /opt/fdb/
 COPY --from=python-deps /opt/venv /opt/venv
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
-ENV PYTHONPATH=/opt/venv/lib/python3.11/site-packages
-ENV LD_LIBRARY_PATH=/opt/fdb/lib:/usr/local/lib
+ENV PYTHONPATH=/app:/opt/venv/lib/python3.11/site-packages
 
 COPY --from=builder /ecmwf/polytope-server/target/release/${BIN_NAME} /app/polytope-fe-worker
 COPY workers/polytope-fe-worker/run_polytope_worker.py /app/
 COPY workers/polytope-fe-worker/polytope.py /app/
+COPY workers/polytope-fe-worker/dynamic_grid/ /app/dynamic_grid/
 ENTRYPOINT ["/app/polytope-fe-worker"]
 
 ###############################
-# Stage 5: Debug Image
+# Debug image (adds bash for exec access)
 ###############################
 FROM python:3.11-slim-bookworm AS debug
 ARG VERSION
 ARG REVISION
-ARG GJ_LIBS_IMAGE
 ARG PACKAGE_NAME=polytope-fe-worker
 ARG BIN_NAME=polytope-fe-worker
 LABEL org.opencontainers.image.version="$VERSION" \
       org.opencontainers.image.revision="$REVISION" \
-      org.opencontainers.image.source="https://github.com/ecmwf/polytope-server" \
-      int.ecmwf.polytope.libs-image="$GJ_LIBS_IMAGE"
+      org.opencontainers.image.source="https://github.com/ecmwf/polytope-server"
 
-RUN apt-get update && apt-get install -y ca-certificates libgomp1 libaec0 libcurl4 libopenjp2-7 bash && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libgomp1 libaec0 libcurl4 libopenjp2-7 bash \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-COPY --from=gj-build-debug /opt/fdb/ /opt/fdb/
 COPY --from=python-deps /opt/venv /opt/venv
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
-ENV PYTHONPATH=/opt/venv/lib/python3.11/site-packages
-ENV LD_LIBRARY_PATH=/opt/fdb/lib:/usr/local/lib
+ENV PYTHONPATH=/app:/opt/venv/lib/python3.11/site-packages
 
 COPY --from=builder /ecmwf/polytope-server/target/release/${BIN_NAME} /app/polytope-fe-worker
 COPY workers/polytope-fe-worker/run_polytope_worker.py /app/
 COPY workers/polytope-fe-worker/polytope.py /app/
+COPY workers/polytope-fe-worker/dynamic_grid/ /app/dynamic_grid/
 ENTRYPOINT ["/app/polytope-fe-worker"]

--- a/workers/polytope-fe-worker/dynamic_grid/__init__.py
+++ b/workers/polytope-fe-worker/dynamic_grid/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone dynamic grid service."""

--- a/workers/polytope-fe-worker/dynamic_grid/__init__.py
+++ b/workers/polytope-fe-worker/dynamic_grid/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Standalone dynamic grid service."""

--- a/workers/polytope-fe-worker/dynamic_grid/__main__.py
+++ b/workers/polytope-fe-worker/dynamic_grid/__main__.py
@@ -1,0 +1,4 @@
+from .service import main
+
+if __name__ == "__main__":
+    main()

--- a/workers/polytope-fe-worker/dynamic_grid/__main__.py
+++ b/workers/polytope-fe-worker/dynamic_grid/__main__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .service import main
 
 if __name__ == "__main__":

--- a/workers/polytope-fe-worker/dynamic_grid/helper.py
+++ b/workers/polytope-fe-worker/dynamic_grid/helper.py
@@ -1,0 +1,119 @@
+import logging
+import os
+from urllib.parse import urljoin
+
+import requests
+from covjsonkit.param_db import get_param_id_from_db
+
+
+def normalise_lookup_value(key, value):
+    value = value.split("/") if isinstance(value, str) else value
+
+    if isinstance(value, list):
+        if key == "georef" and len(value) != 1:
+            raise ValueError("Grid lookup requires a single georef")
+        if len(value) == 0:
+            return None
+        value = value[0]
+
+    if isinstance(value, dict):
+        return None
+
+    if key == "param" and not str(value).lstrip("-").isdigit():
+        try:
+            value = get_param_id_from_db(value)
+        except Exception:
+            logging.warning("Could not convert param shortname '%s' to param id", value)
+
+    return value
+
+
+def build_grid_lookup_request(request_dict):
+    lookup_request = {}
+    for key, value in request_dict.items():
+        if key in {"feature", "format"}:
+            continue
+        normalised = normalise_lookup_value(key, value)
+        if normalised is not None:
+            lookup_request[key] = normalised
+    return lookup_request
+
+
+def gridspec_to_grid_config(gridspec, md5hash):
+    if gridspec.get("type") != "lambert_conformal":
+        return None
+
+    return {
+        "name": "mapper",
+        "type": "lambert_conformal",
+        "md5_hash": md5hash,
+        "is_spherical": gridspec.get("earth_round"),
+        "radius": gridspec.get("radius"),
+        "nv": gridspec.get("nv"),
+        "nx": gridspec.get("nx"),
+        "ny": gridspec.get("ny"),
+        "LoVInDegrees": gridspec.get("LoVInDegrees"),
+        "Dx": gridspec.get("Dx"),
+        "Dy": gridspec.get("Dy"),
+        "latFirstInRadians": gridspec.get("latFirstInRadians"),
+        "lonFirstInRadians": gridspec.get("lonFirstInRadians"),
+        "LoVInRadians": gridspec.get("LoVInRadians"),
+        "Latin1InRadians": gridspec.get("Latin1InRadians"),
+        "Latin2InRadians": gridspec.get("Latin2InRadians"),
+        "LaDInRadians": gridspec.get("LaDInRadians"),
+        "axes": ["latitude", "longitude"],
+    }
+
+
+def lookup_grid_config_local(req):
+    from .local import lookup_grid_config_local as _lookup_grid_config_local
+
+    return _lookup_grid_config_local(req)
+
+
+def lookup_grid_config_remote(req, service_url, timeout=None, retries=None, retry_timeout=None):
+    url = urljoin(service_url.rstrip("/") + "/", "lookup-grid-config")
+    if timeout is None:
+        timeout = float(os.environ.get("POLYTOPE_DYNAMIC_GRID_SERVICE_TIMEOUT", "1"))
+    if retries is None:
+        retries = int(os.environ.get("POLYTOPE_DYNAMIC_GRID_SERVICE_RETRIES", "1"))
+    if retry_timeout is None:
+        retry_timeout = float(os.environ.get("POLYTOPE_DYNAMIC_GRID_SERVICE_RETRY_TIMEOUT", "5"))
+
+    timeouts = [timeout] + [retry_timeout] * retries
+    last_error = None
+    for request_timeout in timeouts:
+        try:
+            response = requests.post(url, json={"request": req}, timeout=request_timeout)
+            response.raise_for_status()
+            payload = response.json()
+            return (payload["gridspec"], payload["md5hash"])
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("dynamic grid remote lookup failed without a captured error")
+
+
+def lookup_grid_config(req, service_url=None):
+    service_url = service_url or os.environ.get("POLYTOPE_DYNAMIC_GRID_SERVICE_URL")
+    if service_url:
+        return lookup_grid_config_remote(req, service_url)
+    return lookup_grid_config_local(req)
+
+
+def replace_dynamic_grid_options(config_options, req, service_url=None):
+    if "georef" not in req.keys():
+        raise ValueError("Grid lookup requires request.georef")
+    gridspec, md5hash = lookup_grid_config(req, service_url=service_url)
+    grid_config = gridspec_to_grid_config(gridspec, md5hash)
+    if grid_config is None:
+        return False
+
+    for axis_conf in config_options.get("axis_config", []):
+        for idx, transformation in enumerate(axis_conf.get("transformations", [])):
+            if transformation.get("name") == "mapper":
+                axis_conf["transformations"][idx] = grid_config
+                return True
+    return False

--- a/workers/polytope-fe-worker/dynamic_grid/helper.py
+++ b/workers/polytope-fe-worker/dynamic_grid/helper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from urllib.parse import urljoin

--- a/workers/polytope-fe-worker/dynamic_grid/local.py
+++ b/workers/polytope-fe-worker/dynamic_grid/local.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import math
 import os

--- a/workers/polytope-fe-worker/dynamic_grid/local.py
+++ b/workers/polytope-fe-worker/dynamic_grid/local.py
@@ -1,0 +1,235 @@
+import json
+import math
+import os
+import tempfile
+import threading
+
+
+class _LazyEccodes:
+    _module = None
+
+    def _load(self):
+        if self._module is None:
+            import eccodes as _eccodes
+
+            self._module = _eccodes
+        return self._module
+
+    def codes_get(self, *args, **kwargs):
+        return self._load().codes_get(*args, **kwargs)
+
+    def codes_new_from_message(self, *args, **kwargs):
+        return self._load().codes_new_from_message(*args, **kwargs)
+
+    def codes_release(self, *args, **kwargs):
+        return self._load().codes_release(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._load(), name)
+
+
+eccodes = _LazyEccodes()
+
+_GRID_CACHE = None
+_GRID_CACHE_LOCK = threading.Lock()
+
+
+def _get_grid_spacing(gid, metric_key, fallback_key):
+    try:
+        spacing = eccodes.codes_get(gid, metric_key)
+    except Exception:
+        spacing = None
+
+    if spacing is not None and spacing > 0:
+        return spacing
+
+    return eccodes.codes_get(gid, fallback_key)
+
+
+def _grid_cache_enabled():
+    return os.environ.get("POLYTOPE_DISABLE_GRID_CACHE", "").lower() not in {"1", "true", "yes", "on"}
+
+
+def _read_exact_into(data_handle, length):
+    buffer = bytearray(length)
+    view = memoryview(buffer)
+    offset = 0
+
+    while offset < length:
+        bytes_read = data_handle.readinto(view[offset:])
+        if bytes_read <= 0:
+            raise EOFError(f"Short GRIB read: wanted {length} bytes, got {offset}")
+        offset += bytes_read
+
+    return bytes(buffer)
+
+
+def read_first_grib_message(data_handle, data_length):
+    if data_length <= 0:
+        raise ValueError(f"Invalid data handle length: {data_length}")
+
+    return _read_exact_into(data_handle, data_length)
+
+
+def get_first_grib_message(req):
+    import pyfdb
+
+    with pyfdb.FDB() as fdb:
+        list_iter = fdb.list(req)
+        try:
+            first_element = next(list_iter)
+        except StopIteration as exc:
+            raise ValueError("FDB list returned no fields") from exc
+
+        with first_element.data_handle as dh:
+            if dh is None:
+                raise ValueError("List element has no data handle")
+            field_size = first_element.length()
+            msg_bytes = read_first_grib_message(dh, field_size)
+
+    gid = eccodes.codes_new_from_message(msg_bytes)
+    return gid
+
+
+def get_gridspec_lambert_conformal(gid):
+    to_rad = math.pi / 180
+
+    md5hash = eccodes.codes_get(gid, "md5GridSection")
+
+    earth_round = (eccodes.codes_get(gid, "shapeOfTheEarth") == 0) or (eccodes.codes_get(gid, "shapeOfTheEarth") == 6)
+
+    if earth_round:
+        if eccodes.codes_get(gid, "shapeOfTheEarth") == 6:
+            radius = 6371229
+        elif eccodes.codes_get(gid, "shapeOfTheEarth") == 0:
+            radius = 6367470
+    else:
+        radius = None
+
+    nv = eccodes.codes_get(gid, "NV")
+    nx = eccodes.codes_get(gid, "Nx")
+    ny = eccodes.codes_get(gid, "Ny")
+    LoVInDegrees = eccodes.codes_get(gid, "LoV") / 1000000
+    Dx = _get_grid_spacing(gid, "DxInMetres", "Dx")
+    Dy = _get_grid_spacing(gid, "DyInMetres", "Dy")
+    latFirstInRadians = eccodes.codes_get(gid, "latitudeOfFirstGridPoint") / 1000000 * to_rad
+    lonFirstInRadians = eccodes.codes_get(gid, "longitudeOfFirstGridPoint") / 1000000 * to_rad
+    LoVInRadians = eccodes.codes_get(gid, "LoV") / 1000000 * to_rad
+    Latin1InRadians = eccodes.codes_get(gid, "Latin1") / 1000000 * to_rad
+    Latin2InRadians = eccodes.codes_get(gid, "Latin2") / 1000000 * to_rad
+    LaDInRadians = eccodes.codes_get(gid, "LaD") / 1000000 * to_rad
+
+    gridspec = {
+        "type": "lambert_conformal",
+        "earth_round": earth_round,
+        "radius": radius,
+        "nv": nv,
+        "nx": nx,
+        "ny": ny,
+        "LoVInDegrees": LoVInDegrees,
+        "Dx": Dx,
+        "Dy": Dy,
+        "latFirstInRadians": latFirstInRadians,
+        "lonFirstInRadians": lonFirstInRadians,
+        "LoVInRadians": LoVInRadians,
+        "Latin1InRadians": Latin1InRadians,
+        "Latin2InRadians": Latin2InRadians,
+        "LaDInRadians": LaDInRadians,
+    }
+    return (gridspec, md5hash)
+
+
+def get_gridspec_icon(gid):
+    md5hash = eccodes.codes_get(gid, "md5GridSection")
+    gridspec = {}
+    return (gridspec, md5hash)
+
+
+def get_gridspec_and_hash(gid):
+    grid_type = eccodes.codes_get(gid, "gridType")
+    if grid_type == "lambert_lam":
+        return get_gridspec_lambert_conformal(gid)
+    elif grid_type == "icon":
+        return get_gridspec_icon(gid)
+    else:
+        raise ValueError(f"Unsupported grid type: {grid_type}")
+
+
+def _grid_cache_file():
+    return os.path.join(os.path.dirname(__file__), "grid_cache.json")
+
+
+def _load_cache():
+    try:
+        with open(_grid_cache_file(), "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _save_cache(cache):
+    grid_cache_file = _grid_cache_file()
+    dirpath = os.path.dirname(grid_cache_file)
+    os.makedirs(dirpath, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=dirpath, prefix=".grid_cache.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(cache, fh, indent=2, sort_keys=True)
+        os.replace(tmp, grid_cache_file)
+    finally:
+        if os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except Exception:
+                pass
+
+
+def _cache_key(req_georef):
+    try:
+        return json.dumps(req_georef, sort_keys=True, default=str)
+    except Exception:
+        return str(req_georef)
+
+
+def _get_cache_locked():
+    global _GRID_CACHE
+    if _GRID_CACHE is None:
+        _GRID_CACHE = _load_cache()
+    return _GRID_CACHE
+
+
+def lookup_grid_config_local(req):
+    req_georef = req["georef"]
+    cache_key = _cache_key(req_georef)
+    cache_enabled = _grid_cache_enabled()
+
+    if cache_enabled:
+        with _GRID_CACHE_LOCK:
+            cache = _get_cache_locked()
+            if cache_key in cache:
+                entry = cache[cache_key]
+                return (entry.get("gridspec"), entry.get("md5hash"))
+
+    gid = get_first_grib_message(req)
+    try:
+        gridspec, md5hash = get_gridspec_and_hash(gid)
+    finally:
+        eccodes.codes_release(gid)
+
+    if not cache_enabled:
+        return (gridspec, md5hash)
+
+    with _GRID_CACHE_LOCK:
+        cache = _get_cache_locked()
+        if cache_key in cache:
+            entry = cache[cache_key]
+            return (entry.get("gridspec"), entry.get("md5hash"))
+
+        cache[cache_key] = {"gridspec": gridspec, "md5hash": md5hash}
+        try:
+            _save_cache(cache)
+        except Exception:
+            pass
+        return (gridspec, md5hash)

--- a/workers/polytope-fe-worker/dynamic_grid/service.py
+++ b/workers/polytope-fe-worker/dynamic_grid/service.py
@@ -1,0 +1,111 @@
+import argparse
+import json
+import logging
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from .local import lookup_grid_config_local
+
+LOGGER = logging.getLogger(__name__)
+
+MAX_REQUEST_BYTES = 64 * 1024
+
+
+class SwitchingGridHandler(BaseHTTPRequestHandler):
+    def _send_json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        except BrokenPipeError:
+            LOGGER.warning("client disconnected before response could be sent")
+        except OSError:
+            LOGGER.exception("failed to send HTTP response")
+
+    def do_POST(self):
+        if self.path.rstrip("/") != "/lookup-grid-config":
+            LOGGER.warning("unknown POST path: %s", self.path)
+            self._send_json(404, {"error": "not found"})
+            return
+
+        try:
+            content_length_header = self.headers.get("Content-Length")
+            if content_length_header is None:
+                self._send_json(400, {"error": "missing Content-Length"})
+                return
+
+            try:
+                content_length = int(content_length_header)
+            except ValueError:
+                self._send_json(400, {"error": "invalid Content-Length"})
+                return
+
+            if content_length < 0:
+                self._send_json(400, {"error": "invalid Content-Length"})
+                return
+            if content_length > MAX_REQUEST_BYTES:
+                self._send_json(413, {"error": "request body too large"})
+                return
+
+            raw = self.rfile.read(content_length)
+            payload = json.loads(raw.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                self._send_json(400, {"error": "JSON payload must be an object"})
+                return
+
+            req = payload.get("request", payload)
+            if not isinstance(req, dict):
+                self._send_json(400, {"error": "request must be an object"})
+                return
+            if not isinstance(req.get("georef"), str) or not req["georef"]:
+                self._send_json(400, {"error": "request.georef is required"})
+                return
+
+            LOGGER.info("lookup-grid-config request received for georef=%s", req.get("georef", "unknown"))
+            gridspec, md5hash = lookup_grid_config_local(req)
+            self._send_json(200, {"gridspec": gridspec, "md5hash": md5hash})
+            LOGGER.info("lookup-grid-config request succeeded for georef=%s", req.get("georef", "unknown"))
+        except json.JSONDecodeError:
+            LOGGER.warning("invalid JSON payload received")
+            self._send_json(400, {"error": "invalid JSON payload"})
+        except (AssertionError, KeyError, ValueError) as exc:
+            LOGGER.warning("bad lookup-grid-config request: %s", exc)
+            self._send_json(400, {"error": str(exc)})
+        except Exception:
+            LOGGER.exception("lookup-grid-config failed")
+            self._send_json(500, {"error": "internal server error"})
+
+    def do_GET(self):
+        if self.path.rstrip("/") == "/healthz":
+            LOGGER.debug("health check requested")
+            self._send_json(200, {"ok": True})
+            return
+        LOGGER.warning("unknown GET path: %s", self.path)
+        self._send_json(404, {"error": "not found"})
+
+    def log_message(self, format, *args):
+        LOGGER.info("%s - %s", self.address_string(), format % args)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    server = ThreadingHTTPServer((args.host, args.port), SwitchingGridHandler)
+    LOGGER.info("Starting dynamic-grid service on %s:%s", args.host, args.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        LOGGER.info("Stopping dynamic-grid service")
+    finally:
+        server.server_close()
+        LOGGER.info("Dynamic-grid service stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/polytope-fe-worker/dynamic_grid/service.py
+++ b/workers/polytope-fe-worker/dynamic_grid/service.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 import logging

--- a/workers/polytope-fe-worker/polytope.py
+++ b/workers/polytope-fe-worker/polytope.py
@@ -15,6 +15,8 @@ class PolytopeDataSource:
         self.config = config
         self.type = config["type"]
         assert self.type == "polytope"
+        self.dynamic_grid = config.pop("dynamic_grid", False)
+        self.dynamic_grid_service_url = config.pop("dynamic_grid_service_url", None)
         self.pre_path = config.get("options", {}).pop("pre_path", [])
         self.defaults = config.get("defaults", {})
         # https://github.com/ecmwf/polytope-server/issues/68
@@ -97,12 +99,41 @@ class PolytopeDataSource:
             if k in pre_path_axes:
                 if isinstance(v, list):
                     if self.gh70_fix_step_ranges:
-                        if k == "param":
-                            pre_path[k] = v[0]
+                        if k == "param" and not str(v[0]).lstrip("-").isdigit():
+                            try:
+                                from covjsonkit.param_db import get_param_id_from_db
+                                v[0] = get_param_id_from_db(v[0])
+                            except Exception:
+                                logging.warning(
+                                    "Could not convert param shortname '%s' to param id",
+                                    v[0],
+                                )
+                        pre_path[k] = v[0]
                     if len(v) == 1:
                         v = v[0]
+                        if k == "param" and not str(v).lstrip("-").isdigit():
+                            try:
+                                from covjsonkit.param_db import get_param_id_from_db
+                                v = get_param_id_from_db(v)
+                            except Exception:
+                                logging.warning(
+                                    "Could not convert param shortname '%s' to param id",
+                                    v,
+                                )
                         pre_path[k] = v
         polytope_mars_config["options"]["pre_path"] = pre_path
+
+        if self.dynamic_grid:
+            from dynamic_grid.helper import (
+                build_grid_lookup_request,
+                replace_dynamic_grid_options,
+            )
+            grid_lookup_request = build_grid_lookup_request(r)
+            replace_dynamic_grid_options(
+                polytope_mars_config["options"],
+                grid_lookup_request,
+                service_url=self.dynamic_grid_service_url,
+            )
 
         if self.gh69_fix_grids:
             change_grids(r, polytope_mars_config)
@@ -243,8 +274,9 @@ def change_hash(request, config):
     if request.get("dataset", None) == "climate-dt":
         if request.get("resolution", None) == "high":
             if request.get("model", None) == "icon":
-                hash = "9533855ee8e38314e19aaa0434c310da"
-                return change_config_grid_hash(config, hash)
+                if request.get("generation", None) == "1":
+                    hash = "9533855ee8e38314e19aaa0434c310da"
+                    return change_config_grid_hash(config, hash)
     return config
 
 

--- a/workers/polytope-fe-worker/requirements.txt
+++ b/workers/polytope-fe-worker/requirements.txt
@@ -1,6 +1,6 @@
 polytope-mars==0.3.12
 polytope-python==2.1.15
-covjsonkit==0.2.20
+covjsonkit==0.2.21
 PyYAML==6.0.3
-pyfdb==5.21.0.19
-pygribjump @ git+https://github.com/ecmwf/gribjump.git@0.12.0
+pyfdb==5.22.0.26
+pygribjump[binary]==0.12.0.26


### PR DESCRIPTION
## Summary

Removes the dependency on pre-built ECCR C++ library images (`cpp-fdb-gribjump-libs`) in favour of PyPI manylinux wheels that bundle their own C++ stack.

## Changes

- **Dockerfile**: drop `GJ_LIBS_IMAGE`/`GJ_LIBS_DEBUG_IMAGE` build args and the associated `COPY --from=gj-build` stages; add `dynamic_grid/` copy; clean up apt installs with `--no-install-recommends`
- **dynamic_grid/**: new Python module providing an HTTP-based grid config lookup service (`service.py`), local FDB-backed lookup (`local.py`), and helpers (`helper.py`)
- **polytope.py**: add dynamic grid option substitution before policy application; add param shortname→ID conversion via `covjsonkit.param_db`
- **requirements.txt**: bump `covjsonkit` 0.2.20→0.2.21, `pyfdb` 5.21.0.19→5.22.0.26, switch `pygribjump` from git to PyPI (`pygribjump[binary]==0.12.0.26`)
- **skaffold.yaml**: update header comment to reflect `polytope-fe-worker` no longer needs a separate ECCR cpp-libs image

## Testing

Deployed to lumi-test and mn5-test; all tests passed (37/37 on mn5-test, 63/66 on lumi-test with 3 pre-existing failures).