### PR TITLE
Revert pre_path behaviour to pre v2

### DIFF
--- a/workers/polytope-fe-worker/polytope.py
+++ b/workers/polytope-fe-worker/polytope.py
@@ -110,7 +110,7 @@ class PolytopeDataSource:
                                     "Could not convert param shortname '%s' to param id",
                                     v[0],
                                 )
-                        pre_path[k] = v[0]
+                            pre_path[k] = v[0]
                     if len(v) == 1:
                         v = v[0]
                         if k == "param" and not str(v).lstrip("-").isdigit():

--- a/workers/polytope-fe-worker/requirements.txt
+++ b/workers/polytope-fe-worker/requirements.txt
@@ -1,5 +1,5 @@
 polytope-mars==0.3.12
-polytope-python==2.1.15
+polytope-python==2.1.17
 covjsonkit==0.2.22
 PyYAML==6.0.3
 pyfdb==5.22.0.26

--- a/workers/polytope-fe-worker/requirements.txt
+++ b/workers/polytope-fe-worker/requirements.txt
@@ -1,6 +1,6 @@
 polytope-mars==0.3.12
 polytope-python==2.1.15
-covjsonkit==0.2.21
+covjsonkit==0.2.22
 PyYAML==6.0.3
 pyfdb==5.22.0.26
 pygribjump[binary]==0.12.0.26


### PR DESCRIPTION
In new polytope server we always add the first element of a field if its in the pre_path, this is different to how it previously worked where only the first element was added if it was param. This change reverts to that behavior.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
