### PR TITLE
feat(fe-worker): capture python logs as single rust event; stop tracebacks to users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,6 +3935,7 @@ dependencies = [
  "polytope-worker-common",
  "pyo3",
  "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/workers/polytope-fe-worker/Cargo.toml
+++ b/workers/polytope-fe-worker/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3"
 polytope-worker-common = { path = "../common" }
 pyo3 = { version = "0.23", features = ["auto-initialize"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/workers/polytope-fe-worker/run_polytope_worker.py
+++ b/workers/polytope-fe-worker/run_polytope_worker.py
@@ -5,9 +5,92 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
+import os
 import sys
+import threading
 import time
+import traceback
 from pathlib import Path
+
+
+# Thread-local storage for per-call log capture.
+# Each worker thread (when worker_concurrency > 1) gets its own buffer.
+_log_buffer = threading.local()
+
+# Install-once guard for the persistent root logger handler
+_handler_installed = False
+
+
+class _LogCapturingHandler(logging.Handler):
+    """Captures log records into a thread-local buffer during process() calls.
+
+    Appends records as {"level": str, "logger": str, "message": str} dicts
+    to the current thread's buffer, if one is set. Does nothing otherwise.
+    """
+
+    def emit(self, record):
+        if not hasattr(_log_buffer, "records"):
+            return
+        try:
+            message = record.getMessage()
+        except Exception:
+            message = str(record.msg)
+        _log_buffer.records.append(
+            {
+                "level": record.levelname,
+                "logger": record.name,
+                "message": message,
+            }
+        )
+
+
+def _python_log_level() -> int:
+    """Parse RUST_LOG env var to determine Python logging level.
+
+    Takes the FIRST bare token (no '=') from comma-separated RUST_LOG,
+    lowercases it, and maps:
+      trace/debug -> logging.DEBUG
+      info        -> logging.INFO
+      warn/warning-> logging.WARNING
+      error       -> logging.ERROR
+      off         -> logging.CRITICAL + 1
+    Default: logging.INFO when unset or unknown.
+    """
+    rust_log = os.environ.get("RUST_LOG", "").strip()
+    if not rust_log:
+        return logging.INFO
+
+    # Split by comma and find the first bare token (no '=')
+    for token in rust_log.split(","):
+        token = token.strip()
+        if "=" not in token:
+            token_lower = token.lower()
+            if token_lower in ("trace", "debug"):
+                return logging.DEBUG
+            elif token_lower == "info":
+                return logging.INFO
+            elif token_lower in ("warn", "warning"):
+                return logging.WARNING
+            elif token_lower == "error":
+                return logging.ERROR
+            elif token_lower == "off":
+                return logging.CRITICAL + 1
+            break
+
+    return logging.INFO
+
+
+def _install_log_handler():
+    """Install a persistent log handler on the root logger (idempotent)."""
+    global _handler_installed
+    if _handler_installed:
+        return
+
+    handler = _LogCapturingHandler()
+    handler.setLevel(logging.DEBUG)  # Capture all levels; root logger controls filtering
+    logging.root.addHandler(handler)
+    _handler_installed = True
 
 
 class _User:
@@ -54,12 +137,37 @@ def _get_datasource(config_path):
     return _datasource
 
 
-def process(payload_json):
-    """Called from Rust via PyO3. Returns (output_bytes, timings_json)."""
-    import traceback
+def process(payload_json: str) -> tuple:
+    """Called from Rust via PyO3.
+
+    Returns: (body_bytes: bytes, status_json: str)
+
+    status_json is json.dumps(...) of an object with:
+      - ok (bool)
+      - timings (object) — the existing timings dict when ok=true; {} otherwise
+      - logs (array) — list of {"level": str, "logger": str, "message": str}
+        for every Python log record emitted during THIS call.
+      - error — null when ok=true; when ok=false, {"message": str} with a
+        clean message (never a traceback).
+
+    On success: ok=true, body_bytes = output bytes, timings populated, error=null.
+    On job-level exception: ok=false, body_bytes=b"", error.message = clean message,
+      and the full traceback is appended to logs as a synthetic ERROR record.
+
+    process() may still raise only for catastrophic/protocol errors (e.g.
+    json.loads(payload_json) failing) — leave that unhandled as today.
+    """
+    # Install the log handler idempotently and set the level
+    _install_log_handler()
+    log_level = _python_log_level()
+    logging.root.setLevel(log_level)
+
+    # Initialize per-call log buffer for this thread
+    _log_buffer.records = []
 
     t0 = time.monotonic()
 
+    # Payload parsing may raise — let that propagate as a catastrophic error
     payload = json.loads(payload_json)
     datasource = _get_datasource(payload["config_path"])
     t_init = time.monotonic()
@@ -87,9 +195,43 @@ def process(payload_json):
                 "total_ms": round((t_result - t0) * 1000, 1),
             }
         )
-        return (output, json.dumps(timings))
-    except Exception:
-        raise RuntimeError(traceback.format_exc())
+
+        # Success path: ok=true, logs collected, error=null
+        logs = _log_buffer.records
+        _log_buffer.records = []
+        status = {
+            "ok": True,
+            "timings": timings,
+            "logs": logs,
+            "error": None,
+        }
+        return (output, json.dumps(status))
+
+    except Exception as exc:
+        # Job-level exception: ok=false, clean message in error.message,
+        # full traceback appended to logs as a synthetic ERROR record.
+        clean_message = getattr(exc, "message", None) or str(exc) or exc.__class__.__name__
+        full_traceback = traceback.format_exc()
+
+        # Append the traceback as a synthetic log record
+        _log_buffer.records.append(
+            {
+                "level": "ERROR",
+                "logger": "polytope-fe-worker",
+                "message": full_traceback,
+            }
+        )
+
+        logs = _log_buffer.records
+        _log_buffer.records = []
+        status = {
+            "ok": False,
+            "timings": {},
+            "logs": logs,
+            "error": {"message": str(clean_message)},
+        }
+        return (b"", json.dumps(status))
+
     finally:
         try:
             datasource.destroy(request)

--- a/workers/polytope-fe-worker/src/main.rs
+++ b/workers/polytope-fe-worker/src/main.rs
@@ -9,7 +9,101 @@ use polytope_worker_common::{ProcessResult, Processor, WorkItem, WorkerConfig, r
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyTuple};
 use serde_json::json;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
+
+#[derive(serde::Deserialize)]
+struct PyStatus {
+    ok: bool,
+    #[serde(default)]
+    timings: serde_json::Value,
+    #[serde(default)]
+    logs: Vec<PyLogRecord>,
+    #[serde(default)]
+    error: Option<PyError>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct PyLogRecord {
+    level: String,
+    logger: String,
+    message: String,
+}
+
+#[derive(serde::Deserialize)]
+struct PyError {
+    message: String,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum LogSeverity {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogSeverity {
+    fn from_python_level(level: &str) -> Self {
+        match level.to_uppercase().as_str() {
+            "CRITICAL" | "ERROR" => LogSeverity::Error,
+            "WARNING" | "WARN" => LogSeverity::Warn,
+            "INFO" => LogSeverity::Info,
+            "DEBUG" => LogSeverity::Debug,
+            _ => LogSeverity::Info,
+        }
+    }
+}
+
+fn emit_python_logs(job_id: &str, logs: &[PyLogRecord]) {
+    if logs.is_empty() {
+        return;
+    }
+
+    let max_severity = logs
+        .iter()
+        .map(|log| LogSeverity::from_python_level(&log.level))
+        .max()
+        .unwrap_or(LogSeverity::Info);
+
+    let log_count = logs.len();
+    let logs_json = serde_json::to_string(logs)
+        .unwrap_or_else(|e| format!("[failed to serialize logs: {}]", e));
+
+    match max_severity {
+        LogSeverity::Error => {
+            error!(
+                job_id = %job_id,
+                python_log_count = log_count,
+                python_logs = %logs_json,
+                "python worker logs"
+            );
+        }
+        LogSeverity::Warn => {
+            warn!(
+                job_id = %job_id,
+                python_log_count = log_count,
+                python_logs = %logs_json,
+                "python worker logs"
+            );
+        }
+        LogSeverity::Info => {
+            info!(
+                job_id = %job_id,
+                python_log_count = log_count,
+                python_logs = %logs_json,
+                "python worker logs"
+            );
+        }
+        LogSeverity::Debug => {
+            debug!(
+                job_id = %job_id,
+                python_log_count = log_count,
+                python_logs = %logs_json,
+                "python worker logs"
+            );
+        }
+    }
+}
 
 struct PolytopeProcessor {
     config_path: String,
@@ -51,21 +145,43 @@ impl Processor for PolytopeProcessor {
                         "expected bytes at index 0, got: {e}"
                     ))
                 })?;
-                let timings: String = tuple.get_item(1)?.extract()?;
-                Ok((py_bytes.as_bytes().to_vec(), timings))
+                let status_json: String = tuple.get_item(1)?.extract()?;
+                Ok((py_bytes.as_bytes().to_vec(), status_json))
             })
         })
         .await;
 
         match result {
-            Ok(Ok((bytes, timings))) => {
-                let len = bytes.len() as u64;
-                info!(job_id = %job_id, bytes = len, timings = %timings, "request completed");
-                let stream =
-                    futures::stream::once(futures::future::ready(
-                        Ok::<bytes::Bytes, std::io::Error>(bytes::Bytes::from(bytes)),
-                    ));
-                ProcessResult::success("application/prs.coverage+json", Box::new(stream))
+            Ok(Ok((bytes, status_json))) => {
+                let status: PyStatus = match serde_json::from_str(&status_json) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        error!(job_id = %job_id, error = %err, status_json = %status_json, "failed to parse status_json");
+                        return ProcessResult::error(format!(
+                            "protocol error: failed to parse status_json: {err}"
+                        ));
+                    }
+                };
+
+                emit_python_logs(&job_id, &status.logs);
+
+                if status.ok {
+                    let len = bytes.len() as u64;
+                    let timings = serde_json::to_string(&status.timings).unwrap_or_default();
+                    info!(job_id = %job_id, bytes = len, timings = %timings, "request completed");
+                    let stream = futures::stream::once(futures::future::ready(Ok::<
+                        bytes::Bytes,
+                        std::io::Error,
+                    >(
+                        bytes::Bytes::from(bytes),
+                    )));
+                    ProcessResult::success("application/prs.coverage+json", Box::new(stream))
+                } else {
+                    let message = status.error.map(|e| e.message).unwrap_or_else(|| {
+                        "python worker reported failure with no message".to_string()
+                    });
+                    ProcessResult::error(message)
+                }
             }
             Ok(Err(py_err)) => {
                 error!(job_id = %job_id, error = %py_err, "python error");
@@ -202,7 +318,13 @@ def process(payload_json):
     # Fail if metadata value is not passed through
     assert payload["metadata"].get("test_key") == "test_value", "metadata content not preserved"
     output = json.dumps({"echo": payload["request"], "metadata": payload["metadata"]}).encode("utf-8")
-    return (output, '{"total_ms": 0}')
+    status = {
+        "ok": True,
+        "timings": {"total_ms": 0},
+        "logs": [{"level": "INFO", "logger": "root", "message": "hello from test"}],
+        "error": None
+    }
+    return (output, json.dumps(status))
 "#,
         )
         .unwrap();
@@ -240,6 +362,70 @@ def process(payload_json):
             }
             ProcessResult::Reject { reason } => panic!("expected success, got reject: {reason}"),
             ProcessResult::Error { message } => panic!("expected success, got error: {message}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pyo3_error_handling() {
+        let dir = temp_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        // Use a different temp directory to ensure no module conflicts
+        std::fs::write(
+            dir.join("run_polytope_worker.py"),
+            r#"
+import json
+
+def process(payload_json):
+    status = {
+        "ok": False,
+        "timings": {},
+        "logs": [{"level": "ERROR", "logger": "root", "message": "test error log"}],
+        "error": {"message": "simulated failure"}
+    }
+    return (b"", json.dumps(status))
+"#,
+        )
+        .unwrap();
+
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let sys = py.import("sys").unwrap();
+            let modules = sys.getattr("modules").unwrap();
+            let _ = modules.call_method1("pop", ("run_polytope_worker",));
+            // Remove old path entries
+            let path = sys.getattr("path").unwrap();
+            let path_list: Vec<String> = path.extract().unwrap();
+            for p in path_list.iter().rev() {
+                if p.contains("polytope-worker-test") {
+                    let _ = path.call_method1("remove", (p,));
+                }
+            }
+            path.call_method1("insert", (0i32, dir.display().to_string()))
+                .unwrap();
+        });
+
+        let processor = PolytopeProcessor {
+            config_path: "/tmp/unused.yaml".into(),
+        };
+
+        let result = processor
+            .process(WorkItem {
+                job_id: "job-2".into(),
+                request: json!({"class": "od"}),
+                user: json!({}),
+                metadata: json!({}),
+                callback_url: None,
+            })
+            .await;
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        match result {
+            ProcessResult::Error { message } => {
+                assert_eq!(message, "simulated failure");
+            }
+            ProcessResult::Success { .. } => panic!("expected error, got success"),
+            ProcessResult::Reject { reason } => panic!("expected error, got reject: {reason}"),
         }
     }
 }

--- a/workers/polytope-fe-worker/tests/test_logging_and_errors.py
+++ b/workers/polytope-fe-worker/tests/test_logging_and_errors.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test logging capture and error handling in run_polytope_worker.
+
+Proves that:
+1. Success path captures Python logs and returns ok=true with body bytes
+2. Error path captures clean message in error.message and traceback in logs
+3. Exception .message attribute is preferred over str(exc) when present
+4. _python_log_level() correctly parses RUST_LOG environment variable
+"""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import run_polytope_worker
+
+
+class FakeDatasource:
+    """Fake datasource for testing without polytope_mars/FDB dependencies."""
+
+    def __init__(self, retrieve_behavior=None, result_behavior=None):
+        """
+        Args:
+            retrieve_behavior: callable(request) -> timings dict, or raises
+            result_behavior: callable(request) -> iterable of chunks
+        """
+        self.retrieve_behavior = retrieve_behavior
+        self.result_behavior = result_behavior
+
+    def retrieve(self, request):
+        if self.retrieve_behavior:
+            return self.retrieve_behavior(request)
+        return {"test_ms": 1.0}
+
+    def result(self, request):
+        if self.result_behavior:
+            return self.result_behavior(request)
+        return [b"test output"]
+
+    def destroy(self, request):
+        pass
+
+
+class ExceptionWithMessage(Exception):
+    """Exception class with a .message attribute but empty str()."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__()  # Don't pass message to super, so str(exc) is empty
+
+
+@pytest.fixture
+def reset_log_buffer():
+    """Reset thread-local log buffer between tests to prevent cross-contamination."""
+    # Clear any existing buffer
+    if hasattr(run_polytope_worker._log_buffer, "records"):
+        delattr(run_polytope_worker._log_buffer, "records")
+    yield
+    # Clear again after test
+    if hasattr(run_polytope_worker._log_buffer, "records"):
+        delattr(run_polytope_worker._log_buffer, "records")
+
+
+def test_success_path_captures_logs(monkeypatch, tmp_path, reset_log_buffer):
+    """Success: fake datasource emits logs, returns timings and body bytes."""
+
+    def retrieve_with_logs(request):
+        logging.info("Starting retrieval")
+        logging.warning("This is a warning during retrieval")
+        return {"retrieve_ms": 123.4}
+
+    def result_with_logs(request):
+        logging.debug("Generating result chunks")
+        yield b"chunk1"
+        yield b"chunk2"
+
+    fake_ds = FakeDatasource(
+        retrieve_behavior=retrieve_with_logs,
+        result_behavior=result_with_logs,
+    )
+
+    monkeypatch.setattr(
+        run_polytope_worker, "_get_datasource", lambda config_path: fake_ds
+    )
+
+    # Create minimal config file
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("type: polytope")
+
+    payload = {
+        "config_path": str(config_file),
+        "request": {"class": "od"},
+        "user": {"username": "test"},
+        "metadata": {},
+    }
+
+    body_bytes, status_json = run_polytope_worker.process(json.dumps(payload))
+    status = json.loads(status_json)
+
+    # Assert success
+    assert status["ok"] is True
+    assert body_bytes == b"chunk1chunk2"
+    assert status["error"] is None
+    assert "timings" in status
+    assert status["timings"]["retrieve_ms"] == 123.4
+
+    # Assert logs were captured (at least the info and warning)
+    assert "logs" in status
+    logs = status["logs"]
+    assert len(logs) >= 2
+
+    # Find the specific logs we emitted
+    log_messages = [log["message"] for log in logs]
+    assert "Starting retrieval" in log_messages
+    assert "This is a warning during retrieval" in log_messages
+
+    # Check log levels
+    info_log = [log for log in logs if "Starting retrieval" in log["message"]][0]
+    assert info_log["level"] == "INFO"
+
+    warning_log = [
+        log for log in logs if "This is a warning during retrieval" in log["message"]
+    ][0]
+    assert warning_log["level"] == "WARNING"
+
+
+def test_error_path_clean_message_traceback_in_logs(
+    monkeypatch, tmp_path, reset_log_buffer
+):
+    """Error: fake datasource raises ValueError, assert clean message and traceback in logs."""
+
+    def retrieve_raises(request):
+        raise ValueError("boom")
+
+    fake_ds = FakeDatasource(retrieve_behavior=retrieve_raises)
+
+    monkeypatch.setattr(
+        run_polytope_worker, "_get_datasource", lambda config_path: fake_ds
+    )
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("type: polytope")
+
+    payload = {
+        "config_path": str(config_file),
+        "request": {"class": "od"},
+        "user": {"username": "test"},
+        "metadata": {},
+    }
+
+    body_bytes, status_json = run_polytope_worker.process(json.dumps(payload))
+    status = json.loads(status_json)
+
+    # Assert failure
+    assert status["ok"] is False
+    assert body_bytes == b""
+    assert status["timings"] == {}
+
+    # Assert clean error message (no traceback)
+    assert status["error"] is not None
+    assert status["error"]["message"] == "boom"
+    assert "Traceback" not in status["error"]["message"]
+
+    # Assert traceback is in logs
+    assert "logs" in status
+    logs = status["logs"]
+    assert len(logs) >= 1
+
+    # Find the ERROR log with the traceback
+    error_logs = [log for log in logs if log["level"] == "ERROR"]
+    assert len(error_logs) >= 1
+
+    traceback_log = error_logs[-1]  # The synthetic traceback log
+    assert "Traceback" in traceback_log["message"]
+    assert "ValueError" in traceback_log["message"]
+    assert "boom" in traceback_log["message"]
+    assert traceback_log["logger"] == "polytope-fe-worker"
+
+
+def test_exception_with_message_attribute(monkeypatch, tmp_path, reset_log_buffer):
+    """Error: exception with .message attribute but empty str() -> use .message."""
+
+    def retrieve_raises_message_exc(request):
+        raise ExceptionWithMessage("custom message attribute")
+
+    fake_ds = FakeDatasource(retrieve_behavior=retrieve_raises_message_exc)
+
+    monkeypatch.setattr(
+        run_polytope_worker, "_get_datasource", lambda config_path: fake_ds
+    )
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("type: polytope")
+
+    payload = {
+        "config_path": str(config_file),
+        "request": {"class": "od"},
+        "user": {"username": "test"},
+        "metadata": {},
+    }
+
+    body_bytes, status_json = run_polytope_worker.process(json.dumps(payload))
+    status = json.loads(status_json)
+
+    # Assert failure with clean message from .message attribute
+    assert status["ok"] is False
+    assert status["error"]["message"] == "custom message attribute"
+
+
+def test_python_log_level_empty(monkeypatch):
+    """Test _python_log_level with empty/unset RUST_LOG -> INFO."""
+    monkeypatch.setenv("RUST_LOG", "")
+    assert run_polytope_worker._python_log_level() == logging.INFO
+
+    monkeypatch.delenv("RUST_LOG", raising=False)
+    assert run_polytope_worker._python_log_level() == logging.INFO
+
+
+def test_python_log_level_debug(monkeypatch):
+    """Test _python_log_level with 'debug' -> DEBUG."""
+    monkeypatch.setenv("RUST_LOG", "debug")
+    assert run_polytope_worker._python_log_level() == logging.DEBUG
+
+
+def test_python_log_level_trace(monkeypatch):
+    """Test _python_log_level with 'trace' -> DEBUG."""
+    monkeypatch.setenv("RUST_LOG", "trace")
+    assert run_polytope_worker._python_log_level() == logging.DEBUG
+
+
+def test_python_log_level_info(monkeypatch):
+    """Test _python_log_level with 'info' -> INFO."""
+    monkeypatch.setenv("RUST_LOG", "info")
+    assert run_polytope_worker._python_log_level() == logging.INFO
+
+
+def test_python_log_level_warn(monkeypatch):
+    """Test _python_log_level with 'warn' -> WARNING."""
+    monkeypatch.setenv("RUST_LOG", "warn")
+    assert run_polytope_worker._python_log_level() == logging.WARNING
+
+
+def test_python_log_level_warning(monkeypatch):
+    """Test _python_log_level with 'warning' -> WARNING."""
+    monkeypatch.setenv("RUST_LOG", "warning")
+    assert run_polytope_worker._python_log_level() == logging.WARNING
+
+
+def test_python_log_level_error(monkeypatch):
+    """Test _python_log_level with 'error' -> ERROR."""
+    monkeypatch.setenv("RUST_LOG", "error")
+    assert run_polytope_worker._python_log_level() == logging.ERROR
+
+
+def test_python_log_level_off(monkeypatch):
+    """Test _python_log_level with 'off' -> CRITICAL + 1."""
+    monkeypatch.setenv("RUST_LOG", "off")
+    assert run_polytope_worker._python_log_level() == logging.CRITICAL + 1
+
+
+def test_python_log_level_first_bare_token(monkeypatch):
+    """Test _python_log_level with comma-separated RUST_LOG -> first bare token."""
+    monkeypatch.setenv("RUST_LOG", "warn,hyper=off,tower=debug")
+    assert run_polytope_worker._python_log_level() == logging.WARNING
+
+
+def test_python_log_level_only_crate_specific(monkeypatch):
+    """Test _python_log_level with only crate-specific tokens -> default INFO."""
+    monkeypatch.setenv("RUST_LOG", "hyper=debug,tower=warn")
+    assert run_polytope_worker._python_log_level() == logging.INFO
+
+
+def test_python_log_level_unknown_token(monkeypatch):
+    """Test _python_log_level with unknown first token -> default INFO."""
+    monkeypatch.setenv("RUST_LOG", "unknown_level")
+    assert run_polytope_worker._python_log_level() == logging.INFO
+
+
+def test_log_handler_idempotent(reset_log_buffer):
+    """Test that _install_log_handler can be called multiple times safely."""
+    # Get initial handler count
+    initial_handler_count = len(logging.root.handlers)
+
+    # Install handler multiple times
+    run_polytope_worker._install_log_handler()
+    run_polytope_worker._install_log_handler()
+    run_polytope_worker._install_log_handler()
+
+    # Should only add one handler
+    # (Note: depending on test order, there might be 1 existing handler from previous tests)
+    assert len(logging.root.handlers) <= initial_handler_count + 1
+
+
+def test_logs_captured_only_during_process_call(
+    monkeypatch, tmp_path, reset_log_buffer
+):
+    """Test that logs outside process() calls are not captured."""
+
+    def retrieve_with_log(request):
+        logging.info("Inside process call")
+        return {"test_ms": 1.0}
+
+    fake_ds = FakeDatasource(retrieve_behavior=retrieve_with_log)
+    monkeypatch.setattr(
+        run_polytope_worker, "_get_datasource", lambda config_path: fake_ds
+    )
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("type: polytope")
+
+    # Log outside of process() call
+    logging.info("Outside process call")
+
+    payload = {
+        "config_path": str(config_file),
+        "request": {"class": "od"},
+        "user": {"username": "test"},
+        "metadata": {},
+    }
+
+    body_bytes, status_json = run_polytope_worker.process(json.dumps(payload))
+    status = json.loads(status_json)
+
+    # Assert only the log inside process() was captured
+    logs = status["logs"]
+    log_messages = [log["message"] for log in logs]
+    assert "Inside process call" in log_messages
+    assert "Outside process call" not in log_messages
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Two issues with the FE worker:

1. Python exceptions surfaced to end users as **full tracebacks** in the failure message.
2. Python logs (from `polytope_mars`, `polytope_feature`, etc.) were **never captured** anywhere, and their level wasn't configurable.

## Changes

### New Python `process()` contract

Returns `(body_bytes, status_json)` instead of raising on job-level errors. `status_json` carries:

```json
{ "ok": bool, "timings": {...}, "logs": [{...}], "error": null | {"message": "..."} }
```

- **On failure:** `error.message` is a clean message (never a traceback); the full traceback is routed into `logs` as a synthetic `ERROR` record.
- **On success:** `ok=true`, `logs` contains all captured records, `error=null`.

### Python log capture

A persistent `logging.Handler` on the root logger buffers records into a **thread-local** list per `process()` call (safe for `worker_concurrency > 1`). Level is derived from `RUST_LOG` (`debug`→DEBUG, `info`→INFO, `warn`→WARNING, `error`→ERROR; default INFO).

### Rust side

Parses `status_json`, emits the captured Python logs as a **single `tracing` event per job** (always, success and failure) at the **max severity** of the records, then streams the body or returns `ProcessResult::error` with the clean message.

## Verification (lumi-test)

- Integration tests: **65 passed, 2 failed** — the 2 are pre-existing extremes-dt/ng data-availability failures, now surfacing as clean 400 messages instead of tracebacks.
- Pod logs confirmed:
  - One `"python worker logs"` tracing event per job (INFO on success, ERROR on failing jobs).
  - Failing job: full traceback inside the aggregated log event; user-facing `error` field contains only the clean message (`has Traceback: False`).